### PR TITLE
Prevent fatal error in autoloader

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/autoloader.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/autoloader.inc
@@ -27,5 +27,5 @@ spl_autoload_register(function($className) {
 	array_unshift($parts, "openmediavault");
 	$pathName = strtolower(sprintf("%s.inc", implode(DIRECTORY_SEPARATOR,
 	  $parts)));
-	require_once $pathName;
+	include_once $pathName;
 });


### PR DESCRIPTION
Switches from require_once to include_once. The former throws a fatal error when a file isn't found while the later just emits a warning. Because of the fatal error autoloaders registered after the one provided by OMV won't be executed. The error message is also not quite obvious because of this, since it tells you which file that failed to load instead of which class.