### PR TITLE
fix rpc.fstab.json

### DIFF
--- a/deb/openmediavault-lvm2/usr/share/openmediavault/engined/rpc/logicalvolumemgmt.inc
+++ b/deb/openmediavault-lvm2/usr/share/openmediavault/engined/rpc/logicalvolumemgmt.inc
@@ -648,7 +648,7 @@ class OMVRpcServiceLogicalVolumeMgmt extends \OMV\Rpc\ServiceAbstract {
 			$lvv['_used'] = FALSE;
 			// Does the logical volume contain a filesystem and is it used?
 			if(FALSE !== \OMV\Rpc\Rpc::call("FsTab", "getByFsName", [
-				"id" => $lvv['devicefile']
+				"fsname" => $lvv['devicefile']
 			], $context)) {
 				$lvv['_used'] = TRUE;
 			}

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.fstab.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.fstab.json
@@ -52,7 +52,7 @@
 	"params": {
 		"type": "object",
 		"properties": {
-			"id": {
+			"fsname": {
 				"type": "string",
 				"oneOf": [{
 					"type": "string",
@@ -60,6 +60,9 @@
 				},{
 					"type": "string",
 					"format": "devicefile"
+				},{
+					"type": "string",
+					"format": "dirpath"
 				}],
 				"required": true
 			}
@@ -71,7 +74,7 @@
 	"params": {
 		"type": "object",
 		"properties": {
-			"id": {
+			"dir": {
 				"type": "string",
 				"required": true
 			}

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/filesystemmgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/filesystemmgmt.inc
@@ -513,7 +513,7 @@ class OMVRpcServiceFileSystemMgmt extends \OMV\Rpc\ServiceAbstract {
 		// Check uniqueness. If there exists a mount point for the given
 		// device then it has already a filesystem that is in use.
 		if (FALSE !== \OMV\Rpc\Rpc::call("FsTab", "getByFsName", [
-			"id" => $sd->getDeviceFile()
+			"fsname" => $sd->getDeviceFile()
 		], $context)) {
 			throw new \OMV\Exception("A mount point already exists for '%s'.",
 			  $sd->getDeviceFile());

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/fstab.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/fstab.inc
@@ -151,7 +151,7 @@ class OMVRpcServiceFsTab extends \OMV\Rpc\ServiceAbstract {
 	 * Get a mount point configuration object by the given file system name,
 	 * which may be a UUID or block special device.
 	 * @param params An array containing the following fields:
-	 *   \em id The file system identifier, e.g. the UUID or block special
+	 *   \em fsname The file system identifier, e.g. the UUID or block special
 	 *   device file like <ul>
 	 *   \li /dev/sda1
 	 *   \li 02532317-cc35-421e-b750-c6a484fb109a
@@ -173,12 +173,12 @@ class OMVRpcServiceFsTab extends \OMV\Rpc\ServiceAbstract {
 		$objects = $this->callMethod("enumerateEntries", NULL, $context);
 		// Add function parameter to search argument list.
 		$args = [];
-		$args[] = $params['id'];
+		$args[] = $params['fsname'];
 		// If the function parameter is a device file, then try to get the
 		// file system UUID and add it to the search argument list. This is
 		// done to increase the probability to find the fstab config object.
-		if (is_devicefile($params['id'])) {
-			$fs = \OMV\System\Filesystem\Filesystem::getImpl($params['id']);
+		if (is_devicefile($params['fsname'])) {
+			$fs = \OMV\System\Filesystem\Filesystem::getImpl($params['fsname']);
 			if (!is_null($fs) && $fs->exists() && $fs->hasUuid())
 				$args[] = $fs->getUuid();
 		}

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/raidmgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/raidmgmt.inc
@@ -77,7 +77,7 @@ class OMVRpcServiceRaidMgmt extends \OMV\Rpc\ServiceAbstract {
 				$used = TRUE;
 			// Does the RAID device contain a filesystem and is it used?
 			} else if (FALSE !== \OMV\Rpc\Rpc::call("FsTab", "getByFsName", [
-				"id" => $raid->getDeviceFile()
+				"fsname" => $raid->getDeviceFile()
 			], $context)) {
 				$used = TRUE;
 			}


### PR DESCRIPTION
1. there is no `$params['dir']`, only `$params['id']` exists 
https://github.com/openmediavault/openmediavault/blob/master/deb/openmediavault/usr/share/openmediavault/engined/rpc/fstab.inc#L234
https://github.com/openmediavault/openmediavault/blob/master/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.fstab.json#L74 

2. it seems `dirpath` missing or is it desired?
https://github.com/openmediavault/openmediavault/blob/master/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.fstab.json#L57
https://github.com/openmediavault/openmediavault/blob/master/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.fstab.json#L14

3.  match name with `fsname`
https://github.com/openmediavault/openmediavault/blob/master/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.fstab.json#L55
https://github.com/openmediavault/openmediavault/blob/master/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.fstab.json#L12