### PR TITLE
Wrong ipv6 detect in some cases

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/scripts/helper-functions
+++ b/deb/openmediavault/usr/share/openmediavault/scripts/helper-functions
@@ -807,7 +807,7 @@ omv_is_gateway6() {
 # Check if IPv6 is enabled.
 # @return 0 if enabled, otherwise 1.
 omv_is_ipv6_enabled() {
-	[ -f /proc/net/if_inet6 ] && return 0
+	[ -s /proc/net/if_inet6 ] && return 0
 	return 1
 }
 


### PR DESCRIPTION
In some cases the empty /proc/net/if_inet6 file exist and I think that emptiness of this file should be tested.