### PR TITLE
Mantis 0001645: Removed output of mkpatidx from APT::Update conf

### DIFF
--- a/deb/openmediavault/etc/apt/apt.conf.d/99openmediavault-mkaptidx
+++ b/deb/openmediavault/etc/apt/apt.conf.d/99openmediavault-mkaptidx
@@ -1,3 +1,3 @@
 // Create the plugin index.
-APT::Update::Post-Invoke-Success { "which omv-mkaptidx >/dev/null 2>&1 || exit 0; omv-mkaptidx || true"; };
-DPkg::Post-Invoke { "which omv-mkaptidx >/dev/null 2>&1 || exit 0; omv-mkaptidx || true"; };
+APT::Update::Post-Invoke-Success { "which omv-mkaptidx >/dev/null 2>&1 || exit 0; omv-mkaptidx >/dev/null || true"; };
+DPkg::Post-Invoke { "which omv-mkaptidx >/dev/null 2>&1 || exit 0; omv-mkaptidx >/dev/null || true"; };


### PR DESCRIPTION
Because of mkaptidx the /etc/cron.daily/apt script has standard output
that cause a daily mail notification.

Related issues:
http://bugtracker.openmediavault.org/view.php?id=1645
http://bugtracker.openmediavault.org/view.php?id=1334