### PR TITLE
RPC/diskmgmt/rescan detect disk size change as well

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/diskmgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/diskmgmt.inc
@@ -285,5 +285,11 @@ class OMVRpcServiceDiskMgmt extends \OMV\Rpc\ServiceAbstract {
 		  "\$(find /sys/class/scsi_host -iname \"host*\" -type l); ".
 		  "do echo \"- - -\" | tee \${hostdir}/scan >/dev/null; done");
 		$script->execute();
+		// Execute shell script to detect SCSI device size changes.
+		$script = new \OMV\System\ShellScript(
+		  "[ -x /sys/class/scsi_device ] && for devicedir in ".
+		  "\$(find /sys/class/scsi_device -iname \"*:*\" -type l); ".
+		  "do echo 1 | tee \${devicedir}/device/rescan >/dev/null; done");
+		$script->execute();
 	}
 }


### PR DESCRIPTION
The existing script in the rescan function scans the SCSI bus for new/removed devices only.
The new part of the function will rescan every scsi device to detect size changes.
This will result in following kernel message:
[86617.420189] sd 2:0:1:0: [sdb] 31457280 512-byte logical blocks: (16.1 GB/15.0 GiB)
[86617.420219] sdb: detected capacity change from 15032385536 to 16106127360