### PR TITLE
Update openmediavault.postinst

### DIFF
--- a/deb/openmediavault/debian/openmediavault.postinst
+++ b/deb/openmediavault/debian/openmediavault.postinst
@@ -184,7 +184,7 @@ case "$1" in
 			deb-systemd-invoke restart watchdog.service || :
 			deb-systemd-invoke restart rrdcached.service || :
 			deb-systemd-invoke restart collectd.service || :
-			deb-systemd-invoke restart php5-fpm.service || :
+			deb-systemd-invoke restart php7.0-fpm.service || :
 			deb-systemd-invoke restart nginx.service || :
 			deb-systemd-invoke restart monit.service || :
 			deb-systemd-invoke restart avahi-daemon.service || :


### PR DESCRIPTION
change back to php7.0.  I left the other php5 calls as php5 because they should never be called.  I would imagine that you could remove all of the legacy change sections for 4.x since the old versions could not be installed on Stretch.