### PR TITLE
Backport workaround for Chrome from 3.x to 2.x

### DIFF
--- a/deb/openmediavault/var/www/openmediavault/css/omv.css
+++ b/deb/openmediavault/var/www/openmediavault/css/omv.css
@@ -607,3 +607,11 @@ div#headerrlogo {
 /******************************************************************************/
 /* Bugfixes/Workarounds
 /******************************************************************************/
+/* Fix Chrome 56 render bug (EXTJS-23628) */
+/* https://www.sencha.com/forum/showthread.php?335045-Text-field-heights-are-incorrect-and-text-is-misaligned-in-Chrome-56&p=1171870&viewfull=1#post1171870 */
+.x-webkit .x-form-text {
+	height: 100% !important;
+}
+.x-webkit :not(.x-form-textarea-body) > .x-form-trigger-wrap {
+	height: initial;
+}


### PR DESCRIPTION
I have a OMV 2.x box and a OMV 3.x box. Using my Chrome 57.x there is no rendering issue on OMV 3.x web admin interface, but on OMV 2.x box there are many form fields rendered with incorrect heights. After some comparisons, I found OMV 3.x includes workaround in omv.css to fix those issues. After I copied those lines to OMV 2.x, now my OMV 2.x interface is also rendered correctly. 