### PR TITLE
3.x - navigation menu missing from webUI

### DIFF
--- a/deb/openmediavault/var/www/openmediavault/js/omv/workspace/Workspace.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/workspace/Workspace.js
@@ -109,18 +109,28 @@ Ext.define("OMV.workspace.Workspace", {
 		return me.tp = Ext.create("OMV.workspace.node.tree.Panel", {
 			plugins: "responsive",
 			responsiveConfig: {
-				// On tablet/phone/touch devices the tree panel will not
-				// be displayed.
-				"tablet || phone || touch": {
+				// On phone the tree panel will not be displayed.
+				phone: {
 					hidden: true
-				}
-			},
+				},
+				// On tablet/touch devices the tree panel is collapsed
+				"tablet || touch": {
+					// collapsed: true only work if collapsible
+					// is called
+					collapsible: true,
+					collapsed: true
+				},
+				// On desktop the tree is collapsible (as before)
+				desktop: {
+					collapsible: true
+				},
 			region: "west",
 			split: true,
 			width: 210,
 			minSize: 150,
 			maxSize: 280,
-			collapsible: true,
+			// Will result in exception if called twice
+			//collapsible: true,
 			layout: "fit",
 			border: true,
 			scrollable: true,

--- a/deb/openmediavault/var/www/openmediavault/js/omv/workspace/Workspace.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/workspace/Workspace.js
@@ -109,12 +109,12 @@ Ext.define("OMV.workspace.Workspace", {
 		return me.tp = Ext.create("OMV.workspace.node.tree.Panel", {
 			plugins: "responsive",
 			responsiveConfig: {
-				// On phone the tree panel will not be displayed.
-				phone: {
+				// On phone/tablet the tree panel will not be displayed.
+				"phone || tablet": {
 					hidden: true
 				},
-				// On tablet/touch devices the tree panel is collapsed
-				"tablet || touch": {
+				// On touch devices the tree panel is collapsed
+				touch: {
 					// collapsed: true only work if collapsible
 					// is called
 					collapsible: true,

--- a/deb/openmediavault/var/www/openmediavault/js/omv/workspace/Workspace.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/workspace/Workspace.js
@@ -124,6 +124,7 @@ Ext.define("OMV.workspace.Workspace", {
 				desktop: {
 					collapsible: true
 				},
+			},
 			region: "west",
 			split: true,
 			width: 210,


### PR DESCRIPTION
As discused in the following topic, the tree panel should be available on touch devices and tablets.
http://forum.openmediavault.org/index.php/Thread/18323-navigation-menu-missing-from-webUI/

Since ext js tablet also include smartphones running firefox only desktop and touch devices added.

Tested:

Edge, Chrome on Surface Pro 3 (Firefox is not testable since language is not selectable in login screen)
Edge, Chrome on Desktop (without Touch)
Chrome, Firefox on Nexus 6 (Android 7.1.1)