### PR TITLE
Clamav fails to start on new OMV installation due to the missing /var/run/clamav path

### DIFF
--- a/deb/openmediavault-clamav/usr/share/openmediavault/mkconf/clamav
+++ b/deb/openmediavault-clamav/usr/share/openmediavault/mkconf/clamav
@@ -185,6 +185,13 @@ xmlstarlet sel -t \
 sfref=$(omv_config_get "//services/clamav/quarantine/sharedfolderref")
 sfpath=$(omv_get_sharedfolder_path "${sfref}")
 
+# Create the /var/run/clamav path
+if [ ! -d /var/run/clamav ]; then
+    mkdir -p /var/run/clamav
+    chown root:root /var/run/clamav
+    chmod 755 /var/run/clamav
+fi
+
 # Create the cron jobs.
 rm -f ${OMV_CRONSCRIPTS_DIR}/${OMV_CLAMAV_CLAMDSCAN_CRONSCRIPT_TEMPLATE}*
 xmlstarlet sel -t \


### PR DESCRIPTION
On a new OMV installation Clamav fails to start with the following errors: 

Wed May 24 13:33:31 2017 -> ERROR: Can't save PID to file /var/run/clamav/freshclam.pid: No such file or directory
Wed May 24 13:34:15 2017 -> WARNING: Clamd was NOT notified: Can't connect to clamd through /var/run/clamav/clamd.ctl: No such file or directory

