### PR TITLE
Adapt NanoPi NEO 2(AllWinner H5)

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/system/system.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/system.inc
@@ -329,7 +329,7 @@ class System {
 		$diffTotal = $tnowTotal - $tprevTotal;
 		// Get the processor name.
 		$modelName = gettext("n/a");
-		foreach ([ "modelname", "cpumodel", "Processor" ] as $key) {
+		foreach ([ "modelname", "cpumodel", "Processor", "Hardware" ] as $key) {
 			if (TRUE === $cpuInfo->exists($key)) {
 				$modelName = $cpuInfo->get($key);
 				break;


### PR DESCRIPTION
Hardware: [NanoPi NEO 2](http://wiki.friendlyarm.com/wiki/index.php/NanoPi_NEO2)
Software: Debian Stretch

`cat /proc/cpuinfo`

```
processor	: 0
BogoMIPS	: 48.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4

processor	: 1
BogoMIPS	: 48.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4

processor	: 2
BogoMIPS	: 48.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4

processor	: 3
BogoMIPS	: 48.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4

Hardware	: Allwinnersun50iw2Family
Revision	: 0000
Serial		: 0000000000000000
```