### PR TITLE
Workaround for memory leak when calling OMV.MessageBox.guru

### DIFF
--- a/deb/openmediavault/var/www/openmediavault/js/omv/Rpc.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/Rpc.js
@@ -30,6 +30,7 @@ Ext.define("OMV.Rpc", {
 	requires: [ "OMV.window.MessageBox" ],
 	singleton: true,
 	autoAbort: false,
+	guru: null,
 
 	config: {
 		disabled: false
@@ -167,7 +168,11 @@ Ext.define("OMV.Rpc", {
 				me.setDisabled(true);
 				// Display a dialog forcing user to click 'OK' to reload
 				// the page.
-				OMV.MessageBox.guru({
+				if (this.guru)
+				{
+					this.guru.destroy();
+				}
+				this.guru = OMV.MessageBox.guru({
 					msg: rpcResponse.message,
 					fn: function() {
 						OMV.confirmPageUnload = false;

--- a/deb/openmediavault/var/www/openmediavault/js/omv/window/MessageBox.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/window/MessageBox.js
@@ -346,7 +346,13 @@ Ext.define("OMV.window.MessageBox", {
 			y: 0,
 			baseCls: Ext.baseCSSPrefix + "message-box-guru",
 			html: Ext.String.format("Software Failure.&nbsp;&nbsp;&nbsp;" +
-			  "Press left mouse button to continue.<br/>{0}", config.msg)
+			  "Press left mouse button to continue.<br/>{0}", config.msg),
+			onDestroy: function(){
+			  Ext.getBody().un({
+				keypress: fn,
+				click: fn
+			  });
+			}
 		});
 		// Monitor key press and mouse clicks.
 		var fn = function(e, t, eOpts) {


### PR DESCRIPTION
Workaround for memory leak when OMV.MessageBox.guru is called repeatedly from Rpc.js