### PR TITLE
Fixed Ticket #1647 - Bond0 not shown up / MTU not shown correct.

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/mkconf/issue
+++ b/deb/openmediavault/usr/share/openmediavault/mkconf/issue
@@ -48,7 +48,7 @@ To manage the system visit the ${prdname} web control panel:
 
 EOF
 
-	ifaces=$(ifquery --list --allow=hotplug -X lo)
+	ifaces=$(ifquery --list --allow=hotplug --allow=auto -X lo)
 	if [ -n "${ifaces}" ]; then
 		for iface in ${ifaces} ; do
 			ipaddr=$(omv_get_ipaddr ${iface})

--- a/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/system/network/Interfaces.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/system/network/Interfaces.js
@@ -965,7 +965,8 @@ Ext.define("OMV.module.admin.system.network.interface.Interfaces", {
 		dataIndex: "mtu",
 		stateId: "mtu",
 		width: 45,
-		minValue: 1
+		minValue: 1,
+		maxValue: 2147483647
 	},{
 		xtype: "booleantextcolumn",
 		text: _("WOL"),


### PR DESCRIPTION
Changed mkconf for /etc/issue to allow auto network interfaces so that bonded and vlan interfaces will be listed on the login screens.

Also set a maximum value for the MTU on the web interface.
When max is undefined, numberrangecolumn will always display "-" because Ext.isNumber(max) is false.
I've set the maximum MTU value to the largest signed 32-bit integer since it appears to be the largest value the Linux kernel allows.