### PR TITLE
Allow browser caching Web UI CSS/Javascript/Images.

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/mkconf/nginx.d/10webgui
+++ b/deb/openmediavault/usr/share/openmediavault/mkconf/nginx.d/10webgui
@@ -76,9 +76,13 @@ xmlstarlet sel -t -m "//webadmin" \
   -o "    }" -n \
   -o "    location /extjs6/ {" -n \
   -o "        alias /usr/share/javascript/extjs6/;" -n \
+  -o "        expires 2d;" -n \
   -o "    }" -n \
-  -o "    location /images/ {" -n \
-  -o "        alias ${OMV_DOCUMENTROOT_DIR}/images/;" -n \
+  -o "    location ~ ^/(css|js|images)/ {" -n \
+  -o "        expires 2d;" -n \
+  -o "    }" -n \
+  -o "    location /favicon {" -n \
+  -o "        expires 14d;" -n \
   -o "    }" -n \
   -o "    location ~ \.php$ {" -n \
   -o "        try_files \$uri =404;" -n \


### PR DESCRIPTION
As a workaround for ticket 1363, the nginx mkconf was modified to allow browser caching for static css, javascript, and image files in the web UI.

The maximum cache expiration was set to 2 days to guarantee updates take effect reasonably quickly while also reducing unnecessary HTTP queries for static files.
The favicons expiration was set to 14 days since they rarely change.

Also removed an unnecessary /image/ alias in the nginx config (it wasn't actually changing anything).