### PR TITLE
Fixed ticket #1772: SMART overview shows red, details are all green

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/smartinformation.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/smartinformation.inc
@@ -252,7 +252,7 @@ class SmartInformation {
 			$attrData['assessment'] = self::SMART_ASSESSMENT_BAD_ATTRIBUTE_IN_THE_PAST;
 			return;
 		}
-		// mark bad sector attributes as red when rawvalue >= 1, ticket #1772
+		// Check for bad sectors (Reallocated_Sector_Ct and Current_Pending_Sector).
 		if ($attrData['id'] == 5 || $attrData['id'] == 197) {
 			if (1 <= $attrData['rawvalue']) {
 				$attrData['assessment'] = self::SMART_ASSESSMENT_BAD_SECTOR;

--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/smartinformation.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/smartinformation.inc
@@ -252,6 +252,13 @@ class SmartInformation {
 			$attrData['assessment'] = self::SMART_ASSESSMENT_BAD_ATTRIBUTE_IN_THE_PAST;
 			return;
 		}
+		// mark bad sector attributes as red when rawvalue >= 1, ticket #1772
+		if ($attrData['id'] == 5 || $attrData['id'] == 197) {
+			if (1 <= $attrData['rawvalue']) {
+				$attrData['assessment'] = self::SMART_ASSESSMENT_BAD_SECTOR;
+				return;
+			}
+		}
 	}
 
 	/**

--- a/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/storage/smart/Devices.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/storage/smart/Devices.js
@@ -230,6 +230,7 @@ Ext.define("OMV.module.admin.storage.smart.device.information.Attributes", {
 				case "GOOD":
 					ledColor = "green";
 					break;
+				case "BAD_SECTOR":
 				case "BAD_ATTRIBUTE_NOW":
 				case "BAD_ATTRIBUTE_IN_THE_PAST":
 					ledColor = "red";


### PR DESCRIPTION
When OpenMediaVault gets a drive's overall SMART status, it checks the normal attributes, but then also checks the Reallocated_Sector_Ct (5) and Current_Pending_Sector (197) attributes.

Then when viewing a drive's detailed SMART attributes, these same checks are not performed. If you have a drive with at least 1 reallocated or pending sector, this will cause the drive's overall status to be red, but all the detailed SMART attributes will be green or grey.

To make the status consistent, I added checks to the SMART prefailure attribute checks, which will now cause those 2 attributes to show up as red when their raw values are > 0.