### PR TITLE
smartd device type was not detected properly

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/mkconf/smartmontools
+++ b/deb/openmediavault/usr/share/openmediavault/mkconf/smartmontools
@@ -69,7 +69,7 @@ xmlstarlet sel -t \
 	  xmlstarlet sel -t \
 		-m "//services/smart/monitor/device[uuid='${uuid}']" \
 		  -v devicefile \
-		  -i "string-length(type) > 0" \
+		  -i "string-length(devicetype) > 0" \
 			-v "concat(' -d ',devicetype)" \
 		  -b \
 		-b \


### PR DESCRIPTION
In the configuration generation tool for smartd.conf, the device type was checked by (non-existant) xml "type" node instead of "devicetype"