### PR TITLE
interfaces: Remove auto devicename stanza

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/mkconf/interfaces.d/20ethernet
+++ b/deb/openmediavault/usr/share/openmediavault/mkconf/interfaces.d/20ethernet
@@ -39,7 +39,6 @@ xmlstarlet sel -t \
 	  -i "count(//system/network/interfaces/interface/slaves[contains(.,current()/devicename)]) = 0" \
 		  -n \
 		  -v "concat('# ',devicename,' network interface')" -n \
-		  -v "concat('auto ',devicename)" -n \
 		  -v "concat('allow-hotplug ',devicename)" -n \
           -v "concat('iface ',devicename,' inet ',method)" -n \
 		  -i "method = 'manual'" \


### PR DESCRIPTION
There is a problem with the most recent `ifupdown` package when using both, `auto eth0` and `allow-hotplug eth0`, stanzas in `/etc/network/interfaces`:

```
Aug 25 02:14:56 corellia dhclient[6267]: DHCPREQUEST on eno1 to 255.255.255.255 port 67
Aug 25 02:14:56 corellia ifup[6246]: DHCPREQUEST on eno1 to 255.255.255.255 port 67
Aug 25 02:14:56 corellia dhclient[6267]: DHCPACK from 10.85.42.1
Aug 25 02:14:56 corellia ifup[6246]: DHCPACK from 10.85.42.1
Aug 25 02:14:56 corellia systemd[1]: Reloading LSB: start Samba SMB/CIFS daemon (smbd).
Aug 25 02:14:56 corellia smbd[6295]: Reloading /etc/samba/smb.conf: smbd.
Aug 25 02:14:56 corellia systemd[1]: Reloaded LSB: start Samba SMB/CIFS daemon (smbd).
Aug 25 02:14:56 corellia ifup[6246]: RTNETLINK answers: File exists
Aug 25 02:14:56 corellia systemd[1]: Stopping LSB: Start NTP daemon...
Aug 25 02:14:56 corellia ntpd[6071]: ntpd exiting on signal 15
Aug 25 02:14:56 corellia ntp[6355]: Stopping NTP server: ntpd.
Aug 25 02:14:56 corellia systemd[1]: Stopped LSB: Start NTP daemon.
Aug 25 02:14:56 corellia systemd[1]: Starting LSB: Start NTP daemon...
Aug 25 02:14:56 corellia ntpd[6373]: ntpd 4.2.6p5@1.2349-o Fri Jul 22 17:30:51 UTC 2016 (1)
Aug 25 02:14:56 corellia ntp[6366]: Starting NTP server: ntpd.
Aug 25 02:14:56 corellia ntpd[6374]: proto: precision = 0.108 usec
Aug 25 02:14:56 corellia ntpd[6374]: Listen and drop on 0 v4wildcard 0.0.0.0 UDP 123
Aug 25 02:14:56 corellia systemd[1]: Started LSB: Start NTP daemon.
Aug 25 02:14:56 corellia ntpd[6374]: Listen and drop on 1 v6wildcard :: UDP 123
Aug 25 02:14:56 corellia ntpd[6374]: Listen normally on 2 lo 127.0.0.1 UDP 123
Aug 25 02:14:56 corellia ntpd[6374]: Listen normally on 3 eno1 10.85.42.52 UDP 123
Aug 25 02:14:56 corellia ntpd[6374]: Listen normally on 4 docker0 172.17.0.1 UDP 123
Aug 25 02:14:56 corellia ntpd[6374]: Listen normally on 5 lo ::1 UDP 123
Aug 25 02:14:56 corellia ntpd[6374]: peers refreshed
Aug 25 02:14:56 corellia ntpd[6374]: Listening on routing socket on fd #22 for interface updates
Aug 25 02:14:56 corellia ifup[6246]: Restarting ntp (via systemctl): ntp.service.
Aug 25 02:14:56 corellia dhclient[6267]: bound to 10.85.42.52 -- renewal in 415988 seconds.
Aug 25 02:14:56 corellia ifup[6246]: bound to 10.85.42.52 -- renewal in 415988 seconds.
Aug 25 02:14:56 corellia ifup[6246]: ifquery: recursion detected for interface eno1 in post-up phase
Aug 25 02:14:56 corellia ifup[6246]: run-parts: /etc/network/if-up.d/openmediavault-issue exited with re
Aug 25 02:14:56 corellia ifup[6246]: Failed to bring up eno1.
Aug 25 02:14:56 corellia systemd[1]: Reloading.
Aug 25 02:14:56 corellia systemd[1]: networking.service: Main process exited, code=exited, status=1/FAIL
Aug 25 02:14:56 corellia systemd[1]: Failed to start Raise network interfaces.
Aug 25 02:14:56 corellia systemd[1]: networking.service: Unit entered failed state.
Aug 25 02:14:56 corellia systemd[1]: networking.service: Failed with result 'exit-code'.
```

Bringing up the network fails due to a "recursion detected" error. Removing the `auto eth0` (in my case `eno0`) stanza fixes the problem.