### PR TITLE
btrfs-progs >= 4.8.4 btrfs-show-super depricated

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/btrfs.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/btrfs.inc
@@ -209,7 +209,7 @@ class Btrfs extends Filesystem {
 
 		$cmdArgs = [];
 		$cmdArgs[] = escapeshellarg($this->getDeviceFile());
-		$cmd = new \OMV\System\Process("btrfs-show-super", $cmdArgs);
+		$cmd = new \OMV\System\Process("btrfs inspect dump-super", $cmdArgs);
 		$cmd->setRedirect2to1();
 		$cmd->execute($output);
 


### PR DESCRIPTION
The btrfs-show-super is merged into the main btrfs: btrfs inspect dump-super
