### PR TITLE
Iptables mkconf script should only flush INPUT/OUTPUT chains as the G…

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/mkconf/iptables.d/10ifupdown
+++ b/deb/openmediavault/usr/share/openmediavault/mkconf/iptables.d/10ifupdown
@@ -51,10 +51,12 @@ EOF
 
 xmlstarlet sel -t \
   -i "count(//system/network/iptables/rule[family='inet']) > 0" \
-	  -o "iptables -t filter -F" -n \
+	  -o "iptables -t filter -F INPUT" -n \
+	  -o "iptables -t filter -F OUTPUT" -n \
   -b \
   -i "count(//system/network/iptables/rule[family='inet6']) > 0" \
-	  -o "ip6tables -t filter -F" -n \
+	  -o "ip6tables -t filter -F INPUT" -n \
+	  -o "ip6tables -t filter -F OUTPUT" -n \
   -b \
   -m "//system/network/iptables/rule" -s A:T:L family -s A:N:L rulenum \
 	  -i "family='inet'" -o "iptables" -b \


### PR DESCRIPTION
…UI doesn't provide adding rules to the FORWARD chain

Also to mention there is a bug in the save button when someone has deleted all the rules or just one rule leaving the grid empty, press the save button the module doesn't get marked as dirty leaving the rules still in place
