### PR TITLE
btrfs-show-super command has been obsoleted

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/btrfs.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/btrfs.inc
@@ -209,7 +209,7 @@ class Btrfs extends Filesystem {
 
 		$cmdArgs = [];
 		$cmdArgs[] = escapeshellarg($this->getDeviceFile());
-		$cmd = new \OMV\System\Process("btrfs-show-super", $cmdArgs);
+		$cmd = new \OMV\System\Process("btrfs inspect-internal dump-super", $cmdArgs);
 		$cmd->setRedirect2to1();
 		$cmd->execute($output);
 


### PR DESCRIPTION
On my recently installed OMV 4.0.16 system with kernel v4.13.13 and btrfs-progs v4.13.3 (installed from backports) i've got an error message "btrfs-show-super command not found" when i tried to mount a btrfs filesystem. I've found the solution in the repo of btrfs-progs on github:
"The standalone utility btrfs-show-super has been obsoleted by 'btrfs
inspect-internal dump-super'".