### PR TITLE
allow private key to be updated on existing cert.

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/certificatemgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/certificatemgmt.inc
@@ -157,14 +157,15 @@ class OMVRpcServiceCertificateMgmt extends \OMV\Rpc\ServiceAbstract {
 		openssl_x509_free($certificate);
 		// Set the configuration object.
 		$db = \OMV\Config\Database::getInstance();
-		if (TRUE === $object->isNew()) {
-			// The private key is required here.
-			if ($object->isEmpty("privatekey"))
+		// The private key is required here.
+		if ($object->isEmpty("privatekey")) {
+			if (TRUE === $object->isNew()) {
 				throw new \OMV\Exception("Private key does not exist.");
-		} else {
-			$oldObject = $db->get("conf.system.certificate.ssl",
-				$object->getIdentifier());
-			$object->set("privatekey", $oldObject->get("privatekey"));
+			} else {
+				$oldObject = $db->get("conf.system.certificate.ssl",
+					$object->getIdentifier());
+				$object->set("privatekey", $oldObject->get("privatekey"));
+			}
 		}
 		$db->set($object);
 		// Return the configuration object.


### PR DESCRIPTION
letsencrypt updates the private key as well as the public key.  This change would allow the private key to be updated on an existing cert to keep the user from having to change to a new cert in potentially many places.