### PR TITLE
Fix cron script of recyclebin delete

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/mkconf/samba.d/40recyclebin
+++ b/deb/openmediavault/usr/share/openmediavault/mkconf/samba.d/40recyclebin
@@ -69,9 +69,9 @@ done
 # Exit if 'recyclemaxage' is zero.
 [ "\${amin}" -eq "0" ] && exit 0
 # Exit if another job is running.
-if ! mkdir "${lockfile}" &>/dev/null; then
-	exit 0
-fi
+[ -e ${lockfile} ] && exit 0
+# Create lock
+mkdir "${lockfile}" &>/dev/null
 # Initialize the trap to cleanup on exit.
 trap "rm -rf ${lockfile}; exit" 0 1 2 5 15
 # Exit if the recycle bin directory does not exist.


### PR DESCRIPTION
On server with openmediavault package 3.0.96 I found that never clean the recycle of all shares even if setted correctly (causing big problems of full disks).
After have investigated I found that /var/lib/openmediavault/cron.d/samba-recycle-* file executed manually always exit with status 0 without delete the files that must delete (even if find commands work correctly), exit with both lock dir exist and not.
This PR solves this problem (simpler and faster solution that came to my mind, already tested)
When will be applied can be backported also to 3.0.x please?