### PR TITLE
Fix http request timeout ignored

### DIFF
--- a/deb/openmediavault/var/www/openmediavault/js/omv/data/proxy/Rpc.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/data/proxy/Rpc.js
@@ -69,13 +69,13 @@ Ext.define("OMV.data.proxy.Rpc", {
 		var me = this;
 		var request = me.buildRequest(operation);
 		Ext.apply(request, {
-			timeout: me.timeout,
 			scope: me,
 			callback: me.createRequestCallback(request, operation,
 			  callback, scope),
 			method: me.getMethod(request),
 			disableCaching: false
 		});
+		request.setTimeout(me.timeout);
 		OMV.Rpc.request(request);
 		return request;
 	},


### PR DESCRIPTION
Ext JS 6 does not use timeout member variable but _timeout due to configPrefixed=true. In fact, it reads the value with the getter getTimeout() which choose timeout or _timeout depending on $configPrefixed=true.
Instead of setting timeout member variable we have to use setter setTimeout() to initialize the right member variable.

To increase default http request timeout, edit following configuration files:
-/etc/openmediavault/php.ini: increase max_execution_time (in seconds)
-/etc/nginx/sites-enabled/openmediavault-webgui: increase fastcgi_read_timeout (in seconds)
-/etc/default/openmediavault: set OMV_HTTPREQUEST_TIMEOUT (in milliseconds)

I set OMV_HTTPREQUEST_TIMEOUT to the exactly wanted timeout and the two others with additionnal 15s