### PR TITLE
Change monit configuration so monit can find running forked-daapd

### DIFF
--- a/deb/openmediavault-forkeddaapd/usr/share/openmediavault/mkconf/monit.d/forked-daapd
+++ b/deb/openmediavault-forkeddaapd/usr/share/openmediavault/mkconf/monit.d/forked-daapd
@@ -31,7 +31,7 @@ rm -f ${OMV_MONIT_SERVICE_FORKEDDAAPD_CONFIG}
 [ "$(omv_config_get "//services/daap/enable")" != "1" ] && exit 0
 
 cat <<EOF > ${OMV_MONIT_SERVICE_FORKEDDAAPD_CONFIG}
-check process forked-daapd with pidfile /var/run/forked-daapd.pid
+check process forked-daapd matching forked-daapd
   start program = "/bin/systemctl start forked-daapd"
   stop program = "/bin/systemctl stop forked-daapd"
   mode ${OMV_MONIT_SERVICE_FORKEDDAAPD_MODE}


### PR DESCRIPTION
I am creating an issue (see #62) related to this pull request called "Monit config for forked-daapd causes monit to think forked-daapd is not running".  It contains more details.  I will reference this pull request in the issue.
