### PR TITLE
Reload the shared folder systemd mount units

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -13,6 +13,8 @@ openmediavault (4.1.8-1) stable; urgency=low
     before monit is starting monitoring, it will be started at least by systemd.
     If there are still services that require more time to setup the delay
     can be customized via the environment variable OMV_MONIT_DELAY_SECONDS.
+  * Reload the shared folder systemd mount units if the volume of the shared
+    folder has been changed.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Sat, 26 May 2018 17:02:31 +0200
 

--- a/deb/openmediavault/usr/share/openmediavault/engined/module/sharedfolders.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/module/sharedfolders.inc
@@ -56,7 +56,14 @@ class OMVModuleSharedfolders extends \OMV\Engine\Module\ServiceAbstract
 				$objectv->get("name")), [ "--path", "--suffix=mount" ]);
 			// Mount the shared folder bind mount.
 			$systemCtl = new \OMV\System\SystemCtl($unitName);
-			$systemCtl->enable(TRUE);
+			// Enable the mount unit if this is not done already, otherwise
+			// reload it to take care that the unit file is up-to-date. This
+			// is necessary because it is possible that the file system of the
+			// shared folder may have been changed in the meanwhile.
+			if (FALSE === $systemCtl->isEnabled())
+				$systemCtl->enable(TRUE);
+			else
+				$systemCtl->restart();
 		}
 	}
 
@@ -96,7 +103,7 @@ class OMVModuleSharedfolders extends \OMV\Engine\Module\ServiceAbstract
 	 */
 	function bindListeners(\OMV\Engine\Notify\Dispatcher $dispatcher) {
 		$dispatcher->addListener(
-			OMV_NOTIFY_CREATE | OMV_NOTIFY_DELETE,
+			OMV_NOTIFY_CREATE | OMV_NOTIFY_MODIFY | OMV_NOTIFY_DELETE,
 			"org.openmediavault.conf.system.sharedfolder",
 			[ $this, "setDirty" ]);
 		$dispatcher->addListener(


### PR DESCRIPTION
Reload the shared folder systemd mount units if the volume of the shared folder has been changed.

Signed-off-by: Volker Theile <votdev@gmx.de>