### PR TITLE
Fixed a typo in the Russian locale

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/locale/ru_RU/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/ru_RU/openmediavault.po
@@ -2366,7 +2366,7 @@ msgstr "Питкэрн"
 msgid ""
 "Please check the <a href='http://linux.die.net/man/5/exports' "
 "target='_blank'>manual page</a> for more details."
-msgstr "Ознакомьтесь со <a href='http://linux.die.net/man/5/exports' target='_blank'>страницей описания</ A> для более подробной информации."
+msgstr "Ознакомьтесь со <a href='http://linux.die.net/man/5/exports' target='_blank'>страницей описания</a> для более подробной информации."
 
 msgid ""
 "Please check the <a href='http://www.proftpd.org/docs/contrib/mod_tls.html' "


### PR DESCRIPTION
Corrected the hyperlink tag.
With an error, the help page was opened by clicking on the field to enter a comment when adding the general directory of the NSF.