### PR TITLE
rrdtool: Use SVG images to make reports nicely scalable

### DIFF
--- a/deb/openmediavault-diskstats/usr/share/openmediavault/mkrrdgraph/plugins.d/disk.py
+++ b/deb/openmediavault-diskstats/usr/share/openmediavault/mkrrdgraph/plugins.d/disk.py
@@ -37,7 +37,7 @@ class Plugin(openmediavault.mkrrdgraph.IPlugin):
 		for devname in devnames:
 			config['devname'] = devname
 
-			image_filename = '{image_dir}/disk-octets-{devname}-{period}.png'.format(**config)
+			image_filename = '{image_dir}/disk-octets-{devname}-{period}.svg'.format(**config)
 			if os.path.exists('{data_dir}/disk-{devname}/disk_octets.rrd'.format(**config)):
 				args = []
 				args.append(image_filename)
@@ -70,7 +70,7 @@ class Plugin(openmediavault.mkrrdgraph.IPlugin):
 			else:
 				openmediavault.mkrrdgraph.copy_placeholder_image(image_filename)
 
-			image_filename = '{image_dir}/disk-ops-{devname}-{period}.png'.format(**config)
+			image_filename = '{image_dir}/disk-ops-{devname}-{period}.svg'.format(**config)
 			if os.path.exists('{data_dir}/disk-{devname}/disk_ops.rrd'.format(**config)):
 				args = []
 				args.append(image_filename)
@@ -103,7 +103,7 @@ class Plugin(openmediavault.mkrrdgraph.IPlugin):
 			else:
 				openmediavault.mkrrdgraph.copy_placeholder_image(image_filename)
 
-			image_filename = '{image_dir}/disk-time-{devname}-{period}.png'.format(**config)
+			image_filename = '{image_dir}/disk-time-{devname}-{period}.svg'.format(**config)
 			if os.path.exists('{data_dir}/disk-{devname}/disk_time.rrd'.format(**config)):
 				args = []
 				args.append(image_filename)

--- a/deb/openmediavault-nut/usr/share/openmediavault/mkrrdgraph/plugins.d/nut.py
+++ b/deb/openmediavault-nut/usr/share/openmediavault/mkrrdgraph/plugins.d/nut.py
@@ -54,7 +54,7 @@ class Plugin(openmediavault.mkrrdgraph.IPlugin):
 				continue
 			config['upsname'] = m.group(1)
 
-			image_filename = '{image_dir}/nut-charge-{period}.png'.format(**config)
+			image_filename = '{image_dir}/nut-charge-{period}.svg'.format(**config)
 			if os.path.exists('{data_dir}/nut-{upsname}/percent-charge.rrd'.format(**config)):
 				args = []
 				args.append(image_filename)
@@ -79,7 +79,7 @@ class Plugin(openmediavault.mkrrdgraph.IPlugin):
 			else:
 				openmediavault.mkrrdgraph.copy_placeholder_image(image_filename)
 
-			image_filename = '{image_dir}/nut-load-{period}.png'.format(**config)
+			image_filename = '{image_dir}/nut-load-{period}.svg'.format(**config)
 			if os.path.exists('{data_dir}/nut-{upsname}/percent-load.rrd'.format(**config)):
 				args = []
 				args.append(image_filename)
@@ -109,7 +109,7 @@ class Plugin(openmediavault.mkrrdgraph.IPlugin):
 			# the more important value. Only one temperature can be displayed
 			# because the WebGUI does not display multiple temperature
 			# informations.
-			image_filename = '{image_dir}/nut-temperature-{period}.png'.format(**config)
+			image_filename = '{image_dir}/nut-temperature-{period}.svg'.format(**config)
 			if os.path.exists('{data_dir}/nut-{upsname}/temperature-battery.rrd'.format(**config)):
 				args = []
 				args.append(image_filename)
@@ -151,7 +151,7 @@ class Plugin(openmediavault.mkrrdgraph.IPlugin):
 			else:
 				openmediavault.mkrrdgraph.copy_placeholder_image(image_filename)
 
-			image_filename = '{image_dir}/nut-voltage-{period}.png'.format(**config)
+			image_filename = '{image_dir}/nut-voltage-{period}.svg'.format(**config)
 			if (os.path.exists('{data_dir}/nut-{upsname}/voltage-battery.rrd'.format(**config)) and
 					os.path.exists('{data_dir}/nut-{upsname}/voltage-input.rrd'.format(**config)) and
 					os.path.exists('{data_dir}/nut-{upsname}/voltage-output.rrd'.format(**config))):

--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -6,6 +6,7 @@ openmediavault (5.0) unstable; urgency=low
     will not only create the configuration files, it will also take care
     about to start/stop/restart the services.
   * Issue #93: Use chrony instead of ntpd.
+  * Use SVG images for rrdtool visualizations. Existing plugins must be adapted.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Tue, 08 May 2018 22:06:11 +0200
 

--- a/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/mkrrdgraph.py
+++ b/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/mkrrdgraph.py
@@ -51,7 +51,7 @@ def copy_placeholder_image(filename):
 	:param filename: The destination filename.
 	"""
 	src = openmediavault.getenv('OMV_RRDGRAPH_ERROR_IMAGE',
-		'/usr/share/openmediavault/icons/rrd_graph_error_64.png');
+		'/usr/share/openmediavault/icons/rrd_graph_error_64.svg');
 	shutil.copyfile(src, filename)
 
 def load_collectd_config(plugin_name, option):

--- a/deb/openmediavault/usr/sbin/omv-mkrrdgraph
+++ b/deb/openmediavault/usr/sbin/omv-mkrrdgraph
@@ -48,14 +48,16 @@ def main():
 			'--daemon', 'unix:{}'.format(openmediavault.getenv(
 				'OMV_RRDCACHED_SOCKETFILE', '/var/run/rrdcached.sock')),
 			'--imgformat', openmediavault.getenv(
-				'OMV_COLLECTD_RRDTOOL_GRAPH_IMGFORMAT', 'PNG'),
+				'OMV_COLLECTD_RRDTOOL_GRAPH_IMGFORMAT', 'SVG'),
 			'--width', openmediavault.getenv(
 				'OMV_COLLECTD_RRDTOOL_GRAPH_WIDTH', '400'),
 			'--height', openmediavault.getenv(
 				'OMV_COLLECTD_RRDTOOL_GRAPH_HEIGHT', '120'),
 			'--alt-y-grid',
 			'--interlaced',
-			'--font', 'TITLE:9:.'],
+			'--font', 'DEFAULT:7:.',
+			'--font', 'WATERMARK:5:.',
+			'--font', 'TITLE:8:.'],
 		'data_dir': os.path.join(
 			openmediavault.getenv('OMV_RRDCACHED_BASEDIR',
 				'/var/lib/rrdcached/db'),

--- a/deb/openmediavault/usr/share/openmediavault/icons/license.txt
+++ b/deb/openmediavault/usr/share/openmediavault/icons/license.txt
@@ -2,3 +2,8 @@ Image: rrd_graph_error_64.png
 Designer: Volker Theile
 License: GPL3
 URL: none
+
+Image: rrd_graph_error_64.svg
+Designer: Florian Floimair (derived from rrd_graph_error_64.png by Volker Theile)
+License: GPL3
+URL: none

--- a/deb/openmediavault/usr/share/openmediavault/icons/rrd_graph_error_64.svg
+++ b/deb/openmediavault/usr/share/openmediavault/icons/rrd_graph_error_64.svg
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg10"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64"
+   sodipodi:docname="rrd_graph_error_64.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="2035"
+     id="namedview12"
+     showgrid="true"
+     showguides="false"
+     inkscape:zoom="20.601562"
+     inkscape:cx="28.007585"
+     inkscape:cy="23.666261"
+     inkscape:window-x="-13"
+     inkscape:window-y="-13"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg10">
+    <inkscape:grid
+       type="xygrid"
+       id="grid26" />
+  </sodipodi:namedview>
+  <rect
+     style="fill:#4f4f4f;fill-opacity:0;stroke-width:0.76858747"
+     id="rect24"
+     width="19.277527"
+     height="58.866669"
+     x="22.297352"
+     y="1.1333358" />
+  <rect
+     style="fill:#b9b9b9;fill-opacity:1;stroke-width:0.77446675"
+     id="rect20"
+     width="18.891977"
+     height="38.225109"
+     x="1.7861207"
+     y="21.774895" />
+  <rect
+     style="fill:#b9b9b9;fill-opacity:1;stroke-width:0.78255612"
+     id="rect22"
+     width="18.891977"
+     height="30.580088"
+     x="43.108021"
+     y="29.419916" />
+  <g
+     id="g4645"
+     transform="matrix(0.7711011,0,0,0.76450218,-0.9836423,-1.2621062)">
+    <rect
+       y="3.8254161"
+       x="30.386045"
+       height="76.30793"
+       width="24.5"
+       id="rect22-3"
+       style="fill:#b9b9b9;fill-opacity:1;stroke-width:1.4077493" />
+    <g
+       id="g4623">
+      <path
+         style="fill:#000000;stroke:none;stroke-width:0.13333334"
+         inkscape:connector-curvature="0"
+         id="path4572"
+         d="m 36,46.333336 c -3.466666,2.666667 -1.733333,4 2.666667,2 2.666667,-1.333333 4.266667,-1.333333 6.933334,0 4.4,2 6.133334,0.666667 2.666667,-2 -3.333334,-2.4 -8.933334,-2.4 -12.266668,0 z" />
+      <circle
+         style="fill:#000000;fill-opacity:1"
+         id="path4603"
+         cx="35"
+         cy="35.333336"
+         r="4" />
+      <circle
+         style="fill:#000000;fill-opacity:1"
+         id="path4603-3"
+         cx="50"
+         cy="35.333336"
+         r="4" />
+    </g>
+  </g>
+</svg>

--- a/deb/openmediavault/usr/share/openmediavault/mkrrdgraph/plugins.d/cpu.py
+++ b/deb/openmediavault/usr/share/openmediavault/mkrrdgraph/plugins.d/cpu.py
@@ -36,7 +36,7 @@ class Plugin(openmediavault.mkrrdgraph.IPlugin):
 			'color_cpu_steal': '#000000'
 		})
 		args = []
-		args.append('{image_dir}/cpu-0-{period}.png'.format(**config))
+		args.append('{image_dir}/cpu-0-{period}.svg'.format(**config))
 		args.extend(config['defaults'])
 		args.extend(['--start', config['start']])
 		args.extend(['--title', '"{title_cpu}{title_by_period}"'.format(**config)])

--- a/deb/openmediavault/usr/share/openmediavault/mkrrdgraph/plugins.d/df.py
+++ b/deb/openmediavault/usr/share/openmediavault/mkrrdgraph/plugins.d/df.py
@@ -39,7 +39,7 @@ class Plugin(openmediavault.mkrrdgraph.IPlugin):
 				mountpoint = 'root'
 			config['mountpoint'] = mountpoint.lstrip('/').replace('/', '-')
 			args = []
-			args.append('"{image_dir}/df-{mountpoint}-{period}.png"'.format(**config))
+			args.append('"{image_dir}/df-{mountpoint}-{period}.svg"'.format(**config))
 			args.extend(config['defaults'])
 			args.extend(['--start', config['start']])
 			args.extend(['--title', '"{title_df}{title_by_period}"'.format(**config)])

--- a/deb/openmediavault/usr/share/openmediavault/mkrrdgraph/plugins.d/interface.py
+++ b/deb/openmediavault/usr/share/openmediavault/mkrrdgraph/plugins.d/interface.py
@@ -34,7 +34,7 @@ class Plugin(openmediavault.mkrrdgraph.IPlugin):
 		for interface in interfaces:
 			config['interface'] = interface
 			args = []
-			args.append('{image_dir}/interface-{interface}-{period}.png'.format(**config))
+			args.append('{image_dir}/interface-{interface}-{period}.svg'.format(**config))
 			args.extend(config['defaults'])
 			args.extend(['--start', config['start']])
 			args.extend(['--title', '"{interface} traffic{title_by_period}"'.format(**config)])

--- a/deb/openmediavault/usr/share/openmediavault/mkrrdgraph/plugins.d/load.py
+++ b/deb/openmediavault/usr/share/openmediavault/mkrrdgraph/plugins.d/load.py
@@ -31,7 +31,7 @@ class Plugin(openmediavault.mkrrdgraph.IPlugin):
 			'color_load_longterm': '#ff1300'   # red
 		})
 		args = []
-		args.append('{image_dir}/load-{period}.png'.format(**config))
+		args.append('{image_dir}/load-{period}.svg'.format(**config))
 		args.extend(config['defaults'])
 		args.extend(['--start', config['start']])
 		args.extend(['--title', '"{title_load}{title_by_period}"'.format(**config)])

--- a/deb/openmediavault/usr/share/openmediavault/mkrrdgraph/plugins.d/memory.py
+++ b/deb/openmediavault/usr/share/openmediavault/mkrrdgraph/plugins.d/memory.py
@@ -32,7 +32,7 @@ class Plugin(openmediavault.mkrrdgraph.IPlugin):
 			'color_memory_used': '#ff7a70'      # red
 		})
 		args = []
-		args.append('{image_dir}/memory-{period}.png'.format(**config))
+		args.append('{image_dir}/memory-{period}.svg'.format(**config))
 		args.extend(config['defaults'])
 		args.extend(['--start', config['start']])
 		args.extend(['--title', '"{title_memory}{title_by_period}"'.format(**config)])

--- a/deb/openmediavault/var/www/openmediavault/js/omv/workspace/panel/RrdGraph.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/workspace/panel/RrdGraph.js
@@ -28,7 +28,7 @@
  * @derived OMV.workspace.panel.Panel
  * Panel that is displaying RRD graphs.
  * @param rrdGraphName (required) The name of the RRD graph file. Such a
- *   file looks like xxxxx-(hour|day|week|month|year).png.
+ *   file looks like xxxxx-(hour|day|week|month|year).svg.
  */
 Ext.define("OMV.workspace.panel.RrdGraph", {
 	extend: "OMV.workspace.panel.Panel",
@@ -58,11 +58,11 @@ Ext.define("OMV.workspace.panel.RrdGraph", {
 	getTemplate: function() {
 		return Ext.create("Ext.XTemplate",
 		  '<div class="x-panel-rrdgraph">',
-		  '  <img src="rrd.php?name={name}-hour.png&time={time}" alt="RRD graph - by hour"/><br/>',
-		  '  <img src="rrd.php?name={name}-day.png&time={time}" alt="RRD graph - by day"/><br/>',
-		  '  <img src="rrd.php?name={name}-week.png&time={time}" alt="RRD graph - by week"/><br/>',
-		  '  <img src="rrd.php?name={name}-month.png&time={time}" alt="RRD graph - by month"/><br/>',
-		  '  <img src="rrd.php?name={name}-year.png&time={time}" alt="RRD graph - by year"/>',
+		  '  <img src="rrd.php?name={name}-hour.svg&time={time}" alt="RRD graph - by hour"/><br/>',
+		  '  <img src="rrd.php?name={name}-day.svg&time={time}" alt="RRD graph - by day"/><br/>',
+		  '  <img src="rrd.php?name={name}-week.svg&time={time}" alt="RRD graph - by week"/><br/>',
+		  '  <img src="rrd.php?name={name}-month.svg&time={time}" alt="RRD graph - by month"/><br/>',
+		  '  <img src="rrd.php?name={name}-year.svg&time={time}" alt="RRD graph - by year"/>',
 		  '</div>');
 	},
 

--- a/deb/openmediavault/var/www/openmediavault/rrd.php
+++ b/deb/openmediavault/var/www/openmediavault/rrd.php
@@ -43,7 +43,7 @@ try {
 	if (!file_exists($pathName))
 		$pathName = \OMV\Environment::get("OMV_RRDGRAPH_ERROR_IMAGE");
 	$fd = fopen($pathName, "r");
-	header("Content-type: image/png");
+	header("Content-type: image/svg+xml");
 	fpassthru($fd);
 } catch(\Exception $e) {
 	header("Content-Type: text/html");


### PR DESCRIPTION
Using SVG not only improves the readability of the graphs but
also makes them scalable on all sorts of resolutions or zoom
levels (e.g. on HiDpi/Retina screens)

Additionally make graphs slightly bigger (+50%) by default.