### PR TITLE
On empy error ShowDetails button was shown

### DIFF
--- a/deb/openmediavault/var/www/openmediavault/js/omv/window/MessageBox.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/window/MessageBox.js
@@ -132,7 +132,6 @@ Ext.define("OMV.window.MessageBox", {
 			detailsText += _("Error #") + error.code + ":\n";
 		if (!Ext.isEmpty(error.trace))
 			detailsText += error.trace;
-		detailsText = OMV.util.Format.whitespace(detailsText, "pre");
 		// Display the error dialog.
 		var dlg = Ext.create("Ext.Window", {
 			title: title || _("Error"),
@@ -210,7 +209,7 @@ Ext.define("OMV.window.MessageBox", {
 				hidden: true,
 				scrollable: true,
 				minHeight: 175,
-				html: detailsText
+				html: OMV.util.Format.whitespace(detailsText, "pre")
 			})]
 		});
 		/*


### PR DESCRIPTION
according to naming the variable, detailsText means text formatted string no html format and in addition to it, empty text was being converted to not empty html and it leads the `Show Details` button was visible!