### PR TITLE
Display Amiga Guru Meditation on 404 page.

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/controlpanel/http404.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/controlpanel/http404.inc
@@ -1,0 +1,59 @@
+<?php
+/**
+ * This file is part of OpenMediaVault.
+ *
+ * @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+ * @author    Volker Theile <volker.theile@openmediavault.org>
+ * @copyright Copyright (c) 2009-2018 Volker Theile
+ *
+ * OpenMediaVault is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * OpenMediaVault is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace OMV\ControlPanel;
+
+class Http404 extends ControlPanelAbstract {
+	protected $prd = null;
+
+	public function __construct() {
+		$this->prd = new \OMV\ProductInfo();
+	}
+
+	public function getJavascriptIncludes() {
+		$incList = [];
+		$this->scanFiles("js/omv/window/MessageBox.js", $incList);
+		return $incList;
+	}
+
+	protected function getTitle() {
+		return sprintf("%s - %s", $this->prd->getName(), gettext("HTTP 404 error"));
+	}
+
+	protected function getBodyClass() {
+		return "error-page";
+	}
+
+	protected function getBodyContent() {
+		$title = sprintf("%s - %s", $this->prd->getName(), gettext("Page not found"));
+		return <<<EOF
+		<a title='{$this->prd->getName()}' href='{$this->prd->getURL()}' target='_blank'><div class="product-logo"></div></a>
+		<script type="application/javascript">
+			Ext.onReady(function() {
+				OMV.MessageBox.guru({
+					closable: false,
+					msg: _("The requested page was not found.")
+				});
+			});
+		</script>
+EOF;
+	}
+}

--- a/deb/openmediavault/var/www/openmediavault/404.php
+++ b/deb/openmediavault/var/www/openmediavault/404.php
@@ -19,30 +19,17 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
  */
-require_once("openmediavault/env.inc");
+try {
+	require_once("openmediavault/autoloader.inc");
 
-$prd = new \OMV\ProductInfo();
-$title = sprintf("%s - %s", $prd->getName(), gettext("Page not found"));
+	$page = new \OMV\ControlPanel\Http404();
+	$page->render();
+} catch(\Exception $e) {
+	// Send an error message to the web server's error log.
+	error_log($e->getMessage());
+	// Print the error message.
+	header("Content-Type: text/html");
+	printf("Error #".$e->getCode().":<br/>%s", str_replace("\n", "<br/>",
+	  $e->__toString()));
+}
 ?>
-<!DOCTYPE html>
-<html>
-	<head>
-		<title><?=$title;?></title>
-		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-		<link rel="shortcut icon" type="image/x-icon" href="favicon.ico"/>
-		<link rel="stylesheet" type="text/css" href="/extjs6/classic/theme-triton/resources/theme-triton-all.css"/>
-		<link rel="stylesheet" type="text/css" href="css/theme-all.min.css"/>
-	</head>
-	<body class="error-page">
-		<span class="error-icon x-fa fa-stack fa-2x">
-			<i class="x-color-red x-fa fa fa-stack-2x fa-circle"></i>
-			<i class="x-color-white x-fa fa fa-stack-1x fa-exclamation"></i>
-		</span>
-		<center>
-			<h1>Error 404</h1>
-			<p>Sorry, the page you requested was not found.</p>
-		</center>
-		<hr>
-		<a title='<?=$prd->getName();?>' href='<?=$prd->getURL();?>' target='_blank'><div class="product-logo"></div></a>
-	</body>
-</html>

--- a/deb/openmediavault/var/www/openmediavault/js/omv/window/MessageBox.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/window/MessageBox.js
@@ -321,6 +321,8 @@ Ext.define("OMV.window.MessageBox", {
 	 *     or key has been pressed.
 	 *   \li scope The scope (this reference) in which the function will
 	 *     be executed.
+	 *   \li closable Set to FALSE to ignore mouse clicks and indefinitely
+	 *     display the message box.
 	 * @return The window object.
 	 */
 	guru: function(config) {
@@ -347,23 +349,25 @@ Ext.define("OMV.window.MessageBox", {
 			html: Ext.String.format("Software Failure.&nbsp;&nbsp;&nbsp;" +
 			  "Press left mouse button to continue.<br/>{0}", config.msg)
 		});
-		// Monitor key press and mouse clicks.
-		var fn = function(e, t, eOpts) {
-			// Unregister event handlers.
-			Ext.getBody().un({
+		if (!Ext.isDefined(config.closable) || (true === config.closable)) {
+			// Monitor key press and mouse clicks.
+			var fn = function(e, t, eOpts) {
+				// Unregister event handlers.
+				Ext.getBody().un({
+					keypress: fn,
+					click: fn
+				});
+				// Remove message box.
+				dlg.close();
+				// Execute given callback function.
+				if (Ext.isFunction(config.fn))
+					config.fn.call(config.scope || me, me);
+			};
+			Ext.getBody().on({
 				keypress: fn,
 				click: fn
 			});
-			// Remove message box.
-			dlg.close();
-			// Execute given callback function.
-			if (Ext.isFunction(config.fn))
-				config.fn.call(config.scope || me, me);
-		};
-		Ext.getBody().on({
-			keypress: fn,
-			click: fn
-		});
+		}
 		return dlg.show();
 	}
 }, function() {


### PR DESCRIPTION
In contrast to the displayed text 'Press left mouse button to continue' the LMB is click is disabled on this page because it does not make any sense to hide the Guru Meditation. Changing the text is also no option because the Guru Meditation is a tribute to the Amiga Computer, thus it should look as much as possible as the original.

Signed-off-by: Volker Theile <votdev@gmx.de>