### PR TITLE
Allow proxying omv web-gui to folder by replacing absolute paths with relative

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/controlpanel/controlpanelabstract.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/controlpanel/controlpanelabstract.inc
@@ -115,7 +115,7 @@ EOF;
 
 		// Set core CSS files.
 		$cssList = [
-			"/extjs6/classic/theme-triton/resources/theme-triton-all.css",
+			"extjs6/classic/theme-triton/resources/theme-triton-all.css",
 			"css/theme-all.min.css",
 			"css/theme-triton.min.css",
 			"css/materialdesignicons.min.css"
@@ -140,13 +140,13 @@ EOF;
 		];
 		if (TRUE === \OMV\Environment::getBoolean("OMV_DEBUG_EXTJS", FALSE)) {
 			$jsList = array_merge([
-				"/extjs6/ext-all-debug.js",
-				"/extjs6/classic/theme-triton/theme-triton-debug.js"
+				"extjs6/ext-all-debug.js",
+				"extjs6/classic/theme-triton/theme-triton-debug.js"
 			], $jsList);
 		} else {
 			$jsList = array_merge([
-				"/extjs6/ext-all.js",
-				"/extjs6/classic/theme-triton/theme-triton.js"
+				"extjs6/ext-all.js",
+				"extjs6/classic/theme-triton/theme-triton.js"
 			], $jsList);
 		}
 		foreach ($jsList as $jsListv) {

--- a/deb/openmediavault/var/www/openmediavault/css/theme-all.scss
+++ b/deb/openmediavault/var/www/openmediavault/css/theme-all.scss
@@ -97,8 +97,8 @@
 	height: 42px;
 	right: 20px;
 	bottom: 20px;
-	background: url("/images/header_logo.png");
-	background: url("/images/header_logo.svg"), none;
+	background: url("../images/header_logo.png");
+	background: url("../images/header_logo.svg"), none;
 	background-size: 100% 100%;
 	background-attachment: scroll;
 	background-repeat: no-repeat;
@@ -164,8 +164,8 @@ div#headerlogo {
 	height: 42px;
 	margin-top: 20px;
 	margin-left: 20px;
-	background: url("/images/header_logo.png");
-	background: url("/images/header_logo.svg"), none;
+	background: url("../images/header_logo.png");
+	background: url("../images/header_logo.svg"), none;
 	background-size: 100% 100%;
 	background-repeat: no-repeat;
 	background-color: transparent;
@@ -175,7 +175,7 @@ div#headerrlogo {
 	float: right;
 	height: 100%;
 	width: 362px;
-	background-image: url("/images/header_rlogo.png");
+	background-image: url("../images/header_rlogo.png");
 	display: none;
 }
 /******************************************************************************/
@@ -259,7 +259,7 @@ div#headerrlogo {
 }
 .x-mask-msg-text {
 	padding: 5px 5px 5px 20px;
-	background-image: url("/images/loading.gif");
+	background-image: url("../images/loading.gif");
 	background-repeat: no-repeat;
 	background-position: 0 center;
 }


### PR DESCRIPTION
This pull request replaces 2 absolute paths with relative ones.  These changes allow me to proxy the omv web-gui to a folder (ie: mydomain.com/omv/)

I learned of the issue and how to fix here: https://forum.openmediavault.org/index.php/Thread/20857-OMV-Web-UI-Behind-NGINX-Config/