### PR TITLE
Issue #182: Progress loading bar is not accurate

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,3 +1,10 @@
+openmediavault (4.1.13) stable; urgency=low
+
+  * Issue #182: Remove percentage text in progress bar when config is
+    applied. It is not possible to display an accurate value here.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Mon, 22 Oct 2018 07:03:44 +0200
+
 openmediavault (4.1.12) stable; urgency=low
 
   * Fix display bug in S.M.A.R.T. attributes grid.

--- a/deb/openmediavault/var/www/openmediavault/js/omv/Rpc.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/Rpc.js
@@ -244,7 +244,7 @@ Ext.define("OMV.RpcObserver", {
 			rpcDelay: 500
 		});
 		// Display a waiting dialog while the RPC is running.
-		OMV.MessageBox.wait(options.title, options.msg);
+		OMV.MessageBox.wait(options.title, options.msg, { text: "" });
 		// Execute RPC.
 		var fn = function(id, success, response) {
 			if (!success) {

--- a/deb/openmediavault/var/www/openmediavault/js/omv/window/MessageBox.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/window/MessageBox.js
@@ -295,9 +295,10 @@ Ext.define("OMV.window.MessageBox", {
 	 * Displays a message box with an infinitely auto-updating progress bar.
 	 * @param title The title bar text
 	 * @param msg The message box body text
+	 * @param config A Ext.ProgressBar#wait config object.
 	 */
-	wait: function(title, msg) {
-		return this.callParent([ msg, title || _("Please wait ...") ]);
+	wait: function(title, msg, config) {
+		return this.callParent([ msg, title || _("Please wait ..."), config ]);
 	},
 
 	/**


### PR DESCRIPTION
Remove percentage text in progress bar when config is applied. It is not possible to display an accurate value here.

Signed-off-by: Volker Theile <votdev@gmx.de>
