### PR TITLE
 Use /bin/sh as default shell when creating/importing users via WebUI. 

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -13,6 +13,7 @@ openmediavault (5.0-1) unstable; urgency=low
 openmediavault (4.1.13-1) stable; urgency=low
 
   * Fix various issues found by the lgtm.com project.
+  * Use /bin/sh as default shell when creating/importing users via WebUI.
   * Issue #182: Remove percentage text in progress bar when config is
     applied. It is not possible to display an accurate value here.
   * Issue #192: Allow to define shell at user import.

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/usermgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/usermgmt.inc
@@ -700,7 +700,7 @@ finish:
 					"password" => $matches[5],
 					"groups" => explode(",", $matches[7]),
 					"disallowusermod" => boolvalEx($matches[8]),
-					"shell" => !empty($matches[6]) ? $matches[6] : "/bin/dash",
+					"shell" => !empty($matches[6]) ? $matches[6] : "/bin/sh",
 					"sshpubkeys" => []
 				];
 				if (!empty($matches[2]) && is_numeric($matches[2]))

--- a/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/privilege/user/User.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/privilege/user/User.js
@@ -119,7 +119,7 @@ Ext.define("OMV.module.admin.privilege.user.user.General", {
 				emptyText: _("Select a shell ..."),
 				valueField: "path",
 				displayField: "path",
-				value: "/bin/dash"
+				value: "/bin/sh"
 			},{
 				xtype: "checkbox",
 				name: "disallowusermod",


### PR DESCRIPTION
Signed-off-by: Volker Theile <votdev@gmx.de>