### PR TITLE
Use debian/testing64 image (Buster) as base for the OMV Vagrant dev box.

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -23,7 +23,7 @@
 hostname = "omv5box"
 
 Vagrant.configure("2") do |config|
-	config.vm.box = "debian/stretch64"
+	config.vm.box = "debian/testing64"
 	config.vm.define hostname
 	config.vm.provision :shell, :path => "install.sh"
 	config.vm.network "private_network", ip: "192.172.16.24", auto_config: false


### PR DESCRIPTION
Signed-off-by: Volker Theile <votdev@gmx.de>