### PR TITLE
Change 99openmediavault-proxy mode to 0644

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/apt/default.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/apt/default.sls
@@ -43,7 +43,7 @@ configure_apt_proxy:
     - template: jinja
     - user: root
     - group: root
-    - mode: 640
+    - mode: 644
 
 {% if not use_kernel_backports | to_bool %}
 


### PR DESCRIPTION
/etc/apt/apt.conf.d/99openmediavault-proxy does not have read permission for non root users (0640, instead of 0644 like the other files), so some apt commands, which should not require root permission, fail (e.g. apt search)