### PR TITLE
Setup C.UTF-8 locale

### DIFF
--- a/deb/openmediavault/srv/salt/omv/setup/locale/default.sls
+++ b/deb/openmediavault/srv/salt/omv/setup/locale/default.sls
@@ -25,6 +25,10 @@
 # Get the current configured locale.
 {% set lang = salt['environ.get']('LANG') %}
 
+generate_C.UTF-8_locale:
+  locale.present:
+    - name: "C.UTF-8"
+
 generate_{{ lang }}_locale:
   locale.present:
     - name: "{{ lang }}"

--- a/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/subprocess.py
+++ b/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/subprocess.py
@@ -43,9 +43,9 @@ def _modify_kwargs(kwargs):
     """
     # Append the env keyword if it does not exist.
     if "env" not in kwargs:
-        kwargs["env"] = dict(os.environ, LANG="C")
+        kwargs["env"] = dict(os.environ, LANG="C.UTF-8")
     else:
-        kwargs["env"].update({"LANG": "C"})
+        kwargs["env"].update({"LANG": "C.UTF-8"})
 
 
 def call(*popenargs, **kwargs):

--- a/deb/openmediavault/usr/share/php/openmediavault/system/process.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/process.inc
@@ -35,7 +35,7 @@ class Process {
 	private $background = FALSE;
 	private $env = [
 		"PATH" => "/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
-		"LANG" => "C"
+		"LANG" => "C.UTF-8"
 	];
 
 	/**


### PR DESCRIPTION
Use C.utf-8 to fix the 'click' Python package issues. See https://click.palletsprojects.com/en/7.x/python3/#python-3-surrogate-handling.

Signed-off-by: Volker Theile <votdev@gmx.de>