### PR TITLE
Various rsync improvements

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -15,6 +15,10 @@ openmediavault (5.0-1) unstable; urgency=low
   * Use systemd to reboot/shutdown/standby the system.
   * Issue #93: Use chrony instead of ntpd.
   * Issue #146: Use systemd to configure the network.
+  * Add options 'Group' and 'Owner' to rsync settings. If the 'Archive' option
+    is enabled and one of its implied option 'Recursive',
+    'Preserve permissions', 'Times', 'Group' or 'Owner' is disabled, then this
+    option will be prefixed with '--no-xxx' in the rsync command line.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Tue, 08 May 2018 22:06:11 +0200
 

--- a/deb/openmediavault/srv/salt/omv/deploy/rsync/files/cron-rsync-script.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/rsync/files/cron-rsync-script.j2
@@ -23,12 +23,12 @@
 #!/bin/sh
 {{ pillar['headers']['multiline'] -}}
 . /usr/share/openmediavault/scripts/helper-functions
-cleanup() {" -n \
+cleanup() {
     omv_kill_children $$
-    rm -f {{ runfile }}
+    rm -f "{{ runfile }}"
     exit
 }
-[ -e {{ runfile }} ] && exit 1
+[ -e "{{ runfile }}" ] && exit 1
 {%- if job.type == 'local' or job.mode == 'push' %}
 if ! omv_is_mounted "{{ srcmntdir }}" ; then
     omv_error "Source storage device not mounted at <{{ srcmntdir }}>!"
@@ -42,8 +42,8 @@ if ! omv_is_mounted "{{ destmntdir }}" ; then
 fi
 {%- endif %}
 trap cleanup 0 1 2 5 15
-touch {{ runfile }}
-{%- if not job.quiet | to_bool %}
+touch "{{ runfile }}"
+{%- if not job.option_quiet | to_bool %}
 omv_log "Please wait, syncing <{{ srcuri }}> to <{{ desturi }}> ...\n"
 {%- endif %}
 {%- if job.authentication == 'password' and job.password | length > 0 %}
@@ -51,19 +51,30 @@ export RSYNC_PASSWORD="{{ job.password }}"
 {%- endif %}
 rsync --verbose --log-file="{{ logfile }}"
 {%- if job.authentication == 'pubkey' %}{{ separator }}--rsh "ssh -p {{ job.sshport }} -i '{{ ssh_keys_dir | path_join(ssh_key_prefix ~ job.sshcertificateref) }}'"{%- endif %}
-{%- if job.recursive | to_bool %}{{ separator }}--recursive{%- endif %}
-{%- if job.times | to_bool %}{{ separator }}--times{%- endif %}
-{%- if job.compress | to_bool %}{{ separator }}--compress{%- endif %}
-{%- if job.archive | to_bool %}{{ separator }}--archive{%- endif %}
-{%- if job.delete | to_bool %}{{ separator }}--delete{%- endif %}
-{%- if job.quiet | to_bool %}{{ separator }}--quiet{%- endif %}
-{%- if job.perms | to_bool %}{{ separator }}--perms{%- endif %}
-{%- if job.acls | to_bool %}{{ separator }}--acls{%- endif %}
-{%- if job.xattrs | to_bool %}{{ separator }}--xattrs{%- endif %}
-{%- if job.dryrun | to_bool %}{{ separator }}--dry-run{%- endif %}
-{%- if job.partial | to_bool %}{{ separator }}--partial{%- endif %}
+{%- if job.option_quiet | to_bool %}{{ separator }}--quiet{%- endif %}
+{%- if job.option_dryrun | to_bool %}{{ separator }}--dry-run{%- endif %}
+{%- if job.option_archive | to_bool %}{{ separator }}--archive{%- endif -%}
+{# Prefix implied archive options with '--no-' if enabled #}
+{%- if job.option_archive | to_bool %}
+{%- if not job.option_recursive | to_bool %}{{ separator }}--no-recursive{%- endif %}
+{%- if not job.option_perms | to_bool %}{{ separator }}--no-perms{%- endif %}
+{%- if not job.option_times | to_bool %}{{ separator }}--no-times{%- endif %}
+{%- if not job.option_group | to_bool %}{{ separator }}--no-group{%- endif %}
+{%- if not job.option_owner | to_bool %}{{ separator }}--no-owner{%- endif %}
+{%- else %}
+{%- if job.option_recursive | to_bool %}{{ separator }}--recursive{%- endif %}
+{%- if job.option_perms | to_bool %}{{ separator }}--perms{%- endif %}
+{%- if job.option_times | to_bool %}{{ separator }}--times{%- endif %}
+{%- if job.option_group | to_bool %}{{ separator }}--group{%- endif %}
+{%- if job.option_owner | to_bool %}{{ separator }}--owner{%- endif %}
+{%- endif %}
+{%- if job.option_compress | to_bool %}{{ separator }}--compress{%- endif %}
+{%- if job.option_delete | to_bool %}{{ separator }}--delete{%- endif %}
+{%- if job.option_acls | to_bool %}{{ separator }}--acls{%- endif %}
+{%- if job.option_xattrs | to_bool %}{{ separator }}--xattrs{%- endif %}
+{%- if job.option_partial | to_bool %}{{ separator }}--partial{%- endif %}
 {%- if job.extraoptions | length > 0 %}{{ separator }}{{ job.extraoptions }}{%- endif -%}
 {{ separator }}"{{ srcuri }}" "{{ desturi }}" & wait $!
-{%- if not job.quiet | to_bool %}
+{%- if not job.option_quiet | to_bool %}
 omv_log "\nThe synchronisation has completed successfully."
 {%- endif %}

--- a/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_5.0.0.sh
+++ b/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_5.0.0.sh
@@ -25,4 +25,18 @@ set -e
 
 omv_config_delete "/config/system/network/interfaces/interface/options"
 
+omv_config_rename "/config/services/rsync/jobs/job/recursive" "optionrecursive"
+omv_config_rename "/config/services/rsync/jobs/job/times" "optiontimes"
+omv_config_rename "/config/services/rsync/jobs/job/compress" "optioncompress"
+omv_config_rename "/config/services/rsync/jobs/job/archive" "optionarchive"
+omv_config_rename "/config/services/rsync/jobs/job/delete" "optiondelete"
+omv_config_rename "/config/services/rsync/jobs/job/perms" "optionperms"
+omv_config_rename "/config/services/rsync/jobs/job/acls" "optionacls"
+omv_config_rename "/config/services/rsync/jobs/job/xattrs" "optionxattrs"
+omv_config_rename "/config/services/rsync/jobs/job/dryrun" "optiondryrun"
+omv_config_rename "/config/services/rsync/jobs/job/quiet" "optionquiet"
+omv_config_rename "/config/services/rsync/jobs/job/partial" "optionpartial"
+omv_config_add_key "/config/services/rsync/jobs/job" "optiongroup" "1"
+omv_config_add_key "/config/services/rsync/jobs/job" "optionowner" "1"
+
 exit 0

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.rsync.job.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.rsync.job.json
@@ -100,47 +100,55 @@
 			"type": "string",
 			"pattern": "^[1-7]|[*]$"
 		},
-		"recursive": {
+		"optionrecursive": {
 			"type": "boolean",
 			"default": true
 		},
-		"times": {
+		"optiontimes": {
 			"type": "boolean",
 			"default": true
 		},
-		"compress": {
+		"optiongroup": {
+			"type": "boolean",
+			"default": true
+		},
+		"optionowner": {
+			"type": "boolean",
+			"default": true
+		},
+		"optioncompress": {
 			"type": "boolean",
 			"default": false
 		},
-		"archive": {
+		"optionarchive": {
 			"type": "boolean",
 			"default": true
 		},
-		"delete": {
+		"optiondelete": {
 			"type": "boolean",
 			"default": false
 		},
-		"quiet": {
+		"optionquiet": {
 			"type":"boolean",
 			"default": true
 		},
-		"perms": {
+		"optionperms": {
 			"type": "boolean",
 			"default": true
 		},
-		"acls": {
+		"optionacls": {
 			"type": "boolean",
 			"default": false
 		},
-		"xattrs":{
+		"optionxattrs":{
 			"type": "boolean",
 			"default": false
 		},
-		"dryrun": {
+		"optiondryrun": {
 			"type": "boolean",
 			"default": false
 		},
-		"partial": {
+		"optionpartial": {
 			"type": "boolean",
 			"default": false
 		},

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.rsync.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.rsync.json
@@ -93,47 +93,55 @@
 				"pattern": "^[1-7]|[*]$",
 				"required": true
 			},
-			"recursive": {
+			"optionrecursive": {
 				"type": "boolean",
 				"required": true
 			},
-			"times": {
+			"optiontimes": {
 				"type": "boolean",
 				"required": true
 			},
-			"compress": {
+			"optiongroup": {
 				"type": "boolean",
 				"required": true
 			},
-			"archive": {
+			"optionowner": {
 				"type": "boolean",
 				"required": true
 			},
-			"delete": {
+			"optioncompress": {
 				"type": "boolean",
 				"required": true
 			},
-			"quiet": {
+			"optionarchive": {
+				"type": "boolean",
+				"required": true
+			},
+			"optiondelete": {
+				"type": "boolean",
+				"required": true
+			},
+			"optionquiet": {
 				"type":"boolean",
 				"required": true
 			},
-			"perms": {
+			"optionperms": {
 				"type": "boolean",
 				"required": true
 			},
-			"acls": {
+			"optionacls": {
 				"type": "boolean",
 				"required": true
 			},
-			"xattrs":{
+			"optionxattrs":{
 				"type": "boolean",
 				"required": true
 			},
-			"dryrun": {
+			"optiondryrun": {
 				"type": "boolean",
 				"required": true
 			},
-			"partial": {
+			"optionpartial": {
 				"type": "boolean",
 				"required": true
 			},

--- a/deb/openmediavault/usr/share/openmediavault/templates/config.xml
+++ b/deb/openmediavault/usr/share/openmediavault/templates/config.xml
@@ -559,6 +559,7 @@
 					<uuid>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</uuid>
 					<enable>0|1</enable>
 					<sendemail>0|1<sendemail>
+					<quiet>0</quiet>
 					<comment>xxx</comment>
 					<type>local|remote</type>
 					<src>
@@ -577,17 +578,18 @@
 					<everyndayofmonth>0|1</everyndayofmonth>
 					<month>[01-12|*]</month>
 					<dayofweek>[1-7|*]</dayofweek>
-					<recursive>1</recursive>
-					<times>1</times>
-					<compress>0</compress>
-					<archive>1</archive>
-					<delete>0</delete>
-					<quiet>0</quiet>
-					<perms>1</perms>
-					<acls>1</acls>
-					<xattrs>0</xattrs>
-					<dryrun>0</dryrun>
-					<partial>0</partial>
+					<optionrecursive>1</optionrecursive>
+					<optiontimes>1</optiontimes>
+					<optiongroup>1</optiongroup>
+					<optionowner>1</optionowner>
+					<optioncompress>0</optioncompress>
+					<optionarchive>1</optionarchive>
+					<optiondelete>0</optiondelete>
+					<optionperms>1</optionperms>
+					<optionacls>1</optionacls>
+					<optionxattrs>0</optionxattrs>
+					<optiondryrun>0</optiondryrun>
+					<optionpartial>0</optionpartial>
 					<extraoptions></extraoptions>
 					// remote
 					<mode>push|pull</mode>

--- a/deb/openmediavault/var/www/openmediavault/js/omv/form/plugin/LinkedFields.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/form/plugin/LinkedFields.js
@@ -240,7 +240,7 @@ Ext.define("OMV.form.plugin.LinkedFields", {
 				case "show":
 				case "!hide":
 				case "notHide":
-					if(valid)
+					if (valid)
 						field.show();
 					else
 						field.hide();
@@ -248,7 +248,7 @@ Ext.define("OMV.form.plugin.LinkedFields", {
 				case "hide":
 				case "!show":
 				case "notShow":
-					if(valid)
+					if (valid)
 						field.hide();
 					else
 						field.show();
@@ -261,6 +261,15 @@ Ext.define("OMV.form.plugin.LinkedFields", {
 				case "notVisible":
 					if (Ext.isFunction(field.setVisible))
 						field.setVisible(!valid);
+					break;
+				case "checked":
+					if (valid && (field.xtype == "checkbox"))
+						field.setValue(true);
+					break;
+				case "!checked":
+				case "notChecked":
+					if (valid && (field.xtype == "checkbox"))
+						field.setValue(false);
 					break;
 				}
 			});

--- a/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/service/rsync/Jobs.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/service/rsync/Jobs.js
@@ -156,6 +156,18 @@ Ext.define("OMV.module.admin.service.rsync.Job", {
 						{ name: "authentication", value: "password" }
 					],
 					properties: "show"
+				},{
+					name: [
+						"option_recursive",
+						"option_perms",
+						"option_times",
+						"option_group",
+						"option_owner"
+					],
+					conditions: [
+						{ name: "option_archive", value: true }
+					],
+					properties: "checked"
 				}]
 			}]
 		};
@@ -395,72 +407,6 @@ Ext.define("OMV.module.admin.service.rsync.Job", {
 			value: "*"
 		},{
 			xtype: "checkbox",
-			name: "dryrun",
-			fieldLabel: _("Trial run"),
-			checked: false,
-			boxLabel: _("Perform a trial run with no changes made")
-		},{
-			xtype: "checkbox",
-			name: "recursive",
-			fieldLabel: _("Recursive"),
-			checked: true,
-			boxLabel: _("Recurse into directories")
-		},{
-			xtype: "checkbox",
-			name: "times",
-			fieldLabel: _("Times"),
-			checked: true,
-			boxLabel: _("Preserve modification times")
-		},{
-			xtype: "checkbox",
-			name: "compress",
-			fieldLabel: _("Compress"),
-			checked: false,
-			boxLabel: _("Compress file data during the transfer")
-		},{
-			xtype: "checkbox",
-			name: "archive",
-			fieldLabel: _("Archive"),
-			checked: true,
-			boxLabel: _("Enable archive mode")
-		},{
-			xtype: "checkbox",
-			name: "delete",
-			fieldLabel: _("Delete"),
-			checked: false,
-			boxLabel: _("Delete files on the receiving side that don't exist on sender")
-		},{
-			xtype: "checkbox",
-			name: "quiet",
-			fieldLabel: _("Quiet"),
-			checked: false,
-			boxLabel: _("Suppress non-error messages")
-		},{
-			xtype: "checkbox",
-			name: "perms",
-			fieldLabel: _("Preserve permissions"),
-			checked: true,
-			boxLabel: _("Set the destination permissions to be the same as the source permissions")
-		},{
-			xtype: "checkbox",
-			name: "acls",
-			fieldLabel: _("Preserve ACLs"),
-			checked: false,
-			boxLabel: _("Update the destination ACLs to be the same as the source ACLs")
-		},{
-			xtype: "checkbox",
-			name: "xattrs",
-			fieldLabel: _("Preserve extended attributes"),
-			checked: false,
-			boxLabel: _("Update the destination extended attributes to be the same as the local ones")
-		},{
-			xtype: "checkbox",
-			name: "partial",
-			fieldLabel: _("Keep partially transferred files"),
-			checked: false,
-			boxLabel: _("Enable this option to keep partially transferred files, otherwise they will be deleted if the transfer is interrupted.")
-		},{
-			xtype: "checkbox",
 			name: "sendemail",
 			fieldLabel: _("Send email"),
 			checked: false,
@@ -469,6 +415,84 @@ Ext.define("OMV.module.admin.service.rsync.Job", {
 				ptype: "fieldinfo",
 				text: _("An email message with the command output (if any produced) is send to the administrator.")
 			}]
+		},{
+			xtype: "checkbox",
+			name: "option_dryrun",
+			fieldLabel: _("Trial run"),
+			checked: false,
+			boxLabel: _("Perform a trial run with no changes made")
+		},{
+			xtype: "checkbox",
+			name: "option_quiet",
+			fieldLabel: _("Quiet"),
+			checked: false,
+			boxLabel: _("Suppress non-error messages")
+		},{
+			xtype: "checkbox",
+			name: "option_archive",
+			fieldLabel: _("Archive"),
+			checked: true,
+			boxLabel: _("Enable archive mode")
+		},{
+			xtype: "checkbox",
+			name: "option_recursive",
+			fieldLabel: _("Recursive"),
+			checked: true,
+			boxLabel: _("Recurse into directories")
+		},{
+			xtype: "checkbox",
+			name: "option_perms",
+			fieldLabel: _("Preserve permissions"),
+			checked: true,
+			boxLabel: _("Set the destination permissions to be the same as the source permissions")
+		},{
+			xtype: "checkbox",
+			name: "option_times",
+			fieldLabel: _("Times"),
+			checked: true,
+			boxLabel: _("Preserve modification times")
+		},{
+			xtype: "checkbox",
+			name: "option_group",
+			fieldLabel: _("Group"),
+			checked: true,
+			boxLabel: _("Preserve group")
+		},{
+			xtype: "checkbox",
+			name: "option_owner",
+			fieldLabel: _("Owner"),
+			checked: true,
+			boxLabel: _("Preserve owner")
+		},{
+			xtype: "checkbox",
+			name: "option_compress",
+			fieldLabel: _("Compress"),
+			checked: false,
+			boxLabel: _("Compress file data during the transfer")
+		},{
+			xtype: "checkbox",
+			name: "option_acls",
+			fieldLabel: _("Preserve ACLs"),
+			checked: false,
+			boxLabel: _("Update the destination ACLs to be the same as the source ACLs")
+		},{
+			xtype: "checkbox",
+			name: "option_xattrs",
+			fieldLabel: _("Preserve extended attributes"),
+			checked: false,
+			boxLabel: _("Update the destination extended attributes to be the same as the local ones")
+		},{
+			xtype: "checkbox",
+			name: "option_partial",
+			fieldLabel: _("Keep partially transferred files"),
+			checked: false,
+			boxLabel: _("Enable this option to keep partially transferred files, otherwise they will be deleted if the transfer is interrupted.")
+		},{
+			xtype: "checkbox",
+			name: "option_delete",
+			fieldLabel: _("Delete"),
+			checked: false,
+			boxLabel: _("Delete files on the receiving side that don't exist on sender")
 		},{
 			xtype: "textfield",
 			name: "extraoptions",


### PR DESCRIPTION
Add options 'Group' and 'Owner' to rsync settings. If the 'Archive' option is enabled and one of its implied option 'Recursive', 'Preserve permissions', 'Times', 'Group' or 'Owner' is disabled, then this option will be prefixed with '--no-xxx' in the rsync command line.

Signed-off-by: Volker Theile <votdev@gmx.de>