### PR TITLE
Workaround for omv-mkaptidx to fix `SystemError: error return without exception set`

### DIFF
--- a/deb/openmediavault/usr/sbin/omv-mkaptidx
+++ b/deb/openmediavault/usr/sbin/omv-mkaptidx
@@ -72,6 +72,12 @@ def get_extended_description(raw_description):
             lines[i] = "\n"
     return "\n".join(lines)
 
+def _get_value(f, default=None):
+    try:
+        return f()
+    except SystemError:
+        pass
+    return default
 
 cache = apt.cache.Cache()
 
@@ -113,9 +119,9 @@ for pkg in cache.get_changes():
         "priority": pkg.candidate.priority,
         "filename": pkg.candidate.filename,
         "size": pkg.candidate.size,
-        "md5sum": pkg.candidate.md5,
-        "sha1": pkg.candidate.sha1,
-        "sha256": pkg.candidate.sha256,
+        "md5sum": _get_value(lambda: pkg.candidate.md5),
+        "sha1": _get_value(lambda: pkg.candidate.sha1),
+        "sha256": _get_value(lambda: pkg.candidate.sha256),
         "uri": pkg.candidate.uri,
         "uris": pkg.candidate.uris
     })  # yapf: disable
@@ -164,9 +170,9 @@ for pkg in filtered:
         "priority": pkg.candidate.priority,
         "filename": pkg.candidate.filename,
         "size": pkg.candidate.size,
-        "md5sum": pkg.candidate.md5,
-        "sha1": pkg.candidate.sha1,
-        "sha256": pkg.candidate.sha256,
+        "md5sum": _get_value(lambda: pkg.candidate.md5),
+        "sha1": _get_value(lambda: pkg.candidate.sha1),
+        "sha256": _get_value(lambda: pkg.candidate.sha256),
         "installed": pkg.is_installed
     })  # yapf: disable
 with open(


### PR DESCRIPTION
For some arcane reasons, some apt packages do not have md5_sum in their Packages, this is probably the reason this happens on `omv-mkaptidx` and the reason the plugins list aren't refreshed:
```
root@nas2:/var/lib/openmediavault/apt# /usr/sbin/omv-mkaptidx
Creating index of upgradeable packages ...
Creating index of openmediavault plugins ...
Traceback (most recent call last):
  File "/usr/sbin/omv-mkaptidx", line 170, in <module>
    "md5sum": pkg.candidate.md5,
  File "/usr/lib/python3/dist-packages/apt/package.py", line 772, in md5
    return self._records.md5_hash
SystemError: error return without exception set
```
And looking at for example the package info for `openmediavault-anacron`, there really isn't md5_hash over at the native self.__records dict, but the object dump does show other hashes, so I suspect either my apt database is corrupted or it is intentionally kept empty. I put my bet on the latter.

Potential side effects: checksums might be inaccurate.