### PR TITLE
Extract upstream version for comparison

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/confdbadm/commands.d/migrate.py
+++ b/deb/openmediavault/usr/share/openmediavault/confdbadm/commands.d/migrate.py
@@ -42,7 +42,15 @@ class Command(
             _ = LooseVersion(arg)
         except Exception:
             raise argparse.ArgumentTypeError("No valid version")
-        return arg
+
+        # Extract the upstream version.
+        # [epoch:]upstream_version[-debian_revision]
+        # https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
+        # Note, the regex for the upstream version is simplified.
+        parts = re.match(
+            r'^(\d:)?([^:-]+)(-[a-z0-9\+\.~]+)?$', arg, flags=re.IGNORECASE
+        )
+        return parts.group(2)
 
     def execute(self, *args):
         rc = 1


### PR DESCRIPTION
distutils.version.LooseVersion fails while comparing versions like '5.0.0' < '5.0-1'. The result is a 'TypeError: unorderable types: int() < str()'. This is because the comparison of 0 and '-' does not work. Because of that the package revision must be stripped before the version strings are compared.

Fixes: https://github.com/openmediavault/openmediavault/issues/297

Signed-off-by: Volker Theile <votdev@gmx.de>