### PR TITLE
Various improvements

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/system.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/system.inc
@@ -343,7 +343,6 @@ class System extends \OMV\Rpc\ServiceAbstract {
 		// The information everyone is allowed to see.
 		$result = [
 			"ts" => time(),
-			"time" => strftime("%c"),
 			"hostname" => \OMV\System\Net\Dns::getFqdn()
 		];
 		// Append the information that is only visible to an administrator.

--- a/deb/openmediavault/var/www/openmediavault/js/omv/SystemInfo.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/SystemInfo.js
@@ -37,6 +37,9 @@ Ext.define("OMV.SystemInfo", {
 
 	refreshInterval: 5000,
 
+	// @private
+	data: [],
+
 	constructor: function(config) {
 		var me = this;
 		me.mixins.observable.constructor.call(me, config);
@@ -65,14 +68,10 @@ Ext.define("OMV.SystemInfo", {
 		me.callParent();
 	},
 
-	/**
-	 * Refresh the system information.
-	 */
-	refresh: function() {
+	addListener: function() {
 		var me = this;
-		if (!Ext.isEmpty(me.refreshTask) && (me.refreshTask.isTask)) {
-			me.refreshTask.restart();
-		}
+		me.mixins.observable.addListener.apply(me, arguments);
+		me.fireEvent("refresh", me, me.data);
 	},
 
 	/**
@@ -89,7 +88,8 @@ Ext.define("OMV.SystemInfo", {
 			scope: me,
 			callback: function(id, success, response) {
 				delete me.pendingRequest;
-				me.fireEvent("refresh", me, response);
+				me.data = response;
+				me.fireEvent("refresh", me, me.data);
 			},
 			rpcData: {
 				service: "System",

--- a/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/dashboard/view/SysInfo.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/dashboard/view/SysInfo.js
@@ -108,8 +108,6 @@ Ext.define("OMV.module.admin.dashboard.view.SysInfo", {
 		});
 		me.callParent(arguments);
 		OMV.SystemInfo.on("refresh", me.onRefreshSystemInfo, me);
-		// Force refreshing the data to immediatelly display them.
-		OMV.SystemInfo.refresh();
 	},
 
 	destroy: function() {
@@ -144,7 +142,7 @@ Ext.define("OMV.module.admin.dashboard.view.SysInfo", {
 				"type": "string",
 			},{
 				"name": _("System time"),
-				"value": info.time,
+				"value": new Date(info.ts * 1000).toLocaleString(),
 				"index": index++,
 				"type": "string",
 			},{


### PR DESCRIPTION
- Remove time field in System.getInformation RPC.
- Render system time using unix timestamp and browser locale settings.
- Let the OMV.SystemInfo class work like a RxJS BehaviourSubject.

Signed-off-by: Volker Theile <votdev@gmx.de>