### PR TITLE
Remove 'Local master browser' checkbox in the SMB/CIFS page

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -24,6 +24,8 @@ openmediavault (5.0-1) unstable; urgency=low
     is enabled and one of its implied option 'Recursive',
     'Preserve permissions', 'Times', 'Group' or 'Owner' is disabled, then this
     option will be prefixed with '--no-xxx' in the rsync command line.
+  * Remove 'Local master browser' checkbox in the SMB/CIFS page.
+    If you still need that use the 'Extra Options' field to add it manually.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Tue, 08 May 2018 22:06:11 +0200
 

--- a/deb/openmediavault/srv/salt/omv/deploy/samba/files/global.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/samba/files/global.j2
@@ -61,7 +61,6 @@ use sendfile = {% if config.usesendfile | to_bool %}yes{% else %}no{% endif %}
 aio read size = {{ aio_read_size }}
 aio write size = {{ aio_write_size }}
 {%- endif %}
-local master = {% if config.localmaster | to_bool %}yes{% else %}no{% endif %}
 time server = {% if config.timeserver | to_bool %}yes{% else %}no{% endif %}
 wins support = {% if config.winssupport | to_bool %}yes{% else %}no{% endif %}
 {%- if config.winsserver | length > 0 %}

--- a/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_5.0.0.sh
+++ b/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_5.0.0.sh
@@ -25,6 +25,7 @@ set -e
 
 omv_config_delete "/config/system/network/interfaces/interface/options"
 omv_config_delete "/config/services/zeroconf"
+omv_config_delete "/config/services/smb/localmaster"
 
 omv_config_rename "/config/services/rsync/jobs/job/recursive" "optionrecursive"
 omv_config_rename "/config/services/rsync/jobs/job/times" "optiontimes"

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smb.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smb.json
@@ -32,10 +32,6 @@
 			"type": "boolean",
 			"default": true
 		},
-		"localmaster": {
-			"type": "boolean",
-			"default": true
-		},
 		"timeserver": {
 			"type": "boolean",
 			"default": false

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.smb.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.smb.json
@@ -29,10 +29,6 @@
 				"type": "boolean",
 				"required": true
 			},
-			"localmaster": {
-				"type": "boolean",
-				"required": true
-			},
 			"timeserver": {
 				"type": "boolean",
 				"required": true

--- a/deb/openmediavault/usr/share/openmediavault/templates/config.xml
+++ b/deb/openmediavault/usr/share/openmediavault/templates/config.xml
@@ -486,7 +486,6 @@
 			<loglevel>0</loglevel>
 			<usesendfile>1</usesendfile>
 			<aio>1</aio>
-			<localmaster>1</localmaster>
 			<timeserver>0</timeserver>
 			<winssupport>0</winssupport>
 			<winsserver></winsserver>

--- a/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/service/smb/Settings.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/service/smb/Settings.js
@@ -66,12 +66,6 @@ Ext.define("OMV.module.admin.service.smb.Settings", {
 				}]
 			},{
 				xtype: "checkbox",
-				name: "localmaster",
-				fieldLabel: _("Local master browser"),
-				checked: true,
-				boxLabel: _("Allow this server to try and become a local master browser")
-			},{
-				xtype: "checkbox",
 				name: "timeserver",
 				fieldLabel: _("Time server"),
 				checked: false,


### PR DESCRIPTION
This option is not needed nowadays and is replaced by WSD in modern Windows systems (SMBv2). If you still need that use the 'Extra Options' field to add it manually.

Signed-off-by: Volker Theile <votdev@gmx.de>