### PR TITLE
Prefer X25519 over NIST P-384 and NIST P-256

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/nginx/files/security.conf.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/nginx/files/security.conf.j2
@@ -1,6 +1,7 @@
 {%- set ssl_protocols = salt['pillar.get']('default:OMV_NGINX_SITE_WEBGUI_SSL_PROTOCOLS', 'TLSv1.2 TLSv1.3') -%}
 {%- set ssl_prefer_server_ciphers = salt['pillar.get']('default:OMV_NGINX_SITE_WEBGUI_SSL_PREFER_SERVER_CIPHERS', 'on') -%}
 {%- set ssl_ciphers = salt['pillar.get']('default:OMV_NGINX_SITE_WEBGUI_SSL_CIPHERS', 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256') -%}
+{%- set ssl_ecdh_curve = salt['pillar.get']('default:OMV_NGINX_SITE_WEBGUI_SSL_ECDH_CURVE', 'X25519:secp384r1:prime256v1') -%}
 {%- set hsts_header = salt['pillar.get']('default:OMV_NGINX_SITE_WEBGUI_SECURITY_HSTS', 'max-age=15768000; includeSubdomains') -%}
 {%- set csp_enabled = salt['pillar.get']('default:OMV_NGINX_SITE_WEBGUI_SECURITY_CSP_ENABLE', 'yes') -%}
 {%- set csp_header = salt['pillar.get']('default:OMV_NGINX_SITE_WEBGUI_SECURITY_CSP', 'default-src \'self\' \'unsafe-inline\' \'unsafe-eval\'; img-src \'self\' data:;') -%}
@@ -13,6 +14,7 @@
 ssl_protocols {{ ssl_protocols }};
 ssl_prefer_server_ciphers {{ ssl_prefer_server_ciphers }};
 ssl_ciphers "{{ ssl_ciphers }}";
+ssl_ecdh_curve "{{ ssl_ecdh_curve }}";
 {% endif %}
 {%- if config.enablessl | to_bool and config.forcesslonly | to_bool %}
 # HSTS (HTTP Strict Transport Security)


### PR DESCRIPTION
Prefer X25519 over NIST P-384 and NIST P-256 in nginx's configuration for the webgui. Compared to my previous PR, this one also includes P-256 as a fallback option for older TLS clients.