### PR TITLE
Set HTTP status code

### DIFF
--- a/deb/openmediavault/usr/sbin/omv-engined
+++ b/deb/openmediavault/usr/sbin/omv-engined
@@ -546,7 +546,10 @@ while(FALSE === $sigTerm) {
 					"error" => [
 						"code" => $e->getCode(),
 						"message" => $e->getMessage(),
-						"trace" => $e->__toString()
+						"trace" => $e->__toString(),
+						"http_status_code" =>
+							($e instanceof \OMV\BaseException) ?
+							$e->getHttpStatusCode() : 500
 					]
 				]);
 			}

--- a/deb/openmediavault/usr/share/php/openmediavault/baseexception.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/baseexception.inc
@@ -24,4 +24,27 @@ namespace OMV;
 /**
  * @ingroup api
  */
-class MutexLockException extends BaseException {}
+class BaseException extends \Exception {
+	/**
+	 * @var int The HTTP status code that is used when the exception
+	 *   is thrown while processing a RPC request. Defaults to 500.
+	 */
+	public $httpStatusCode = 500;
+
+	/**
+	 * Get the HTTP status code of this exception.
+	 * @return int The HTTP status code.
+	 */
+	public function getHttpStatusCode() : int {
+		return $this->httpStatusCode;
+	}
+
+	/**
+	 * Set the HTTP status code of this exception.
+	 * @param int $code The HTTP status code.
+	 * @see https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
+	 */
+	public function setHttpStatusCode(int $code) {
+		$this->httpStatusCode = $code;
+	}
+}

--- a/deb/openmediavault/usr/share/php/openmediavault/errormsgexception.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/errormsgexception.inc
@@ -26,7 +26,7 @@ namespace OMV;
  * to allow you to react on this somewhere, e.g. in the Javascript web UI.
  * This is used for session timeout exceptions for example.
  */
-class ErrorMsgException extends \Exception {
+class ErrorMsgException extends BaseException {
 	// RPC
 	const E_RPC_GET_PARAMS_FAILED = 1000;
 	const E_RPC_INVALID_PARAMS = 1001;

--- a/deb/openmediavault/usr/share/php/openmediavault/exception.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/exception.inc
@@ -25,7 +25,7 @@ namespace OMV;
  * \em Exception is the base class for nearly all exceptions of this framework.
  * @ingroup api
  */
-class Exception extends \Exception {
+class Exception extends BaseException {
 	public function __construct() {
 		$code = 0;
 		$args = func_get_args();

--- a/deb/openmediavault/usr/share/php/openmediavault/execexception.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/execexception.inc
@@ -25,7 +25,7 @@ namespace OMV;
  * \em ExecException is thrown when the execution of a process fails.
  * @ingroup api
  */
-class ExecException extends \Exception {
+class ExecException extends BaseException {
 	private $cmdLine = NULL;
 	private $output = [];
 	private $exitStatus = NULL;

--- a/deb/openmediavault/usr/share/php/openmediavault/rpc/rpc.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/rpc/rpc.inc
@@ -196,8 +196,10 @@ class Rpc {
 			if (array_key_exists("error", $response) && !is_null(
 			  $response['error'])) {
 				$error = $response['error'];
-				throw new TraceException($error['message'], $error['code'],
-				  $error['trace']);
+				$e = new TraceException($error['message'], $error['code'],
+					$error['trace']);
+				$e->setHttpStatusCode($error['http_status_code']);
+				throw $e;
 			}
 			return $response['response'];
 		}

--- a/deb/openmediavault/usr/share/php/openmediavault/rpc/serviceabstract.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/rpc/serviceabstract.inc
@@ -90,7 +90,7 @@ abstract class ServiceAbstract {
 		$rpcService->registeredMethodSequences[$method] = [
 			"service" => $this->getName(),
 			"method" => $method2
-	  	];
+		];
 	}
 
 	/**
@@ -171,11 +171,18 @@ abstract class ServiceAbstract {
 	 */
 	final protected function validateMethodParams($params, $schema) {
 //		$this->debug(var_export(func_get_args(), TRUE));
-		// Convert the given paramaters into JSON. This is necessary because
+		// Convert the given parameters into JSON. This is necessary because
 		// the 'params' variable contains an associative array which can not
 		// be processed by the validator.
-		$validator = new ParamsValidator($schema);
-		$validator->validate(json_encode_safe($params));
+		try {
+			$validator = new ParamsValidator($schema);
+			$validator->validate(json_encode_safe($params));
+		} catch(\Exception $e) {
+			if ($e instanceof \OMV\BaseException) {
+				$e->setHttpStatusCode(400);
+			}
+			throw $e;
+		}
 	}
 
 	/**
@@ -193,14 +200,20 @@ abstract class ServiceAbstract {
 			if (!is_array($required['username']))
 				$required['username'] = [ $required['username'] ];
 			foreach ($required['username'] as $usernamek => $usernamev) {
-				if ($context['username'] !== $usernamev)
-					throw new Exception("Invalid context.");
+				if ($context['username'] !== $usernamev) {
+					$e = new Exception("Invalid context username.");
+					$e->setHttpStatusCode(403);
+					throw $e;
+				}
 			}
 		}
 		// - Check the role
 		if (array_key_exists("role", $required)) {
-			if (!($context['role'] & $required['role']))
-				throw new Exception("Invalid context.");
+			if (!($context['role'] & $required['role'])) {
+				$e = new Exception("Invalid context role.");
+				$e->setHttpStatusCode(403);
+				throw $e;
+			}
 		}
 	}
 

--- a/deb/openmediavault/usr/share/php/openmediavault/rpc/traceexception.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/rpc/traceexception.inc
@@ -27,24 +27,24 @@ namespace OMV\Rpc;
  * @ingroup api
  */
 class TraceException extends Exception {
-    private $trace; /**< The exception stack trace. */
+	private $trace; /**< The exception stack trace. */
 
-    /**
-     * Constructor
-     * @param message The exception message to throw.
-     * @param code The exception code.
-     * @param trace The exception stack trace.
-     */
-    public function __construct($message, $code = 0, $trace = "") {
-        $this->trace = $trace;
-        parent::__construct($message, $code);
-    }
+	/**
+	 * Constructor
+	 * @param message The exception message to throw.
+	 * @param code The exception code.
+	 * @param trace The exception stack trace.
+	 */
+	public function __construct($message, $code = 0, $trace = "") {
+		$this->trace = $trace;
+		parent::__construct($message, $code);
+	}
 
-    /**
-     * String representation of the exception.
-     * @return Returns the string representation of the exception.
-     */
-    public function __toString() {
-        return $this->trace;
-    }
+	/**
+	 * String representation of the exception.
+	 * @return Returns the string representation of the exception.
+	 */
+	public function __toString() {
+		return $this->trace;
+	}
 }

--- a/deb/openmediavault/usr/share/php/openmediavault/session.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/session.inc
@@ -143,8 +143,11 @@ class Session {
 	public function validateAuthentication() {
 		if (!$this->isAuthenticated()) {
 			$this->destroy();
-			throw new \OMV\ErrorMsgException(
-			  \OMV\ErrorMsgException::E_SESSION_NOT_AUTHENTICATED);
+			// Throw a 4xx exception.
+			$e = new \OMV\ErrorMsgException(
+				\OMV\ErrorMsgException::E_SESSION_NOT_AUTHENTICATED);
+			$e->setHttpStatusCode(401);
+			throw $e;
 		}
 	}
 
@@ -155,8 +158,11 @@ class Session {
 	public function validateTimeout() {
 		if ($this->isTimeout()) {
 			$this->destroy();
-			throw new \OMV\ErrorMsgException(
-			  \OMV\ErrorMsgException::E_SESSION_TIMEOUT);
+			// Throw a 4xx exception.
+			$e = new \OMV\ErrorMsgException(
+				\OMV\ErrorMsgException::E_SESSION_TIMEOUT);
+			$e->setHttpStatusCode(403);
+			throw $e;
 		}
 	}
 
@@ -170,8 +176,11 @@ class Session {
 		$userInfo = posix_getpwnam($_SESSION['username']);
 		if (FALSE === $userInfo) {
 			$this->destroy();
-			throw new \OMV\ErrorMsgException(
-			  \OMV\ErrorMsgException::E_SESSION_INVALID_USER);
+			// Throw a 4xx exception.
+			$e = new \OMV\ErrorMsgException(
+				\OMV\ErrorMsgException::E_SESSION_INVALID_USER);
+			$e->setHttpStatusCode(403);
+			throw $e;
 		}
 	}
 
@@ -185,8 +194,11 @@ class Session {
 		if ($_SESSION['ipaddress'] == $_SERVER['REMOTE_ADDR'])
 			return;
 		$this->destroy();
-		throw new \OMV\ErrorMsgException(
-		  \OMV\ErrorMsgException::E_SESSION_INVALID_IPADDRESS);
+		// Throw a 4xx exception.
+		$e = new \OMV\ErrorMsgException(
+			\OMV\ErrorMsgException::E_SESSION_INVALID_IPADDRESS);
+		$e->setHttpStatusCode(403);
+		throw $e;
 	}
 
 	/**
@@ -199,8 +211,11 @@ class Session {
 		if ($_SESSION['useragent'] == $_SERVER['HTTP_USER_AGENT'])
 			return;
 		$this->destroy();
-		throw new \OMV\ErrorMsgException(
-		  \OMV\ErrorMsgException::E_SESSION_INVALID_USERAGENT);
+		// Throw a 4xx exception.
+		$e = new \OMV\ErrorMsgException(
+			\OMV\ErrorMsgException::E_SESSION_INVALID_USERAGENT);
+		$e->setHttpStatusCode(403);
+		throw $e;
 	}
 
 	/**

--- a/deb/openmediavault/var/www/openmediavault/404.php
+++ b/deb/openmediavault/var/www/openmediavault/404.php
@@ -29,6 +29,8 @@ try {
 	error_log($e->getMessage());
 	// Print the error message.
 	header("Content-Type: text/html");
+	http_response_code(($e instanceof \OMV\BaseException) ?
+		$e->getHttpStatusCode() : 500);
 	printf("Error #".$e->getCode().":<br/>%s", str_replace("\n", "<br/>",
 	  $e->__toString()));
 }

--- a/deb/openmediavault/var/www/openmediavault/download.php
+++ b/deb/openmediavault/var/www/openmediavault/download.php
@@ -51,6 +51,8 @@ if (array_keys_exists(array("service", "method"), $_POST)) {
 		if (isset($server))
 			$server->cleanup();
 		header("Content-Type: text/html");
+		http_response_code(($e instanceof \OMV\BaseException) ?
+			$e->getHttpStatusCode() : 500);
 		printf("Error #%s:<br/>%s", strval($e->getCode()),
 			str_replace("\n", "<br/>", htmlentities($e->__toString())));
 	}

--- a/deb/openmediavault/var/www/openmediavault/index.php
+++ b/deb/openmediavault/var/www/openmediavault/index.php
@@ -50,6 +50,8 @@ try {
 	error_log($e->getMessage());
 	// Print the error message.
 	header("Content-Type: text/html");
+	http_response_code(($e instanceof \OMV\BaseException) ?
+		$e->getHttpStatusCode() : 500);
 	printf("Error #".$e->getCode().":<br/>%s", str_replace("\n", "<br/>",
 	  $e->__toString()));
 }

--- a/deb/openmediavault/var/www/openmediavault/js/omv/Rpc.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/Rpc.js
@@ -102,17 +102,9 @@ Ext.define("OMV.Rpc", {
 
 		if (success) {
 			try {
-				// Decode RPC response. It contains the fields called
-				// response and error.
-				if(!Ext.isEmpty(response.responseText)) {
+				if (!Ext.isEmpty(response.responseText)) {
 					var o = Ext.JSON.decode(response.responseText);
-					// Check if RPC response contains an error object.
-					if(Ext.isObject(o.error)) {
-						success = false;
-						rpcResponse = o.error;
-					} else {
-						rpcResponse = o.response;
-					}
+					rpcResponse = o.response;
 				}
 			} catch(e) {
 				success = false;
@@ -123,12 +115,25 @@ Ext.define("OMV.Rpc", {
 				};
 			}
 		} else {
-			rpcResponse = {
-				code: null,
-				message: Ext.isEmpty(response.statusText) ?
-				  "" : response.statusText.rtrim(" \n"),
-				trace: response.responseText || response.statusText
-			};
+			if (!Ext.isEmpty(response.responseText)) {
+				try {
+					var o = Ext.JSON.decode(response.responseText);
+					rpcResponse = o.error;
+				} catch(e) {
+					rpcResponse = {
+						code: null,
+						message: "",
+						trace: response.responseText || e.toString()
+					};
+				}
+			} else {
+				rpcResponse = {
+					code: null,
+					message: Ext.isEmpty(response.statusText) ?
+						"" : response.statusText.rtrim(" \n"),
+					trace: response.responseText || response.statusText
+				};
+			}
 		}
 
 		// Handle special errors.

--- a/deb/openmediavault/var/www/openmediavault/rpc.php
+++ b/deb/openmediavault/var/www/openmediavault/rpc.php
@@ -48,6 +48,8 @@ try {
 	if (isset($server))
 		$server->cleanup();
 	header("Content-Type: application/json");
+	http_response_code(($e instanceof \OMV\BaseException) ?
+		$e->getHttpStatusCode() : 500);
 	print json_encode_safe(array(
 		"response" => null,
 		"error" => array(

--- a/deb/openmediavault/var/www/openmediavault/rrd.php
+++ b/deb/openmediavault/var/www/openmediavault/rrd.php
@@ -39,7 +39,7 @@ try {
 	// Build the image file path. If it does not exist, then display an
 	// error image by default.
 	$pathName = build_path(DIRECTORY_SEPARATOR, \OMV\Environment::get(
-	  "OMV_RRDGRAPH_DIR"), $_GET['name']);
+		"OMV_RRDGRAPH_DIR"), $_GET['name']);
 	if (!file_exists($pathName))
 		$pathName = \OMV\Environment::get("OMV_RRDGRAPH_ERROR_IMAGE");
 	$fd = fopen($pathName, "r");
@@ -47,6 +47,8 @@ try {
 	fpassthru($fd);
 } catch(\Exception $e) {
 	header("Content-Type: text/html");
+	http_response_code(($e instanceof \OMV\BaseException) ?
+		$e->getHttpStatusCode() : 500);
 	printf("Error #%s:<br/>%s", strval($e->getCode()),
 		str_replace("\n", "<br/>", htmlentities($e->__toString())));
 }

--- a/deb/openmediavault/var/www/openmediavault/upload.php
+++ b/deb/openmediavault/var/www/openmediavault/upload.php
@@ -47,6 +47,8 @@ try {
 	if (isset($server))
 		$server->cleanup();
 	header("Content-Type: text/html");
+	http_response_code(($e instanceof \OMV\BaseException) ?
+		$e->getHttpStatusCode() : 500);
 	print json_encode_safe(array(
 		"success" => false, // required by ExtJS
 		"responseText" => $e->getMessage(), // required by ExtJS


### PR DESCRIPTION
Assign a HTTP response status code to every exception, so it is possible to forward this information to the frontend. This is needed to correctly implement HTTP error interceptors.

Signed-off-by: Volker Theile <votdev@gmx.de>

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
