### PR TITLE
Postfix will resolve SMTP server with IPv6 even if IPv6 is disabled

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -4,6 +4,8 @@ openmediavault (5.0.3-1) unstable; urgency=low
   * Set correct HTTP status codes.
   * Issue #322: Process Device Mapper devices correctly in method
     openmediavault.fs.Filesystem::get_parent_device_file().
+  * Issue #394: Postfix will resolve SMTP server with IPv6 even if
+    IPv6 is disabled.
   * Disable quota service if not used.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Sun, 19 May 2019 16:21:00 +0200

--- a/deb/openmediavault/srv/salt/omv/deploy/postfix/files/main.cf.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/postfix/files/main.cf.j2
@@ -20,6 +20,9 @@ mydomain = {{ grains['domain'] }}
 {%- endif %}
 mydestination = {{ mydestination }}
 inet_interfaces = {{ inet_interfaces }}
+{%- if not salt['omv_utils.is_ipv6_enabled']() %}
+inet_protocols = ipv4
+{%- endif %}
 relayhost = {{ config.server }}:{{ config.port }}
 sender_canonical_maps = regexp:{{ sender_canonical_maps }}
 sender_bcc_maps = hash:{{ sender_bcc_maps }}


### PR DESCRIPTION
Fixes: https://github.com/openmediavault/openmediavault/issues/394

Signed-off-by: Volker Theile <votdev@gmx.de>

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
