### PR TITLE
update omv-salt for deploying failed

### DIFF
--- a/deb/openmediavault/usr/sbin/omv-salt
+++ b/deb/openmediavault/usr/sbin/omv-salt
@@ -117,7 +117,7 @@ def deploy_run(names, quiet):
     names = map(lambda x: "omv.deploy.{}".format(x), names)
     mopts = salt.config.minion_config(__salt_minion_config_file)
     caller = salt.client.Caller(mopts=mopts)
-    result = caller.cmd("state.orchestrate", names)
+    result = caller.cmd("state.orchestrate", list(names))
     rc = result["retcode"]
     # Print the output.
     if not quiet:


### PR DESCRIPTION
The second param should be 'list' for function salt.client.Caller.cmd, otherwise it will prompt
'No matching sls found for '<map object at xxx>' in env 'base''
Test with 'salt 2019.2.0'


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
