### PR TITLE
Remove parameters forcing a new bind on nginx

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/mkconf/nginx.d/10webgui
+++ b/deb/openmediavault/usr/share/openmediavault/mkconf/nginx.d/10webgui
@@ -105,7 +105,8 @@ xmlstarlet sel -t -m "//webadmin" \
     -v "concat('    listen ',port,';')" -n \
   -b \
   -i "${ipv6enabled} = 1" \
-    -v "concat('    listen [::]:',port,' ipv6only=off;')" -n \
+    -v "concat('    listen ',port,';')" -n \  
+    -v "concat('    listen [::]:',port,';')" -n \
   -b \
   -i "enablessl[. = '1'] and forcesslonly[. = '1']" \
     -o "    if (\$scheme = http) {" -n \
@@ -115,10 +116,11 @@ xmlstarlet sel -t -m "//webadmin" \
   -b \
   -i "enablessl[. = '1']" \
     -i "${ipv6enabled} = 0" \
-      -v "concat('    listen ',sslport,' ssl deferred;')" -n \
+      -v "concat('    listen ',sslport,' ssl;')" -n \
     -b \
     -i "${ipv6enabled} = 1" \
-      -v "concat('    listen [::]:',sslport,' ipv6only=off ssl deferred;')" -n \
+      -v "concat('    listen ',sslport,' ssl;')" -n \    
+      -v "concat('    listen [::]:',sslport,' ssl;')" -n \
     -b \
     -v "concat('    ssl_certificate ${OMV_SSL_CERTIFICATE_DIR}/certs/${OMV_SSL_CERTIFICATE_PREFIX}',sslcertificateref,'.crt;')" -n \
     -v "concat('    ssl_certificate_key ${OMV_SSL_CERTIFICATE_DIR}/private/${OMV_SSL_CERTIFICATE_PREFIX}',sslcertificateref,'.key;')" -n \


### PR DESCRIPTION
Remove parameters forcing a new bind on nginx

When a new server is added manually in nginx configuration, the same ports can't be used cause of the ipv6only and deferred parameters used.
http://nginx.org/en/docs/http/ngx_http_core_module.html

Fixes: https://github.com/openmediavault/openmediavault/issues/444

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
