### PR TITLE
Add smtp_relay_restrictions with explicit default value to the postfix config

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/postfix/files/main.cf.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/postfix/files/main.cf.j2
@@ -13,6 +13,7 @@
 {%- set smtp_tls_CAfile = salt['pillar.get']('default:OMV_POSTFIX_MAIN_SMTP_TLS_CAFILE', '/etc/ssl/certs/ca-certificates.crt') -%}
 {%- set smtp_tls_CApath = salt['pillar.get']('default:OMV_POSTFIX_MAIN_SMTP_TLS_CAPATH', '/etc/ssl/certs') -%}
 {%- set smtp_header_checks = salt['pillar.get']('default:OMV_POSTFIX_MAIN_SMTP_HEADER_CHECKS', '/etc/postfix/smtp_header_checks') -%}
+{%- set smtp_relay_restrictions = salt['pillar.get']('default:OMV_POSTFIX_MAIN_SMTP_RELAY_RESTRICTIONS', 'permit_mynetworks, permit_sasl_authenticated, defer_unauth_destination') -%}
 {%- set transport_maps = salt['pillar.get']('default:OMV_POSTFIX_MAIN_TRANSPORT_MAPS', '/etc/postfix/transport') -%}
 {{ pillar['headers']['multiline'] }}
 {%- if grains['domain'] | length > 0 %}
@@ -43,4 +44,5 @@ smtp_tls_CAfile = {{ smtp_tls_CAfile }}
 smtp_tls_CApath = {{ smtp_tls_CApath }}
 {%- endif %}
 smtp_header_checks = regexp:{{ smtp_header_checks }}
+smtpd_relay_restrictions = {{ smtp_relay_restrictions }}
 transport_maps = hash:{{ transport_maps }}


### PR DESCRIPTION
Add smtp_relay_restrictions with explicit default value to the postfix config

If the value of smtp_relay_restrictions is empty, postfix keeps flooding syslog with fatal error messages. We should explicitly add the default value of smtp_relay_restrictions to the configuration file to suppress the error messages. 
[Reference](http://www.postfix.org/postconf.5.html#smtpd_relay_restrictions)

Fixes: #446

Signed-off-by: Jimmy Page <jimmymasaru@gmail.com>
