### PR TITLE
Prevent TTY-related pseudo-errors

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -23,6 +23,9 @@
 hostname = "omv5box"
 
 Vagrant.configure("2") do |config|
+  # Prevent TTY-related pseudo-errors
+  # We do this by not allocating a pseudo-tty (the default is bash -l)
+  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
 	config.vm.box = "debian/buster64"
 	config.vm.define hostname
 	config.vm.provision :shell, :path => "install.sh"


### PR DESCRIPTION
Prevents the TTY error "mesg: ttyname failed: Inappropriate ioctl for device" by not allocating login shell.

These message are sent out as mail as part of the cron job to update the smartdb, which the user gets weekly if mail is enabled. Reproducing this bug is as easy as enabling mail and calling the cron file /etc/cron.weekly/openmediavault-update-smart-drivedb in the `Scheduled Jobs` web interface tab if you don't want to wait a week.
We do this by configuring the Vagrant box to not allocate a pseudo-tty and issue inline commands, which leads to shell scripts not asking for login shell.

Fixes: #82 

Signed-off-by: xBelladonna <isabelladonnamoore@outlook.com>

- [x] References issue
- [x] Includes tests for new functionality or reproducer for bug
