### PR TITLE
fix: diskstat do not install disk.sls file

### DIFF
--- a/deb/openmediavault-diskstats/debian/openmediavault-diskstats.install
+++ b/deb/openmediavault-diskstats/debian/openmediavault-diskstats.install
@@ -1,2 +1,3 @@
 usr/share/openmediavault/* usr/share/openmediavault/
 var/www/openmediavault/* var/www/openmediavault/
+srv/* srv/


### PR DESCRIPTION
fix: diskstat do not install disk.sls
not sure if something else is needed but on my test it generates the picture 