### PR TITLE
Create fs does not exclude swap partition

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/backend/swap.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/backend/swap.inc
@@ -21,16 +21,12 @@
  */
 namespace OMV\System\Filesystem\Backend;
 
-///////////////////////////////////////////////////////////////////////////////
-// Register default filesystem backends.
-///////////////////////////////////////////////////////////////////////////////
-$backends = [ "Btrfs", "Ext", "Ext2", "Ext3", "Ext4", "Hfsplus",
-  "Iso9660", "Jfs", "Msdos", "None", "Ntfs", "Reiserfs", "Udf", "Ufs",
-  "Umsdos", "Exfat", "Vfat", "Xfs", "Fuseblk", "Swap" ];
-$mngr = Manager::getInstance();
-foreach ($backends as $backendk => $backendv) {
-	$className = sprintf("%s\%s", __NAMESPACE__, $backendv);
-	$mngr->registerBackend(new $className());
+/**
+ * Swap is not a real filesystem, but it's the easiest way to
+ * integrate it.
+ */
+class Swap extends BackendAbstract {
+	public function __construct() {
+		$this->type = "swap";
+	}
 }
-if (TRUE === $debug)
-	$mngr->dump();


### PR DESCRIPTION
Let the filesystem backend know about Swap partitions. Swap is not a filesystem, but it is the easiest and smartest way to handle them in the OMV backend.

Fixes: https://github.com/openmediavault/openmediavault/issues/475

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
