### PR TITLE
Improve OMV\System\Filesystem\Filesystem::getImplByMountPoint()…

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,7 @@
 openmediavault (5.2.6-1) unstable; urgency=low
 
-  *
+  * Improve OMV\System\Filesystem\Filesystem::getImplByMountPoint() method.
+    This should result in less parsing errors of the mount tab.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Tue, 28 Jan 2020 14:26:00 +0100
 

--- a/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/filesystem.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/filesystem.inc
@@ -878,33 +878,23 @@ class Filesystem extends \OMV\System\BlockDevice
 	}
 
 	/**
-	 * Get the object of the class which implements the specified filesystem
+	 * Get the object of the class which implements the filesystem
 	 * for the given mount point.
 	 * @param dir The file system path prefix, e.g. '/home/ftp/data'.
-	 * @return The class object or NULL on failure.
+	 * @return The class object (which implements the interface
+	 *   OMV\System\Filesystem\FilesystemInterface) or NULL on failure.
 	 */
 	public static function getImplByMountPoint($dir) {
 		if (TRUE === empty($dir))
 			return NULL;
-		$result = NULL;
-		foreach (file("/proc/mounts") as $rowk => $rowv) {
-			// Parse command output:
-			// rootfs / rootfs rw 0 0
-			// none /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
-			// none /proc proc rw,nosuid,nodev,noexec,relatime 0 0
-			// tmpfs /dev/shm tmpfs rw,nosuid,nodev,relatime 0 0
-			// /dev/sdb2 /home/ftp/data ext4 rw,noexec,relatime,user_xattr,acl,barrier=1,data=ordered,jqfmt=vfsv0,usrjquota=aquota.user,grpjquota=aquota.group 0 0
-			// /dev/sde1 /media/46607e80-dc8e-427e-9939-7909985dfe5b ext4 rw,noexec,relatime,user_xattr,acl,barrier=1,data=ordered,jqfmt=vfsv0,usrjquota=aquota.user,grpjquota=aquota.group 0 0
-			$parts = explode(" ", $rowv);
-			if ($parts[1] == escape_path($dir, TRUE)) {
-				// Get the backend by the file system type (e.g. ext4, xfs,
-				// nfs, aufs, ...).
-				$mngr = Backend\Manager::getInstance();
-				if (NULL !== ($backend = $mngr->getBackendByType($parts[2])))
-					$result = $backend->getImpl($parts[0]);
-				break;
-			}
-		}
-		return $result;
+		// Exit immediately if the specified directory is no mount point.
+		$mp = new \OMV\System\MountPoint($dir);
+		if (FALSE === $mp->isMountPoint())
+			return NULL;
+		// Get the device file that is mounted on the given directory.
+		$deviceFile = $mp->getDeviceFile();
+		$mngr = Backend\Manager::getInstance();
+		$backend = $mngr->getBackendById($deviceFile);
+		return $backend->getImpl($deviceFile);
 	}
 }

--- a/deb/openmediavault/usr/share/php/openmediavault/system/mountpoint.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/mountpoint.inc
@@ -195,6 +195,25 @@ class MountPoint {
 	}
 
 	/**
+	 * Get the device file that is mounted on the given directory.
+	 * Note, the device MUST be mounted.
+	 * @return The device file of that is mounted on the given
+	 *   directory, e.g. '/dev/vda1'.
+	 */
+	public function getDeviceFile() {
+		$cmdArgs = [];
+		$cmdArgs[] = "--first-only";
+		$cmdArgs[] = "--noheadings";
+		$cmdArgs[] = "--output=SOURCE";
+		$cmdArgs[] = "--raw";
+		$cmdArgs[] = escapeshellarg($this->getPath());
+		$cmd = new \OMV\System\Process("findmnt", $cmdArgs);
+		$cmd->setRedirect2to1();
+		$cmd->execute($output);
+		return trim($output[0]);
+	}
+
+	/**
 	 * Get the mountpoint path where the file system should be mounted to.
 	 * Note, this path is OMV specific: /srv/<FSUUID>.
 	 * @param id string The device file or UUID of the file system, e.g.


### PR DESCRIPTION
This should result in less parsing errors of the mount tab.

Use findmnt to get the device that is mounted on the given directory.

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
