### PR TITLE
add ubuntu support

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/apt/default.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/apt/default.sls
@@ -94,19 +94,23 @@ remove_apt_sources_list_debian_security:
   file.absent:
     - name: "/etc/apt/sources.list.d/openmediavault-debian-security.list"
 
-# Check if the Debian security repository is already configured (e.g.
+remove_apt_sources_list_os_security:
+  file.absent:
+    - name: "/etc/apt/sources.list.d/openmediavault-os-security.list"
+
+# Check if the Debian or Ubuntu security repository is already configured (e.g.
 # in /etc/apt/sources.list). Only add it if this is not the case.
 {% set repos = [] %}
 {% for value in salt['pkg.list_repos']().values() %}
 {% set _ = repos.extend(value) %}
 {% endfor %}
-{% if repos | rejectattr('disabled') | selectattr('type', 'equalto', 'deb') | selectattr('uri', 'match', '^https?://security.debian.org/debian-security$') | list | length == 0 %}
+{% if repos | rejectattr('disabled') | selectattr('type', 'equalto', 'deb') | selectattr('uri', 'match', '^https?://security.(debian.org|ubuntu.com)/.*-security$') | list | length == 0 %}
 
-configure_apt_sources_list_debian_security:
+configure_apt_sources_list_os_security:
   file.managed:
-    - name: "/etc/apt/sources.list.d/openmediavault-debian-security.list"
+    - name: "/etc/apt/sources.list.d/openmediavault-os-security.list"
     - source:
-      - salt://{{ slspath }}/files/etc-apt-sources_list_d-openmediavault-debian-security_list.j2
+      - salt://{{ slspath }}/files/etc-apt-sources_list_d-openmediavault-os-security_list.j2
     - template: jinja
     - user: root
     - group: root

--- a/deb/openmediavault/srv/salt/omv/deploy/apt/files/etc-apt-sources_list_d-openmediavault-debian-security_list.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/apt/files/etc-apt-sources_list_d-openmediavault-debian-security_list.j2
@@ -1,2 +1,0 @@
-deb http://security.debian.org/debian-security {{ grains['oscodename'] }}/updates main contrib non-free
-deb-src http://security.debian.org/debian-security {{ grains['oscodename'] }}/updates main contrib non-free

--- a/deb/openmediavault/srv/salt/omv/deploy/apt/files/etc-apt-sources_list_d-openmediavault-kernel-backports_list.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/apt/files/etc-apt-sources_list_d-openmediavault-kernel-backports_list.j2
@@ -1,1 +1,5 @@
+{%- if grains['os'] == 'Ubuntu' %}
+deb mirror://mirrors.ubuntu.com/mirrors.txt {{ grains['oscodename'] }}-backports main restricted universe
+{%- else %}
 deb http://httpredir.debian.org/debian {{ grains['oscodename'] }}-backports main contrib non-free
+{%- endif %}

--- a/deb/openmediavault/srv/salt/omv/deploy/apt/files/etc-apt-sources_list_d-openmediavault-os-security_list.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/apt/files/etc-apt-sources_list_d-openmediavault-os-security_list.j2
@@ -1,0 +1,7 @@
+{%- if grains['os'] == 'Ubuntu' %}
+deb http://security.ubuntu.com/ubuntu {{ grains['oscodename'] }}-security main restricted universe
+deb-src http://security.ubuntu.com/ubuntu {{ grains['oscodename'] }}-security main restricted universe
+{%- else %}
+deb http://security.debian.org/debian-security {{ grains['oscodename'] }}/updates main contrib non-free
+deb-src http://security.debian.org/debian-security {{ grains['oscodename'] }}/updates main contrib non-free
+{%- endif %}


### PR DESCRIPTION
add ubuntu support

I have been testing OMV 5.x on Ubuntu 19.10 Eoan and it works very well.  The only issue I have found is that the backports and security repos are hardcoded to Debian repos.

Fixes: ubuntu support

Signed-off-by: Aaron Murray <plugins@omv-extras.org>

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug