### PR TITLE
adding tags-like styling for user groups in User.js

### DIFF
--- a/deb/openmediavault/var/www/openmediavault/css/theme-all.scss
+++ b/deb/openmediavault/var/www/openmediavault/css/theme-all.scss
@@ -621,3 +621,14 @@ div#headerrlogo {
 .x-webkit :not(.x-form-textarea-body) > .x-form-trigger-wrap {
 	height: initial;
 }
+
+/******************************************************************************/
+/* Tags class for group cell in User grid panel */
+.x-group-tag {
+	display: inline-block;
+	border: 1px solid #d0d0d0;
+	padding: 0px 3px 0px 3px;
+	margin: 1px;
+	border-radius: 2px;
+	background-color: #f6f6f6;
+}

--- a/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/privilege/user/User.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/privilege/user/User.js
@@ -623,10 +623,14 @@ Ext.define("OMV.module.admin.privilege.user.Users", {
 		text: _("Groups"),
 		dataIndex: "groups",
 		stateId: "groups",
+		cellWrap: true,
+		width: 200,
 		renderer: function(value) {
-			if(Ext.isArray(value))
-				value = value.join(", ");
-			return OMV.util.Format.whitespace(value);
+			var items = value, value = '';
+			items.forEach(function(item) {
+				value += "<span class='x-group-tag'>"+item+"</span>";
+			});
+			return value;
 		}
 	}],
 


### PR DESCRIPTION
Hello

This is a proposed appearance modification to make user groups visually easy to read.
 
![Screenshot from 2020-02-08 08-44-36](https://user-images.githubusercontent.com/53077134/74079982-cff47e00-4a4f-11ea-8009-3bdee41179f3.png)
