### PR TITLE
Fix path to UPS tools in nut for Buster

### DIFF
--- a/deb/openmediavault-nut/srv/salt/omv/deploy/monit/services/files/nut.j2
+++ b/deb/openmediavault-nut/srv/salt/omv/deploy/monit/services/files/nut.j2
@@ -16,7 +16,7 @@ check process nut-monitor with matching upsmon
     noalert {{ email_config.primaryemail }}
 {%- endif %}
 
-check program nut-upsc-{{ nut_config.upsname }} with path "/usr/bin/upsc {{ nut_config.upsname }}"
+check program nut-upsc-{{ nut_config.upsname }} with path "/bin/upsc {{ nut_config.upsname }}"
     group nut
-    start program = "/usr/sbin/upsdrvctl start"
+    start program = "/sbin/upsdrvctl start"
     if status != 0 for 2 cycles then restart


### PR DESCRIPTION
The path to the UPS tools has changed in Debian Buster. This commit fixes the path in the monit configuration.