### PR TITLE
Add UPS client (netclient) support in NUT plugin

### DIFF
--- a/deb/openmediavault-nut/srv/salt/omv/deploy/monit/services/files/nut.j2
+++ b/deb/openmediavault-nut/srv/salt/omv/deploy/monit/services/files/nut.j2
@@ -1,3 +1,4 @@
+{%- if nut_config.mode != 'netclient' %}
 check process nut-server with matching upsd
     group nut
     start program = "/bin/systemctl start nut-server"
@@ -6,7 +7,7 @@ check process nut-server with matching upsd
 {%- if email_config.enable | to_bool and not notification_config.enable | to_bool %}
     noalert {{ email_config.primaryemail }}
 {%- endif %}
-
+{%- endif %}
 check process nut-monitor with matching upsmon
     group nut
     start program = "/bin/systemctl start nut-monitor"
@@ -16,7 +17,9 @@ check process nut-monitor with matching upsmon
     noalert {{ email_config.primaryemail }}
 {%- endif %}
 
+{%- if nut_config.mode != 'netclient' %}
 check program nut-upsc-{{ nut_config.upsname }} with path "/usr/bin/upsc {{ nut_config.upsname }}"
     group nut
     start program = "/usr/sbin/upsdrvctl start"
     if status != 0 for 2 cycles then restart
+{%- endif %}

--- a/deb/openmediavault-nut/srv/salt/omv/deploy/nut/default.sls
+++ b/deb/openmediavault-nut/srv/salt/omv/deploy/nut/default.sls
@@ -44,7 +44,7 @@ configure_nut_nut_conf:
     - contents: |
         {{ pillar['headers']['auto_generated'] }}
         {{ pillar['headers']['warning'] }}
-        MODE={{ "netserver" if nut_config.remotemonitor | to_bool else "standalone" }}
+        MODE={{ "netserver" if nut_config.remotemonitor | to_bool else nut_config.mode }}
     - user: root
     - group: nut
     - mode: 640
@@ -157,6 +157,8 @@ remove_nut_udev_serialups_rule:
 
 {% endif %}
 
+{% if nut_config.mode != 'netclient' %}
+
 start_nut_driver_service:
   service.running:
     - name: nut-driver
@@ -172,16 +174,18 @@ start_nut_server_service:
       - file: configure_nut_upsd_conf
       - file: configure_nut_upsmon_conf
 
+monitor_nut_server_service:
+  monit.monitor:
+    - name: nut-server
+
+{% endif %}
+
 start_nut_monitor_service:
   service.running:
     - name: nut-monitor
     - enable: True
     - watch:
       - file: configure_nut_upsmon_conf
-
-monitor_nut_server_service:
-  monit.monitor:
-    - name: nut-server
 
 monitor_nut_monitor_service:
   monit.monitor:

--- a/deb/openmediavault-nut/srv/salt/omv/deploy/nut/files/etc-nut-upsmon_conf.j2
+++ b/deb/openmediavault-nut/srv/salt/omv/deploy/nut/files/etc-nut-upsmon_conf.j2
@@ -15,7 +15,11 @@
 {%- set nocommwarntime = salt['pillar.get']('default:OMV_NUT_UPSMON_NOCOMMWARNTIME', '300') -%}
 {%- set finaldelay = salt['pillar.get']('default:OMV_NUT_UPSMON_FINALDELAY', '5') -%}
 {{ pillar['headers']['multiline'] -}}
+{%- if config.mode == 'netclient' -%}
+MONITOR {{ config.upsname }}@{{ config.netclienthostname }} {{ config.powervalue }} {{ config.netclientusername }} {{ config.netclientpassword }} slave
+{%- else -%}
 MONITOR {{ config.upsname }} 1 {{ monitor_user }} {{ monitor_passwd }} master
+{%- endif %}
 MINSUPPLIES {{ minsupplies }}
 SHUTDOWNCMD "{{ shutdowncmd }}"
 NOTIFYCMD "{{ notifycmd }}"

--- a/deb/openmediavault-nut/usr/share/openmediavault/confdb/create.d/conf.service.nut.sh
+++ b/deb/openmediavault-nut/usr/share/openmediavault/confdb/create.d/conf.service.nut.sh
@@ -50,8 +50,13 @@ EOF
 )
 	omv_config_add_node "/config/services" "nut"
 	omv_config_add_key "/config/services/nut" "enable" "0"
+	omv_config_add_key "/config/services/nut" "mode" "standalone"
 	omv_config_add_key "/config/services/nut" "upsname" "ups"
 	omv_config_add_key "/config/services/nut" "comment" ""
+	omv_config_add_key "/config/services/nut" "netclienthostname" ""
+	omv_config_add_key "/config/services/nut" "netclientusername" ""
+	omv_config_add_key "/config/services/nut" "netclientpassword" ""
+	omv_config_add_key "/config/services/nut" "powervalue" "1"
 	omv_config_add_key "/config/services/nut" "driverconf" "${driverconf}"
 	omv_config_add_key "/config/services/nut" "shutdownmode" "onbatt"
 	omv_config_add_key "/config/services/nut" "shutdowntimer" "30"

--- a/deb/openmediavault-nut/usr/share/openmediavault/confdb/migrations.d/conf.service.nut_5.4.1.sh
+++ b/deb/openmediavault-nut/usr/share/openmediavault/confdb/migrations.d/conf.service.nut_5.4.1.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+#
 # This file is part of OpenMediaVault.
 #
 # @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
@@ -17,28 +19,14 @@
 # You should have received a copy of the GNU General Public License
 # along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
 
-{% set config = salt['omv_conf.get']('conf.service.nut') %}
-{% set port = salt['pillar.get']('default:OMV_NUT_UPSD_PORT', '3493') %}
+set -e
 
-{% if config.enable | to_bool %}
+. /usr/share/openmediavault/scripts/helper-functions
 
-configure_collectd_conf_nut_plugin:
-  file.managed:
-    - name: "/etc/collectd/collectd.conf.d/nut.conf"
-    - contents: |
-        LoadPlugin nut
-        <Plugin nut>
-            {% if config.mode == 'netclient' -%}
-            UPS "{{ config.upsname }}@{{ config.netclienthostname }}"
-            {%- else -%}
-            UPS "{{ config.upsname }}@localhost:{{ port }}"
-            {%- endif %}
-        </Plugin>
+omv_config_add_key "/config/services/nut" "mode" "standalone"
+omv_config_add_key "/config/services/nut" "netclienthostname" ""
+omv_config_add_key "/config/services/nut" "netclientusername" ""
+omv_config_add_key "/config/services/nut" "netclientpassword" ""
+omv_config_add_key "/config/services/nut" "powervalue" "1"
 
-{% else %}
-
-remove_collectd_conf_nut_plugin:
-  file.absent:
-    - name: "/etc/collectd/collectd.conf.d/nut.conf"
-
-{% endif %}
+exit 0

--- a/deb/openmediavault-nut/usr/share/openmediavault/datamodels/conf.service.nut.json
+++ b/deb/openmediavault-nut/usr/share/openmediavault/datamodels/conf.service.nut.json
@@ -11,12 +11,33 @@
 			"type": "boolean",
 			"default": false
 		},
+		"mode": {
+			"type": "string",
+			"enum": [ "netclient", "standalone" ],
+			"default": "standalone"
+		},
 		"upsname": {
 			"type": "string",
 			"pattern": "^[a-z0-9_-]+$"
 		},
 		"comment": {
 			"type": "string"
+		},
+		"netclienthostname": {
+			"type": "string"
+		},
+		"netclientusername": {
+			"type": "string",
+			"default": ""
+		},
+		"netclientpassword": {
+			"type": "string",
+			"default": ""
+		},
+		"powervalue": {
+			"type": "integer",
+			"minimum": 0,
+			"default": 1
 		},
 		"driverconf": {
 			"type": "string"

--- a/deb/openmediavault-nut/usr/share/openmediavault/datamodels/rpc.nut.json
+++ b/deb/openmediavault-nut/usr/share/openmediavault/datamodels/rpc.nut.json
@@ -5,42 +5,64 @@
 		"type": "object",
 		"properties": {
 			"enable": {
-			    "type": "boolean",
+				"type": "boolean",
+				"required": true
+			},
+			"mode": {
+				"type": "string",
+				"enum": [ "netclient", "standalone" ],
 				"required": true
 			},
 			"upsname": {
-			    "type": "string",
-			    "pattern": "^[a-z0-9_-]+$",
+				"type": "string",
+				"pattern": "^[a-z0-9_-]+$",
 				"required": true
 			},
 			"comment": {
-			    "type": "string",
+				"type": "string",
+				"required": true
+			},
+			"netclienthostname": {
+				"type": "string",
+				"required": true
+			},
+			"netclientusername": {
+				"type": "string",
+				"required": true
+			},
+			"netclientpassword": {
+				"type": "string",
+				"required": true
+			},
+			"powervalue": {
+				"type": "integer",
+				"minimum": 0,
 				"required": true
 			},
 			"driverconf": {
-			    "type": "string",
+				"type": "string",
 				"required": true
 			},
 			"shutdownmode": {
-			    "type": "string",
-			    "enum":[ "fsd", "onbatt" ],
+				"type": "string",
+				"enum":[ "fsd", "onbatt" ],
 				"required": true
 			},
 			"shutdowntimer": {
-			    "type": "integer",
-			    "minimum": 1,
+				"type": "integer",
+				"minimum": 1,
 				"required": true
 			},
 			"remotemonitor": {
-			    "type": "boolean",
+				"type": "boolean",
 				"required": true
 			},
 			"remoteuser": {
-			    "type": "string",
+				"type": "string",
 				"required": true
 			},
 			"remotepassword": {
-			    "type": "string",
+				"type": "string",
 				"required": true
 			}
 		}

--- a/deb/openmediavault-nut/usr/share/openmediavault/engined/module/nut.inc
+++ b/deb/openmediavault-nut/usr/share/openmediavault/engined/module/nut.inc
@@ -36,7 +36,12 @@ class NetworkUPSTools extends \OMV\Engine\Module\ServiceAbstract
 	public function getStatus() {
 		$db = \OMV\Config\Database::getInstance();
 		$object = $db->get("conf.service.nut");
-		$systemCtl = new \OMV\System\SystemCtl("nut-server");
+		$mode = $object->get("mode");
+		if ("netclient" === $mode) {
+			$systemCtl = new \OMV\System\SystemCtl("nut-monitor");
+		} else {
+			$systemCtl = new \OMV\System\SystemCtl("nut-server");
+		}
 		return [
 			"name" => $this->getName(),
 			"title" => gettext("UPS"),

--- a/deb/openmediavault-nut/usr/share/openmediavault/engined/rpc/nut.inc
+++ b/deb/openmediavault-nut/usr/share/openmediavault/engined/rpc/nut.inc
@@ -93,8 +93,14 @@ class OMVRpcServiceNetworkUPSTools extends \OMV\Rpc\ServiceAbstract {
 		if (FALSE === $object->get("enable")) {
 			$stats = gettext("Service disabled");
 		} else {
+			$mode = $object->get("mode");
 			$cmdArgs = [];
-			$cmdArgs[] = escapeshellarg($object->get("upsname"));
+			if ("netclient" === $mode) {
+				$remoteUps = $object->get("upsname")."@".$object->get("netclienthostname");
+				$cmdArgs[] = escapeshellarg($remoteUps);
+			} else {
+				$cmdArgs[] = escapeshellarg($object->get("upsname"));
+			}
 			$cmd = new \OMV\System\Process("upsc", $cmdArgs);
 			$cmd->setRedirect2to1();
 			$cmd->execute($output);

--- a/deb/openmediavault-nut/usr/share/openmediavault/mkrrdgraph/plugins.d/nut.py
+++ b/deb/openmediavault-nut/usr/share/openmediavault/mkrrdgraph/plugins.d/nut.py
@@ -22,6 +22,7 @@ import openmediavault.mkrrdgraph
 import openmediavault.subprocess
 import os
 import re
+import copy
 
 
 class Plugin(openmediavault.mkrrdgraph.IPlugin):
@@ -53,10 +54,15 @@ class Plugin(openmediavault.mkrrdgraph.IPlugin):
         )
         for ups_config in ups_configs:
             # Get the configuration name of the UPS.
-            m = re.match(r'^(\S+)@(\S+):(\d+)$', ups_config)
+            m = re.match(r'^(\S+)@([^\s:]+)(:(\d+))?$', ups_config)
             if not m:
                 continue
             config['upsname'] = m.group(1)
+            hostname = m.group(2)
+            if hostname != 'localhost':
+                config = copy.deepcopy(config) # Do not affect original data_dir
+                config['data_dir'] = os.path.abspath(os.path.join(
+                    config['data_dir'], os.pardir, hostname))
 
             image_filename = '{image_dir}/nut-charge-{period}.png'.format(
                 **config

--- a/deb/openmediavault-nut/var/www/openmediavault/js/omv/module/admin/service/nut/Nut.js
+++ b/deb/openmediavault-nut/var/www/openmediavault/js/omv/module/admin/service/nut/Nut.js
@@ -47,7 +47,8 @@ Ext.define("OMV.module.admin.service.nut.Settings", {
 			],
 			conditions: [
 				{ name: "enable", value: true },
-				{ name: "remotemonitor", value: true }
+				{ name: "remotemonitor", value: true },
+				{ name: "mode", value: "standalone"}
 			],
 			properties: [
 				"!allowBlank",
@@ -61,6 +62,38 @@ Ext.define("OMV.module.admin.service.nut.Settings", {
 			properties: [
 				"!allowBlank",
 				"!readOnly"
+			]
+		},{
+			name: [
+				"netclienthostname",
+				"netclientusername",
+				"netclientpassword",
+				"powervalue",
+			],
+			conditions: [
+				{ name: "mode", value: "standalone"},
+			],
+			properties: [
+				"allowBlank",
+				"!show"
+			]
+		},{
+			name: "driverconf",
+			conditions: [
+				{ name: "mode", value: "netclient" }
+			],
+			properties: [
+				"allowBlank",
+				"!show"
+			]
+		},{
+			name: "remotemonitor",
+			conditions: [
+				{ name: "mode", value: "netclient" }
+			],
+			properties: [
+				"readOnly",
+				"!checked"
 			]
 		}]
 	}],
@@ -78,6 +111,28 @@ Ext.define("OMV.module.admin.service.nut.Settings", {
 				fieldLabel: _("Enable"),
 				checked: false
 			},{
+				xtype: "combo",
+				name: "mode",
+				fieldLabel: _("Mode"),
+				queryMode: "local",
+				store: Ext.create("Ext.data.ArrayStore", {
+					fields: [ "value", "text" ],
+					data: [
+						[ "netclient", _("Netclient") ],
+						[ "standalone", _("Standalone") ],
+					]
+				}),
+				displayField: "text",
+				valueField: "value",
+				allowBlank: false,
+				editable: false,
+				triggerAction: "all",
+				value: "standalone",
+				plugins: [{
+					ptype: "fieldinfo",
+					text: _("'Standalone' for local UPS, 'Netclient' for remote UPS on a NUT server."),
+				}]
+			},{
 				xtype: "textfield",
 				name: "upsname",
 				fieldLabel: _("Identifier"),
@@ -85,13 +140,40 @@ Ext.define("OMV.module.admin.service.nut.Settings", {
 				vtype: "upsname",
 				plugins: [{
 					ptype: "fieldinfo",
-					text: _("The name used to uniquely identify your UPS on this system.")
+					text: _("The name used to uniquely identify your UPS on local or remote system.")
 				}]
 			},{
 				xtype: "textfield",
 				name: "comment",
 				fieldLabel: _("Comment"),
 				allowBlank: true
+			},{
+				xtype: "textfield",
+				name: "netclienthostname",
+				fieldLabel: _("Netclient hostname"),
+				allowBlank: false
+			},{
+				xtype: "textfield",
+				name: "netclientusername",
+				fieldLabel: _("Netclient username"),
+				allowBlank: false
+			},{
+				xtype: "textfield",
+				name: "netclientpassword",
+				fieldLabel: _("Netclient password"),
+				allowBlank: false
+			},{
+				xtype: "numberfield",
+				name: "powervalue",
+				fieldLabel: _("Powervalue"),
+				minValue: 0,
+				allowDecimals: false,
+				allowBlank: false,
+				value: 1,
+				plugins: [{
+					ptype: "fieldinfo",
+					text: _("The number of power supplies that the UPS feeds on this system (usually 1), refer to <a href='https://networkupstools.org/docs/man/upsmon.conf.html' target='_blank'>UPSMON.CONF(5)</a> for more information.")
+				}]
 			},{
 				xtype: "textarea",
 				name: "driverconf",
@@ -189,11 +271,12 @@ Ext.define("OMV.module.admin.service.nut.Settings", {
 		}
 		// Update remote monitoring settings
 		var remotemonitor = this.findField("remotemonitor").checked;
+		var standalone = (this.findField("mode") === "standalone");
 		fields = [ "remoteuser", "remotepassword" ];
 		for(var i = 0; i < fields.length; i++) {
 			var c = this.findField(fields[i]);
 			if(!Ext.isEmpty(c)) {
-				c.allowBlank = !(enable && remotemonitor);
+				c.allowBlank = !(enable && remotemonitor && standalone);
 				c.setReadOnly(!remotemonitor);
 			}
 		}


### PR DESCRIPTION
Fixes: #318

The patch is for OMV5.
Tested with my UPS on local standalone mode, local standalone with remote monitor.
And UPS on DS918+ for netclient mode.

Signed-off-by: Daniel Tsai <idaniel.twc@gmail.com
- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
