### PR TITLE
fix RPC enumerateMountedFilesystems optional parameters

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/functions.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/functions.inc
@@ -234,11 +234,12 @@ function array_rand_value(array $array, $num = 1) {
  * @ingroup api
  * @param array $array An array with keys.
  * @param string $key The key of the element.
+ * @param string $default The default value returned if not found.
  * @return Returns the boolean value of the given key.
  */
-function array_boolval(array $array, $key) {
+function array_boolval($array, $key, $default = false) {
 	if (!isset($array[$key]))
-		return false;
+		return $default;
 	return boolvalEx($array[$key]);
 }
 

--- a/deb/openmediavault/usr/share/php/openmediavault/functions.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/functions.inc
@@ -238,7 +238,9 @@ function array_rand_value(array $array, $num = 1) {
  * @return Returns the boolean value of the given key.
  */
 function array_boolval($array, $key, $default = false) {
-	if (!isset($array[$key]))
+	if (!is_array($array) || !isset($array[$key])) {
+		return $default;
+	}
 		return $default;
 	return boolvalEx($array[$key]);
 }

--- a/deb/openmediavault/usr/share/php/openmediavault/functions.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/functions.inc
@@ -238,7 +238,7 @@ function array_rand_value(array $array, $num = 1) {
  * @return Returns the boolean value of the given key.
  */
 function array_boolval($array, $key, $default = false) {
-	if (!is_array($array) || !isset($array[$key])) {
+	if (!is_array($array) || !array_key_exists($key, $array)) {
 		return $default;
 	}
 	return boolvalEx($array[$key]);

--- a/deb/openmediavault/usr/share/php/openmediavault/functions.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/functions.inc
@@ -241,7 +241,6 @@ function array_boolval($array, $key, $default = false) {
 	if (!is_array($array) || !isset($array[$key])) {
 		return $default;
 	}
-		return $default;
 	return boolvalEx($array[$key]);
 }
 


### PR DESCRIPTION
update array_boolval function in /usr/share/php/openmediavault/functions.inc
* default value with a 3rd optional parameter
* work also without parameter

* default value with a 3rd optional parameter
[/usr/share/openmediavault/engined/rpc/filesystemmgmt.inc](https://github.com/openmediavault/openmediavault/blob/master/deb/openmediavault/usr/share/openmediavault/engined/rpc/filesystemmgmt.inc) is calling array_boolval with 3 parameters, the last one is the default value not used by the function -> this has been fixed

* work also without parameter
omv-rpc 'FileSystemMgmt' 'enumerateMountedFilesystems'
is not working
PHP Fatal error: Uncaught TypeError: Argument 1 passed to array_boolval() must be of the type array, null given, called in /usr/share/openmediavault/engined/rpc/filesystemmgmt.inc on line 213 and defined in /usr/share/php/openmediavault/functions.inc:239
-> this has been fixed


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
