### PR TITLE
Issue 730 chrony allow clients

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,6 @@
 openmediavault (5.5.3-1) stable; urgency=low
 
-  * Issue #730: Allow chrony to serve clients
+  * Issue #730: Allow chrony to serve clients.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Sat, 06 Jun 2020 23:09:16 +0200
 

--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,6 @@
 openmediavault (5.5.3-1) stable; urgency=low
 
-  *
+  * Issue #730: Allow chrony to serve clients
 
  -- Volker Theile <volker.theile@openmediavault.org>  Sat, 06 Jun 2020 23:09:16 +0200
 

--- a/deb/openmediavault/srv/salt/omv/deploy/chrony/files/etc-chrony-chrony_conf.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/chrony/files/etc-chrony-chrony_conf.j2
@@ -7,7 +7,7 @@
 
 {{ pillar['headers']['multiline'] }}
 
-{%- for timeserver in timeservers.replace(',', ' ').replace(';', ' ').split() %}
+{%- for timeserver in ntp_config.timeservers.replace(',', ' ').replace(';', ' ').split() %}
 server {{ timeserver }} iburst
 {%- endfor %}
 
@@ -39,3 +39,8 @@ rtcsync
 # Step the system clock instead of slewing it if the adjustment is larger than
 # one second, but only in the first three clock updates.
 makestep {{ makestep }}
+
+# Allow clients to request time with allow directives below.
+{%- for client in ntp_config.clients.replace(',', ' ').replace(';', ' ').split() %}
+allow {{ client }}
+{%- endfor %}

--- a/deb/openmediavault/srv/salt/omv/deploy/chrony/files/etc-chrony-chrony_conf.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/chrony/files/etc-chrony-chrony_conf.j2
@@ -40,7 +40,7 @@ rtcsync
 # one second, but only in the first three clock updates.
 makestep {{ makestep }}
 
-# Allow clients to request time with allow directives below.
 {%- for client in ntp_config.clients.replace(',', ' ').replace(';', ' ').split() %}
+# Allow clients to request time with allow directives below.
 allow {{ client }}
 {%- endfor %}

--- a/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_5.5.3.sh
+++ b/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_5.5.3.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+#
 # This file is part of OpenMediaVault.
 #
 # @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
@@ -17,34 +19,10 @@
 # You should have received a copy of the GNU General Public License
 # along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
 
-{% set config = salt['omv_conf.get']('conf.system.time') %}
+set -e
 
-configure_chrony:
-  file.managed:
-    - name: "/etc/chrony/chrony.conf"
-    - source:
-      - salt://{{ tpldir }}/files/etc-chrony-chrony_conf.j2
-    - template: jinja
-    - context:
-        ntp_config: {{ config.ntp | json }}
-    - user: root
-    - group: root
-    - mode: 644
+. /usr/share/openmediavault/scripts/helper-functions
 
-{% if config.ntp.enable | to_bool %}
+omv_config_add_key "/config/system/time/ntp" "clients" ""
 
-start_chrony_service:
-  service.running:
-    - name: chrony
-    - enable: True
-    - watch:
-      - file: configure_chrony
-
-{% else %}
-
-stop_chrony_service:
-  service.dead:
-    - name: chrony
-    - enable: False
-
-{% endif %}
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.system.time.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.system.time.json
@@ -20,6 +20,10 @@
 				"timeservers": {
 					"type": "string",
 					"default": "pool.ntp.org,pool1.ntp.org;pool2.ntp.org"
+				},
+				"clients": {
+					"type": "string",
+					"default": ""
 				}
 			}
 		}

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.system.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.system.json
@@ -15,6 +15,10 @@
 			"ntptimeservers": {
 				"type": "string",
 				"required": true
+			},
+			"ntpclients": {
+				"type": "string",
+				"required": false
 			}
 		}
 	}

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/system.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/system.inc
@@ -254,7 +254,8 @@ class System extends \OMV\Rpc\ServiceAbstract {
 			],
 			"timezone" => $object->get("timezone"),
 			"ntpenable" => $object->get("ntp.enable"),
-			"ntptimeservers" => $object->get("ntp.timeservers")
+			"ntptimeservers" => $object->get("ntp.timeservers"),
+			"ntpclients" => $object->get("ntp.clients")
 		];
 	}
 
@@ -284,6 +285,7 @@ class System extends \OMV\Rpc\ServiceAbstract {
 		$object->set("timezone", $params['timezone']);
 		$object->set("ntp.enable", $params['ntpenable']);
 		$object->set("ntp.timeservers", $params['ntptimeservers']);
+		$object->set("ntp.clients", $params['ntpclients']);
 		// Set the configuration object.
 		$db->set($object);
 		// Return the configuration object.

--- a/deb/openmediavault/usr/share/openmediavault/templates/config.xml
+++ b/deb/openmediavault/usr/share/openmediavault/templates/config.xml
@@ -35,6 +35,7 @@
 			<ntp>
 				<enable>0</enable>
 				<timeservers>pool.ntp.org</timeservers>
+				<clients></clients>
 			</ntp>
 		</time>
 		<email>

--- a/deb/openmediavault/usr/share/openmediavault/unittests/data/config.xml
+++ b/deb/openmediavault/usr/share/openmediavault/unittests/data/config.xml
@@ -35,6 +35,7 @@
       <ntp>
         <enable>0</enable>
         <timeservers>pool.ntp.org</timeservers>
+        <clients></clients>
       </ntp>
     </time>
     <email>

--- a/deb/openmediavault/usr/share/openmediavault/unittests/php/test_openmediavault_config_configobject.php
+++ b/deb/openmediavault/usr/share/openmediavault/unittests/php/test_openmediavault_config_configobject.php
@@ -64,6 +64,7 @@ class test_openmediavault_config_configobject extends \PHPUnit\Framework\TestCas
 		$this->assertFalse($object->get("ntp.enable"));
 		$this->assertEquals($object->get("ntp.timeservers"),
 			"pool.ntp.org,pool1.ntp.org;pool2.ntp.org");
+		$this->assertEquals($object->get("ntp.clients"), "");
 	}
 
 	public function testGetSet3() {

--- a/deb/openmediavault/usr/share/openmediavault/unittests/php/test_openmediavault_config_database.php
+++ b/deb/openmediavault/usr/share/openmediavault/unittests/php/test_openmediavault_config_database.php
@@ -54,6 +54,7 @@ class test_openmediavault_config_database extends \PHPUnit\Framework\TestCase {
 		$object = $db->get("conf.system.time");
 		$this->assertInstanceOf("OMV\Config\ConfigObject", $object);
 		$this->assertEquals($object->get("ntp.timeservers"), "pool.ntp.org");
+		$this->assertEquals($object->get("ntp.clients"), "");
 	}
 
 	public function testGet2() {

--- a/deb/openmediavault/usr/share/openmediavault/unittests/php/test_openmediavault_json_schema.php
+++ b/deb/openmediavault/usr/share/openmediavault/unittests/php/test_openmediavault_json_schema.php
@@ -47,6 +47,10 @@ class test_openmediavault_json_schema extends \PHPUnit\Framework\TestCase {
 						"timeservers" => [
 							"type" => "string",
 							"default" => "pool.ntp.org"
+						],
+						"clients" => [
+							"type" => "string",
+							"default" => ""
 						]
 					]
 				],

--- a/deb/openmediavault/usr/share/openmediavault/unittests/python/test_openmediavault_config_database.py
+++ b/deb/openmediavault/usr/share/openmediavault/unittests/python/test_openmediavault_config_database.py
@@ -63,6 +63,7 @@ class DatabaseTestCase(unittest.TestCase):
         self.assertEqual(obj.get("timezone"), "Europe/Berlin")
         self.assertFalse(obj.get("ntp.enable"))
         self.assertEqual(obj.get("ntp.timeservers"), "pool.ntp.org")
+        self.assertEqual(obj.get("ntp.clients"), "")
 
     def test_get_2(self):
         db = openmediavault.config.Database()

--- a/deb/openmediavault/usr/share/openmediavault/unittests/python/test_openmediavault_config_object.py
+++ b/deb/openmediavault/usr/share/openmediavault/unittests/python/test_openmediavault_config_object.py
@@ -61,6 +61,7 @@ class ConfigObjectTestCase(unittest.TestCase):
             conf_obj.get("ntp.timeservers"),
             "pool.ntp.org,pool1.ntp.org;pool2.ntp.org",
         )
+        self.assertEqual(obj.get("ntp.clients"), "")
 
     def test_set_get_3(self):
         conf_obj = openmediavault.config.Object("conf.system.sharedfolder")

--- a/deb/openmediavault/usr/share/openmediavault/unittests/python/test_openmediavault_json_schema.py
+++ b/deb/openmediavault/usr/share/openmediavault/unittests/python/test_openmediavault_json_schema.py
@@ -38,6 +38,10 @@ class SchemaTestCase(unittest.TestCase):
                                 "type": "string",
                                 "default": "pool.ntp.org",
                             },
+                            "clients": {
+                                "type": "string",
+                                "default": "",
+                            },
                         },
                     },
                     "privilege": {

--- a/deb/openmediavault/usr/share/php/openmediavault/config/configobject.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/config/configobject.inc
@@ -111,6 +111,7 @@ class ConfigObject {
 	 *         (
 	 *             [enable] => 1
 	 *             [timeservers] => pool.ntp.org,pool1.ntp.org;pool2.ntp.org,sss
+	 *             [clients] => 10.0.0.0/16,192.168.1.0/24;10.1.0.1/32
 	 *         )
 	 * )
 	 * @endcode

--- a/deb/openmediavault/usr/share/php/openmediavault/json/schema.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/json/schema.inc
@@ -70,6 +70,10 @@ class Schema {
 	 * 	      array (
 	 * 	        'type' => 'string',
 	 * 	      ),
+	 * 	      'clients' =>
+	 * 	      array (
+	 * 	        'type' => 'string',
+	 * 	      ),
 	 * 	  ),
 	 * 	  ),
 	 * 	),

--- a/deb/openmediavault/var/www/openmediavault/js/ext-overrides.js
+++ b/deb/openmediavault/var/www/openmediavault/js/ext-overrides.js
@@ -269,8 +269,8 @@ Ext.apply(Ext.form.field.VTypes, {
 			return true;
 		return false;
 	},
-	hostnameIPText: _("This field should be a host name or an IP address in CIDR notation"),
-	hostnameIPMask: /[a-z0-9:\-\.\/]/i,
+	hostnameIPNetCIDRText: _("This field should be a host name or an IP address in CIDR notation"),
+	hostnameIPNetCIDRMask: /[a-z0-9:\-\.\/]/i,
 
 	hostnameIPNetCIDRList: function(v) {
 		var valid = true;
@@ -283,8 +283,8 @@ Ext.apply(Ext.form.field.VTypes, {
 		}, this);
 		return valid;
 	},
-	hostnameIPListText: _("This field should be a list of host names or IP addresses in CIDR notation separated by <,> or <;>"),
-	hostnameIPListMask: /[a-z0-9:\-\.\/,;]/i,
+	hostnameIPNetCIDRListText: _("This field should be a list of host names or IP addresses in CIDR notation separated by <,> or <;>"),
+	hostnameIPNetCIDRListMask: /[a-z0-9:\-\.\/,;]/i,
 
 	domainname: function(v) {
 		// See http://shauninman.com/archive/2006/05/08/validating_domain_names

--- a/deb/openmediavault/var/www/openmediavault/js/ext-overrides.js
+++ b/deb/openmediavault/var/www/openmediavault/js/ext-overrides.js
@@ -262,6 +262,30 @@ Ext.apply(Ext.form.field.VTypes, {
 	hostnameIPListText: _("This field should be a list of host names or IP addresses separated by <,> or <;>"),
 	hostnameIPListMask: /[a-z0-9:\-\.,;]/i,
 
+	hostnameIPNetCIDR: function(v) {
+		if(Ext.form.field.VTypes.hostname(v))
+			return true;
+		if(Ext.form.field.VTypes.IPNetCIDR(v))
+			return true;
+		return false;
+	},
+	hostnameIPText: _("This field should be a host name or an IP address in CIDR notation"),
+	hostnameIPMask: /[a-z0-9:\-\.\/]/i,
+
+	hostnameIPNetCIDRList: function(v) {
+		var valid = true;
+		var parts = v.split(new RegExp('[,;]')) || [];
+		Ext.Array.each(parts, function(part) {
+			if(!Ext.form.VTypes.hostnameIPNetCIDR(part)) {
+				valid = false;
+				return false;
+			}
+		}, this);
+		return valid;
+	},
+	hostnameIPListText: _("This field should be a list of host names or IP addresses in CIDR notation separated by <,> or <;>"),
+	hostnameIPListMask: /[a-z0-9:\-\.\/,;]/i,
+
 	domainname: function(v) {
 		// See http://shauninman.com/archive/2006/05/08/validating_domain_names
 		return /^[a-zA-Z0-9]([-a-zA-Z0-9]{0,61}[a-zA-Z0-9])?([.][a-zA-Z0-9]([-a-zA-Z0-9]{0,61}[a-zA-Z0-9])?)*$/.test(v);

--- a/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/system/time/Time.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/system/time/Time.js
@@ -47,7 +47,8 @@ Ext.define("OMV.module.admin.system.time.Time", {
 				"hour",
 				"minute",
 				"second",
-				"ntptimeservers"
+				"ntptimeservers",
+				"ntpclients"
 			],
 			conditions: [
 				{ name: "ntpenable", value: true }
@@ -61,6 +62,12 @@ Ext.define("OMV.module.admin.system.time.Time", {
 			properties: "disabled"
 		},{
 			name: "ntptimeservers",
+			conditions: [
+				{ name: "ntpenable", value: true }
+			],
+			properties: [ "allowBlank", "!readOnly" ]
+		},{
+			name: "ntpclients",
 			conditions: [
 				{ name: "ntpenable", value: true }
 			],
@@ -141,6 +148,18 @@ Ext.define("OMV.module.admin.system.time.Time", {
 				allowBlank: true,
 				readOnly: true,
 				value: "pool.ntp.org"
+			},{
+				xtype: "textfield",
+				name: "ntpclients",
+				fieldLabel: _("Allowed clients"),
+				vtype: "hostnameIPNetCIDRList",
+				allowBlank: true,
+				readOnly: true,
+				value: "",
+				plugins: [{
+					ptype: "fieldinfo",
+					text: _("IP addresses in CIDR notation (preferred) or host names of allowed clients.")
+				}]
 			},{
 				xtype: "fieldcontainer",
 				fieldLabel: _("Manual"),

--- a/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/system/time/Time.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/system/time/Time.js
@@ -158,7 +158,7 @@ Ext.define("OMV.module.admin.system.time.Time", {
 				value: "",
 				plugins: [{
 					ptype: "fieldinfo",
-					text: _("IP addresses in CIDR notation (preferred) or host names of allowed clients.")
+					text: _("IP addresses in CIDR notation or host names of clients that are allowed to access the NTP server.")
 				}]
 			},{
 				xtype: "fieldcontainer",


### PR DESCRIPTION
This change provides a way for users to specify 'allow' directives to chrony so that OMV can serve time requests. When "Use NTP server" is selected, "Allow clients" becomes available. This is a domain or IP list like "Time servers," however entering a partial IP address (e.g. '10.0') will allow all clients in unspecified subnets. See chrony docs for more information.

Supersedes: https://github.com/openmediavault/openmediavault/pull/731
Fixes: https://github.com/openmediavault/openmediavault/issues/730

Signed-off-by: Gregory Moyer moyerg@syphr.com
Signed-off-by: Volker Theile <votdev@gmx.de>

<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
