### PR TITLE
Update nut.j2 /bin and /sbin locations

### DIFF
--- a/deb/openmediavault-nut/srv/salt/omv/deploy/monit/services/files/nut.j2
+++ b/deb/openmediavault-nut/srv/salt/omv/deploy/monit/services/files/nut.j2
@@ -18,8 +18,8 @@ check process nut-monitor with matching upsmon
 {%- endif %}
 
 {%- if nut_config.mode != 'netclient' %}
-check program nut-upsc-{{ nut_config.upsname }} with path "/usr/bin/upsc {{ nut_config.upsname }}"
+check program nut-upsc-{{ nut_config.upsname }} with path "/bin/upsc {{ nut_config.upsname }}"
     group nut
-    start program = "/usr/sbin/upsdrvctl start"
+    start program = "/sbin/upsdrvctl start"
     if status != 0 for 2 cycles then restart
 {%- endif %}


### PR DESCRIPTION
changed location of upsc and upsdrvctl commands as they are no longer located at /usr/bin and /usr/sbin accordingly.  Should be located at /sbin and /bin.


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
