### PR TITLE
Issue #763: Support ejecting tapes.

### DIFF
--- a/deb/openmediavault-usbbackup/debian/changelog
+++ b/deb/openmediavault-usbbackup/debian/changelog
@@ -1,3 +1,12 @@
+openmediavault-usbbackup (5.0.5-1) stable; urgency=low
+
+  * Issue #763: Support ejecting tapes. After a successful sync
+    in non-interactive mode use the 'eject' command to unmount the
+    filesystem, making the device node disappear and activate the
+    loading mechanism for devices like tape drives.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Thu, 16 Jul 2020 22:36:26 +0200
+
 openmediavault-usbbackup (5.0.4-1) stable; urgency=low
 
   * Issue #656: Build correct file path.

--- a/deb/openmediavault-usbbackup/debian/control
+++ b/deb/openmediavault-usbbackup/debian/control
@@ -9,7 +9,7 @@ Homepage: http://www.openmediavault.org
 
 Package: openmediavault-usbbackup
 Architecture: all
-Depends: rsync, openmediavault (>= 5.3.4)
+Depends: rsync, eject, openmediavault (>= 5.3.4)
 Priority: optional
 Description: openmediavault USB/eSATA backup plugin
  Automatically synchronise a shared folder to an USB/eSATA device and vice

--- a/deb/openmediavault-usbbackup/srv/salt/omv/deploy/usbbackup/files/systemd-unitfile-script.j2
+++ b/deb/openmediavault-usbbackup/srv/salt/omv/deploy/usbbackup/files/systemd-unitfile-script.j2
@@ -17,8 +17,9 @@ cleanup() {
     # Remove temporary files.
     rm -f "{{ runfile }}"
     rm -f "${outfile}"
-    # Umount the storage device.
-    umount "{{ devicefile }}" || true
+    # Umount the filesystem, remove device node and eject tray/tape.
+    eject "{{ devicefile }}" || true
+    # Cleanup mount directory.
     rmdir "{{ mount_path }}" || true
     exit
 }


### PR DESCRIPTION
After a successful sync in non-interactive mode use the 'eject' command to unmount the filesystem, making the device node disappear and activate the loading mechanism for devices like tape drives.

Fixes: https://github.com/openmediavault/openmediavault/issues/763

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
