### PR TITLE
User can choose administrator users

### DIFF
--- a/deb/openmediavault/debian/openmediavault.postinst
+++ b/deb/openmediavault/debian/openmediavault.postinst
@@ -75,6 +75,11 @@ case "$1" in
 					--comment 'openmediavault WebGUI Administrator' \
 					admin
 			fi
+			####################################################################
+			# User 'admin' is added to group 'openmediavault-webgui' to provide
+			# access to web interface.
+			####################################################################
+			adduser admin openmediavault-webgui
 
 			####################################################################
 			# Create various required files.

--- a/deb/openmediavault/var/www/openmediavault/rpc/session.inc
+++ b/deb/openmediavault/var/www/openmediavault/rpc/session.inc
@@ -36,6 +36,23 @@ class OMVRpcServiceSession extends \OMV\Rpc\ServiceAbstract {
 	}
 
 	/**
+	* Indicate if user is an administrator (member of group openmediavault-webgui)
+	* @param username The name of the user.
+	* @return TRUE is user is administrator, FALSE otherwise.
+	*/
+	private function isAdmin($username) {
+		$group = posix_getgrnam('openmediavault-webgui');
+		$adminList = $group ? $group['members'] : array();
+		
+		if (empty($adminList)) {
+			syslog(LOG_WARNING, 'No openmediavault administrator could be find in the group openmediavault-webgui');
+			// failback to name admin account
+			$adminList = array('admin');
+		}
+		return in_array($username, $adminList);
+	}
+
+	/**
 	 * Login user.
 	 * @param params The method parameters containing the following fields:
 	 *   \em username The name of the user.
@@ -67,7 +84,7 @@ class OMVRpcServiceSession extends \OMV\Rpc\ServiceAbstract {
 				}
 			} else {
 				// Initialize session.
-				$role = ($params['username'] === "admin") ?
+				$role = $this->isAdmin($params['username']) ?
 					OMV_ROLE_ADMINISTRATOR : OMV_ROLE_USER;
 				$session->initialize($params['username'], $role);
 			}


### PR DESCRIPTION
[Short description]
User can choose administrator users by placing them into the group openmediavault-webgui.

[A longer multiline description]
Not being able to change administrator login is a lack of security (login already known) as well as not being able to have several administrators on the same machine (password sharing).
Also not being able to customize the login for the administrator is a lack of comfort for the user.
Using a coded login is bad practice.
This pull request resolves all the above issues by detecting who is openmediavault web administrator. The user can choose who is administrator by placing the account into the group openmediavault-webgui.

This is retro-compatible with previous behavior ('admin' account still created with 'openmediavault' password by default).

Signed-off-by: [Julien Blitte] <[julien.blitte@gmail.com]>

