### PR TITLE
Use udev over /sys to get model and vendor information

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevice.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevice.inc
@@ -33,11 +33,15 @@ class StorageDevice extends \OMV\System\BlockDevice
 	 * @return string The device model, otherwise an empty string.
 	 */
 	public function getModel() {
-		$filename = sprintf("/sys/block/%s/device/model",
-			$this->getDeviceName(TRUE));
-		if (file_exists($filename))
-			return trim(file_get_contents($filename));
-		return "";
+		if (FALSE === $this->hasUdevProperty("ID_MODEL")) {
+			$filename = sprintf("/sys/block/%s/device/model",
+				$this->getDeviceName(TRUE));
+			if (file_exists($filename))
+				return trim(file_get_contents($filename));
+			return "";
+		}
+		$property = $this->getUdevProperty("ID_MODEL");
+		return str_replace("_", " ", $property);  
 	}
 
 	/**
@@ -45,11 +49,15 @@ class StorageDevice extends \OMV\System\BlockDevice
 	 * @return string The device vendor, otherwise an empty string.
 	 */
 	public function getVendor() {
-		$filename = sprintf("/sys/block/%s/device/vendor",
-			$this->getDeviceName(TRUE));
-		if (file_exists($filename))
-			return trim(file_get_contents($filename));
-		return "";
+		if (FALSE === $this->hasUdevProperty("ID_VENDOR")) {
+			$filename = sprintf("/sys/block/%s/device/vendor",
+				$this->getDeviceName(TRUE));
+			if (file_exists($filename))
+				return trim(file_get_contents($filename));
+			return "";
+		}
+		$property = $this->getUdevProperty("ID_VENDOR");
+		return str_replace("_", " ", $property);
 	}
 
 	/**


### PR DESCRIPTION
Use udev over /sys to get model and vendor information 

Use udev over /sys to get model and vendor information as user can't update bad or incorrect information in /sys. Fallback to use /sys if udev fields ID_MODEL or ID_VENDOR is not populated.

Fixes #783

Signed-off-by: John Jore <jj@royal.net>