### PR TITLE
Update storagedevicesg.inc

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevicesg.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevicesg.inc
@@ -100,11 +100,15 @@ class StorageDeviceSG implements SmartInterface {
 	 * @return The device model, otherwise an empty string.
 	 */
 	public function getModel() {
-		$filename = sprintf("/sys/class/scsi_generic/%s/device/model",
-		  $this->getDeviceName());
-		if (file_exists($filename))
-			return trim(file_get_contents($filename));
-		return "";
+		if (FALSE === $this->hasUdevProperty("ID_MODEL")) {
+			$filename = sprintf("/sys/class/scsi_generic/%s/device/model",
+				$this->getDeviceName());
+			if (file_exists($filename))
+				return trim(file_get_contents($filename));
+			return "";
+		}
+		$property = $this->getUdevProperty("ID_MODEL");
+		return str_replace("_", " ", $property); 		
 	}
 
 	/**
@@ -112,11 +116,15 @@ class StorageDeviceSG implements SmartInterface {
 	 * @return The device vendor, otherwise an empty string.
 	 */
 	public function getVendor() {
-		$filename = sprintf("/sys/class/scsi_generic/%s/device/vendor",
-		  $this->getDeviceName());
-		if (file_exists($filename))
-			return trim(file_get_contents($filename));
-		return "";
+		if (FALSE === $this->hasUdevProperty("ID_VENDOR")) {		
+			$filename = sprintf("/sys/class/scsi_generic/%s/device/vendor",
+		  		$this->getDeviceName());
+			if (file_exists($filename))
+				return trim(file_get_contents($filename));
+			return "";
+		}
+		$property = $this->getUdevProperty("ID_VENDOR");
+		return str_replace("_", " ", $property);
 	}
 
 	/**


### PR DESCRIPTION
Use udev over /sys to get model and vendor information

Use udev over /sys to get model and vendor information as user can't update bad or incorrect information in /sys. Fallback to use /sys if udev fields ID_MODEL or ID_VENDOR is not populated.

Signed-off-by: John Jore <jj@royal.net>
