### PR TITLE
Remove unnecessary line break in CPU usage legend

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/mkrrdgraph/plugins.d/cpu.py
+++ b/deb/openmediavault/usr/share/openmediavault/mkrrdgraph/plugins.d/cpu.py
@@ -63,9 +63,10 @@ class Plugin(openmediavault.mkrrdgraph.IPlugin):
         args.append('AREA:waitio{color_cpu_waitio}:"Wait-IO":STACK'.format(**config))
         args.append('AREA:nice{color_cpu_nice}:"Nice":STACK'.format(**config))
         args.append('AREA:user{color_cpu_user}:"User":STACK'.format(**config))
-        args.append('AREA:softirq{color_cpu_softirq}:"Soft-IRQ\c":STACK'.format(**config))
+        args.append('AREA:softirq{color_cpu_softirq}:"Soft-IRQ":STACK'.format(**config))
         args.append('AREA:interrupt{color_cpu_irq}:"IRQ":STACK'.format(**config))
-        args.append('AREA:idle{color_cpu_idle}:"Idle\c":STACK'.format(**config))
+        args.append('AREA:idle{color_cpu_idle}:"Idle":STACK'.format(**config))
+        args.append('COMMENT:"\c"')
         args.append('COMMENT:"{last_update}"'.format(**config))
         # yapf: enable
         openmediavault.mkrrdgraph.call_rrdtool_graph(args)


### PR DESCRIPTION
When using OMV_COLLECTD_RRDTOOL_GRAPH_WIDTH to make graph wider CPU legend was still split into two lines even when there was enough space for one line

Before (width 800 and 200):
![image](https://user-images.githubusercontent.com/18705953/92305265-fa76cd00-ef85-11ea-8cc3-6e156dbc7bc1.png)
![image](https://user-images.githubusercontent.com/18705953/92305229-b257aa80-ef85-11ea-9d58-5d4a4451a239.png)

After (width 800 and 200):
![image](https://user-images.githubusercontent.com/18705953/92305206-69075b00-ef85-11ea-8b56-51ee1c2d3bc2.png)
![image](https://user-images.githubusercontent.com/18705953/92305214-8e946480-ef85-11ea-9a85-c37a608362c0.png)

Signed-off-by: sebeksd <18705953+sebeksd@users.noreply.github.com>