### PR TITLE
Update 99-openmediavault-dev-disk-by-id.rules

### DIFF
--- a/deb/openmediavault/etc/udev/rules.d/99-openmediavault-dev-disk-by-id.rules
+++ b/deb/openmediavault/etc/udev/rules.d/99-openmediavault-dev-disk-by-id.rules
@@ -31,7 +31,9 @@ ACTION=="add", KERNEL=="sd*", SUBSYSTEMS=="usb", \
   ENV{ID_VENDOR}=="JMicron", \
   PROGRAM="/usr/lib/udev/serial_id %N", \
   ENV{ID_SERIAL}="USB-%c-$env{ID_INSTANCE}", \
-  ENV{ID_SERIAL_SHORT}="%c"
+  ENV{ID_SERIAL_SHORT}="%c", \
+  SYMLINK="disk/by-path/$env{ID_PATH}", \
+  SYMLINK+="disk/by-id/$env{ID_BUS}-$env{ID_SERIAL}"
 
 # JMicron JMS561U two ports SATA 6Gb/s bridge
 # https://www.sabrent.com/product/EC-DFLT/usb-3-0-sata-external-hard-drive-lay-flat-docking-station-2-5-3-5in-hdd-ssd/


### PR DESCRIPTION
Hi,

I had the same problem described in https://github.com/openmediavault/openmediavault/issues/665. Because the USB device reported the same serial for two different USB hard drives the link under /dev/disks/by-id got overwritten by whichever drive was added last. In the front under Disks or SMART only one of the two drives was listed.

The already existing fix in /etc/udev/rules.d/99-openmediavault-dev-disk-by-id.rules does indeed correct the ID_SERIAL* env variables, but it will not fix the symlink and therefore the front end will only show one of the drives despite that rule.

I added the two SYMLINK lines. At first I added twice (used += instead of = twice). This, however, created a third symlink in .../by-id/. Two symlinks had the fixed ID_SERIAL and the third was the "old", faulty symlink. For reasons unclear to me it is that faulty symlink that gets picked up by openmediavault as the devicefile and while the command "omv-rpc DiskMgmt enumerateDevices" enumerates both drives correctly, the front end will still only show one drive (I assume that the front end does its own filtering based on the devicefile property).

So I ended up with the solution provided here: first overwrite any existing SYMLINKs and add the by-path and the fixed by-id symlinks.

However, I have a hunch that a better solution would be to rename the rules files to something < 60-...rules instead of 99-...rules. The file which creates the faulty symlink is /lib/udev/rules.d/60-persistent-storage.rules. If the ID_SERIAL field is fixed before that rules file is parsed the extra SMYLINK magic would not be required. Yet I cannot recommend this course of action as my knowledge of udev is very limited and I do not know what other unforeseen consequences this might have.

Cheers
-- Hannes


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
