### PR TITLE
Use PHP_EOL to separate email headers.

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/email.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/email.inc
@@ -64,7 +64,7 @@ class Email {
 		if (!empty($this->from))
 			$headers[] = sprintf('From: %s', $this->from);
 		return mail($this->to, $this->subject, $this->message,
-		  implode("\r\n", $headers));
+			implode(PHP_EOL, $headers));
 	}
 
 	/**


### PR DESCRIPTION
According to

* https://richardwarrender.com/2007/09/problem-with-php-mail-and-additional-headers/
* https://serverfault.com/questions/325506/php-mail-headers-not-working-properly-with-postfix

it is better to use PHP_EOL ('\n' on Linux) to separate headers.

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
