### PR TITLE
Rename UDEV rules file

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,9 @@
 openmediavault (5.5.13-1) stable; urgency=low
 
   * Fix bug in quota deployment on XFS filesystems.
+  * Rename UDEV rules file 99-openmediavault-dev-disk-by-id.rules to
+    01-openmediavault-fix-serial.rules. It is used to fix the serial
+    number problem of some USB PATA/SATA bridge controllers.
   * Issue #829: Show the listing of directory entries to which the
     anonymous user normally has no access permissions.
 

--- a/deb/openmediavault/etc/udev/rules.d/01-openmediavault-fix-serial.rules
+++ b/deb/openmediavault/etc/udev/rules.d/01-openmediavault-fix-serial.rules
@@ -40,9 +40,7 @@ ACTION=="add", KERNEL=="sd*", SUBSYSTEM=="block", \
   PROGRAM="/usr/lib/udev/serial_id %N", \
   ENV{ID_SERIAL}="$env{ID_VENDOR}_$env{ID_MODEL}_$env{ID_SERIAL_SHORT}-$env{ID_INSTANCE}", \
   ENV{ID_SERIAL_SHORT}="%c", \
-  ENV{ID_SERIAL}="$env{ID_VENDOR}_$env{ID_MODEL}_%c-$env{ID_INSTANCE}" \
-  SYMLINK="disk/by-path/$env{ID_PATH}", \
-  SYMLINK+="disk/by-id/$env{ID_BUS}-$env{ID_SERIAL}"
+  ENV{ID_SERIAL}="$env{ID_VENDOR}_$env{ID_MODEL}_%c-$env{ID_INSTANCE}"
 
 # JMicron JM20337 USB PATA/SATA bridge on Orangepi PC2
 ACTION=="add", KERNEL=="sd*", SUBSYSTEMS=="usb", \
@@ -57,9 +55,7 @@ ACTION=="add", KERNEL=="sd*", SUBSYSTEM=="block", \
   ATTRS{idVendor}=="0080", ATTRS{idProduct}=="a001", \
   PROGRAM="/usr/lib/udev/serial_id %N", \
   ENV{ID_SERIAL}="$env{ID_VENDOR}_$env{ID_MODEL}_%c-$env{ID_INSTANCE}", \
-  ENV{ID_SERIAL_SHORT}="%c", \
-  SYMLINK="disk/by-path/$env{ID_PATH}", \
-  SYMLINK+="disk/by-id/$env{ID_BUS}-$env{ID_SERIAL}"
+  ENV{ID_SERIAL_SHORT}="%c"
 
 # ORICO 3.5 inch 5 Bay Magnetic-type USB3.0 Hard Drive Enclosure (DS500U3)
 # http://my.orico.cc/goods.php?id=6659
@@ -103,9 +99,7 @@ ACTION=="add", KERNEL=="sd*", SUBSYSTEM=="block", \
   ENV{ID_VENDOR}=="External", ENV{ID_MODEL}=="USB3.0_DISK00", \
   PROGRAM="/usr/lib/udev/serial_id %N", \
   ENV{ID_SERIAL}="$env{ID_VENDOR}_$env{ID_MODEL}_%c-$env{ID_INSTANCE}", \
-  ENV{ID_SERIAL_SHORT}="%c", \
-  SYMLINK="disk/by-path/$env{ID_PATH}", \
-  SYMLINK+="disk/by-id/$env{ID_BUS}-$env{ID_SERIAL}"
+  ENV{ID_SERIAL_SHORT}="%c"
 
 # QUAD SATA HAT KIT for your Raspberry Pi 4
 # https://shop.allnetchina.cn/products/quad-sata-hat-case-for-raspberry-pi-4?_pos=4&_sid=8298cd20c&_ss=r
@@ -154,9 +148,7 @@ ACTION=="add", KERNEL=="sd*", SUBSYSTEM=="block", \
   ENV{ID_VENDOR}=="ACASIS", ENV{ID_MODEL}=="Go_To_Final_Lap", \
   PROGRAM="/usr/lib/udev/serial_id %N", \
   ENV{ID_SERIAL}="$env{ID_VENDOR}_$env{ID_MODEL}_%c-$env{ID_INSTANCE}", \
-  ENV{ID_SERIAL_SHORT}="%c", \
-  SYMLINK="disk/by-path/$env{ID_PATH}", \
-  SYMLINK+="disk/by-id/$env{ID_BUS}-$env{ID_SERIAL}"
+  ENV{ID_SERIAL_SHORT}="%c"
 
 # VL817 SATA Adaptor
 # https://devicehunt.com/view/type/usb/vendor/2109/device/0715
@@ -200,6 +192,4 @@ ACTION=="add", KERNEL=="sd*", SUBSYSTEM=="block", \
   ENV{ID_VENDOR_ID}=="2109", ENV{ID_MODEL_ID}=="0715", \
   PROGRAM="/usr/lib/udev/serial_id %N", \
   ENV{ID_SERIAL}="$env{ID_VENDOR}_$env{ID_MODEL}_%c-$env{ID_INSTANCE}", \
-  ENV{ID_SERIAL_SHORT}="%c", \
-  SYMLINK="disk/by-path/$env{ID_PATH}", \
-  SYMLINK+="disk/by-id/$env{ID_BUS}-$env{ID_SERIAL}"
+  ENV{ID_SERIAL_SHORT}="%c"


### PR DESCRIPTION
Rename UDEV rules file `99-openmediavault-dev-disk-by-id.rules` to `01-openmediavault-fix-serial.rules`. It is used to fix the serial number problem of some USB PATA/SATA bridge controllers.

The new filename should ensure that the file is processed before `/lib/udev/rules.d/60-persistent-storage.rules`. This way the SYMLINK magic is done by this rules instead of overriding the SYMLINKS ourself.

Signed-off-by: Volker Theile <votdev@gmx.de>

<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
