### PR TITLE
Whenever percent progress is refreshed split it into new line

### DIFF
--- a/deb/openmediavault/var/www/openmediavault/js/omv/window/Execute.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/window/Execute.js
@@ -281,7 +281,7 @@ Ext.define("OMV.window.Execute", {
 						  if ((false === this.progress) && (0 < response.pos))
 							  this.setLoading(false);
 						  // Update the command content.
-						  this.appendValue(response.output);
+						  this.appendValue(response.output.replaceAll("\r\n", "\n").replaceAll('\r', '\n'));
 						  // Update button states.
 						  if (true === this.adaptButtonState) {
 							  this.setButtonDisabled("start",


### PR DESCRIPTION
WebGUI multiline progress

Window is unable to refresh progress in single line (probably by design) but adding every new "refresh" at the end makes text hard to read,
spliting it into new lines makes it readable again and allow for "full command history" like before

Signed-off-by: sebeksd 18705953+sebeksd@users.noreply.github.com

![image](https://user-images.githubusercontent.com/18705953/97081631-f66d4000-1603-11eb-96eb-3df431e1da48.png)
