### PR TITLE
update nut path for latest package

### DIFF
--- a/deb/openmediavault-nut/srv/salt/omv/deploy/monit/services/files/nut.j2
+++ b/deb/openmediavault-nut/srv/salt/omv/deploy/monit/services/files/nut.j2
@@ -18,8 +18,8 @@ check process nut-monitor with matching upsmon
 {%- endif %}
 
 {%- if nut_config.mode != 'netclient' %}
-check program nut-upsc-{{ nut_config.upsname }} with path "/usr/bin/upsc {{ nut_config.upsname }}"
+check program nut-upsc-{{ nut_config.upsname }} with path "/bin/upsc {{ nut_config.upsname }}"
     group nut
-    start program = "/usr/sbin/upsdrvctl start"
+    start program = "/sbin/upsdrvctl start"
     if status != 0 for 2 cycles then restart
 {%- endif %}


### PR DESCRIPTION
The path to executables in Debian `nut-client_2.7.4-8_amd64.deb` and in Ubuntu `nut-client_2.7.4-9ubuntu1_amd64.deb` is different than is expected in this template.

Fixes [https://forum.openmediavault.org/index.php?thread/33333-omv5-nut-plugin-cannot-be-enabled-in-webui/&postID=254283#post254283]

