### PR TITLE
Enhance filesystem classes to support /dev/disk/by-uuid

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,5 +1,8 @@
 openmediavault (5.5.20-1) stable; urgency=low
 
+  * Improved PHP and Python block device and filesystem implementation.
+    Re-add usage of /dev/disk/by-uuid device files for all filesystems
+    (except BTRFS) to workaround problems with JMicron based USB enclosures.
   * Issue #894: Disabled cron jobs are still executed.
   * Issue #896: Improve UDEV rule to fix issues with JMS567 SATA 6Gb/s
     bridge based USB enclosures.

--- a/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/__init__.py
+++ b/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/__init__.py
@@ -20,7 +20,7 @@
 # along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
 __all__ = ["bool", "getenv", "setenv"]
 
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 import openmediavault.settings
 import openmediavault.util

--- a/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/device/block.py
+++ b/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/device/block.py
@@ -20,6 +20,7 @@
 # along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
 import os
 import re
+from typing import Any, Dict, List, Optional
 
 import openmediavault.subprocess
 import pyudev
@@ -29,6 +30,21 @@ from .utils import (is_block_device, is_device_file_by_id,
 
 
 class BlockDevice:
+    """
+    This class is a wrapper for block devices.
+    """
+
+    @classmethod
+    def list_devices(cls) -> List[str]:
+        """
+        Get a list of device files of all block devices, e.g.
+        ['/dev/sdb', '/dev/sdb1', '/dev/vda', '/dev/vda1']
+        :return: Returns a list of device files of all block devices.
+        """
+        context = pyudev.Context()
+        return [device.device_node for device in context.list_devices(
+            subsystem='block')]
+
     def __init__(self, device_file):
         self._device_file = device_file
 
@@ -37,7 +53,7 @@ class BlockDevice:
         return self._device_file
 
     @property
-    def canonical_device_file(self):
+    def canonical_device_file(self) -> str:
         """
         Get the canonical device file, e.g.
 
@@ -51,11 +67,11 @@ class BlockDevice:
         return os.path.realpath(self.device_file)
 
     @property
-    def exists(self):
+    def exists(self) -> bool:
         return is_block_device(self.device_file)
 
     @property
-    def device_links(self):
+    def device_links(self) -> List[str]:
         """
         Get all device file symlinks, e.g.
 
@@ -74,7 +90,7 @@ class BlockDevice:
         return [device_link for device_link in device.device_links]
 
     @property
-    def predictable_device_file(self):
+    def predictable_device_file(self) -> str:
         """
         Get a predictable device file in the following order:
 
@@ -87,21 +103,21 @@ class BlockDevice:
         """
         if self.has_device_file_by_id():
             return self.device_file_by_id
-        if self.has_device_file_by_path():
+        elif self.has_device_file_by_path():
             return self.device_file_by_path
         return self.canonical_device_file
 
-    def has_device_file_by_id(self):
+    def has_device_file_by_id(self) -> bool:
         """
         Check whether the device has a /dev/disk/by-id/xxx device path.
-        :return: Returns TRUE if a disk/by-id device path exists,
-            otherwise FALSE.
+        :return: Returns `True` if a disk/by-id device path exists,
+            otherwise `False`.
         :rtype: bool
         """
         return is_device_file_by_id(self.device_file_by_id)
 
     @property
-    def device_file_by_id(self):
+    def device_file_by_id(self) -> Optional[str]:
         """
         Get the device file, e.g.
 
@@ -110,25 +126,25 @@ class BlockDevice:
         * /dev/disk/by-id/ata-Hitachi_HDT725032VLA360_VFD200R2CWB7ML-part2
 
         :return: Returns the device file (/dev/disk/by-id/xxx) if available,
-            otherwise None.
-        :rtype: str|None
+            otherwise `None`.
+        :rtype: str | None
         """
         for device_link in self.device_links:
             if is_device_file_by_id(device_link):
                 return device_link
         return None
 
-    def has_device_file_by_path(self):
+    def has_device_file_by_path(self) -> bool:
         """
         Check whether the device has a /dev/disk/by-path/xxx device path.
-        :return: Returns TRUE if a disk/by-path device path exists,
-            otherwise FALSE.
+        :return: Returns `True` if a disk/by-path device path exists,
+            otherwise `False`.
         :rtype: bool
         """
         return is_device_file_by_path(self.device_file_by_path)
 
     @property
-    def device_file_by_path(self):
+    def device_file_by_path(self) -> Optional[str]:
         """
         Get the device file, e.g.
 
@@ -137,25 +153,25 @@ class BlockDevice:
         * /dev/disk/by-path/pci-0000:00:10.0-scsi-0:0:1:0-part1
 
         :return: Returns the device file (/dev/disk/by-path/xxx) if available,
-            otherwise None.
-        :rtype: str|None
+            otherwise `None`.
+        :rtype: str | None
         """
         for device_link in self.device_links:
             if is_device_file_by_path(device_link):
                 return device_link
         return None
 
-    def has_device_file_by_uuid(self):
+    def has_device_file_by_uuid(self) -> bool:
         """
         Check whether the device has a /dev/disk/by-uuid/xxx device path.
-        :return: Returns TRUE if a disk/by-uuid device path exists,
-            otherwise FALSE.
+        :return: Returns `True` if a disk/by-uuid device path exists,
+            otherwise `False`.
         :rtype: bool
         """
         return is_device_file_by_uuid(self.device_file_by_uuid)
 
     @property
-    def device_file_by_uuid(self):
+    def device_file_by_uuid(self) -> Optional[str]:
         """
         Get the device file, e.g.
 
@@ -164,19 +180,19 @@ class BlockDevice:
         * /dev/disk/by-uuid/7A48-BA97 (FAT)
 
         :return: Returns the device file (/dev/disk/by-uuid/xxx) if available,
-            otherwise None.
-        :rtype: str|None
+            otherwise `None`.
+        :rtype: str | None
         """
         for device_link in self.device_links:
             if is_device_file_by_uuid(device_link):
                 return device_link
         return None
 
-    def device_name(self, canonical=False):
+    def device_name(self, canonical=False) -> str:
         """
         Get the device name, e.g. sda or hdb.
         :param canonical: If set to True the canonical device file will
-            be used. Defaults to False.
+            be used. Defaults to `False`.
         :type canonical: bool
         :return: The device name.
         :rtype: str
@@ -188,7 +204,7 @@ class BlockDevice:
         )
 
     @property
-    def device_number(self):
+    def device_number(self) -> int:
         """
         The device number of the associated device as integer.
         See `<https://www.kernel.org/doc/Documentation/devices.txt> for more information`_.
@@ -199,7 +215,7 @@ class BlockDevice:
         return device.device_number
 
     @property
-    def major_device_number(self):
+    def major_device_number(self) -> int:
         """
         Get the major device number.
         See `<https://www.kernel.org/doc/Documentation/devices.txt> for more information`_.
@@ -209,7 +225,7 @@ class BlockDevice:
         return os.major(self.device_number)
 
     @property
-    def minor_device_number(self):
+    def minor_device_number(self) -> int:
         """
         Get the minor device number.
         See `<https://www.kernel.org/doc/Documentation/devices.txt> for more information`_.
@@ -218,7 +234,7 @@ class BlockDevice:
         """
         return os.minor(self.device_number)
 
-    def block_size(self):
+    def block_size(self) -> int:
         """
         Get the block size.
         :return: Returns the block size.
@@ -229,7 +245,7 @@ class BlockDevice:
         )
         return int(output.decode().strip())
 
-    def size(self):
+    def size(self) -> int:
         """
         Get the device size in bytes.
         :return: Returns the device size in bytes.
@@ -241,7 +257,7 @@ class BlockDevice:
         return int(output.decode().strip())
 
     @property
-    def udev_properties(self):
+    def udev_properties(self) -> Dict:
         """
         Get the udev properties.
 
@@ -301,25 +317,25 @@ class BlockDevice:
             result[name] = device.properties[name]
         return result
 
-    def has_udev_property(self, name):
+    def has_udev_property(self, name) -> bool:
         """
         Checks if a udev property exists.
         :param name: The name of the property, e.g. ID_VENDOR, ID_MODEL
             or ID_SERIAL_SHORT.
         :type name: str
-        :return: Returns True if the property exists, otherwise False.
+        :return: Returns `True` if the property exists, otherwise `False`.
         :rtype: bool
         """
         return name in self.udev_properties
 
-    def udev_property(self, name, default=None):
+    def udev_property(self, name, default=None) -> Any:
         """
         Get the specified udev property.
         :param name: The name of the property, e.g. ID_VENDOR, ID_MODEL
             or ID_SERIAL_SHORT.
         :type name: str
         :param default: The default value if the property does not exist.
-            Defaults to None.
+            Defaults to `None`.
         :type default: str
         :return: Returns the requested property.
         :rtype: str

--- a/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/device/plugins/dm.py
+++ b/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/device/plugins/dm.py
@@ -62,7 +62,7 @@ class StorageDevice(openmediavault.device.StorageDevice):
         'dmraid', 'mpath', 'part', ...
         :return: Returns the device mapper subsystem or ``None``
             on failure.
-        :rtype: str|None
+        :rtype: str | None
         """
         # The DM_UUID prefix should be set to subsystem owning the device:
         # LVM, CRYPT, DMRAID, MPATH, PART

--- a/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/device/plugins/sg.py
+++ b/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/device/plugins/sg.py
@@ -56,7 +56,7 @@ class StorageDevice(openmediavault.device.StorageDevice):
         @see http://www.tldp.org/HOWTO/SCSI-Generic-HOWTO/proc.html
         :return: Returns the SCSI type, e.g. 0->disk, 5->cdrom, 6->scanner,
             otherwise ``False``.
-        :rtype: int|None
+        :rtype: int | None
         """
         file = '/sys/class/scsi_generic/{}/device/type'.format(
             self.device_name(True)

--- a/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/device/storage.py
+++ b/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/device/storage.py
@@ -23,16 +23,33 @@ import importlib
 import os
 import pkgutil
 import re
+from typing import List, Optional
 
 import openmediavault.string
+import pyudev
 from cached_property import cached_property
 
 from .block import BlockDevice
 
 
 class StorageDevice(BlockDevice):
+    """
+    This class is a wrapper for storage/disk devices.
+    """
+
+    @classmethod
+    def list_devices(cls) -> List[str]:
+        """
+        Get a list of device files of all disk devices, e.g.
+        ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/vda']
+        :return: Returns a list of device files of all disk devices.
+        """
+        context = pyudev.Context()
+        return [device.device_node for device in context.list_devices(
+            subsystem='block', DEVTYPE='disk')]
+
     @property
-    def parent(self):
+    def parent(self) -> Optional['StorageDevice']:
         """
         Create a new instance from the parent device file.
         Examples:
@@ -51,7 +68,7 @@ class StorageDevice(BlockDevice):
         return None
 
     @property
-    def description(self):
+    def description(self) -> str:
         """
         Get the description of the device.
         :return: The device description.
@@ -60,7 +77,7 @@ class StorageDevice(BlockDevice):
         return ''
 
     @property
-    def model(self):
+    def model(self) -> str:
         """
         Get the device model.
         :return: The device model, otherwise an empty string.
@@ -71,7 +88,7 @@ class StorageDevice(BlockDevice):
         )
 
     @property
-    def vendor(self):
+    def vendor(self) -> str:
         """
         Get the device vendor.
         :return: The device vendor, otherwise an empty string.
@@ -82,7 +99,7 @@ class StorageDevice(BlockDevice):
         )
 
     @property
-    def serial(self):
+    def serial(self) -> str:
         """
         Get the device serial number.
         :return: The device serial number, otherwise an empty string.
@@ -92,7 +109,7 @@ class StorageDevice(BlockDevice):
         return serial.replace('_', ' ')
 
     @property
-    def is_rotational(self):
+    def is_rotational(self) -> bool:
         """
         Check if the device is of rotational or non-rotational type.
         See https://www.kernel.org/doc/Documentation/block/queue-sysfs.txt
@@ -120,7 +137,7 @@ class StorageDevice(BlockDevice):
         return 'SSD' not in self.model
 
     @property
-    def is_removable(self):
+    def is_removable(self) -> bool:
         """
         Check if the device is removable.
         :return: Returns ``True`` if the device is removable,
@@ -136,7 +153,7 @@ class StorageDevice(BlockDevice):
         return False
 
     @property
-    def is_usb(self):
+    def is_usb(self) -> bool:
         """
         Check if the given device is an USB device.
         :return: Returns ``True`` if the device is connected via USB,
@@ -162,7 +179,7 @@ class StorageDevice(BlockDevice):
         return False
 
     @property
-    def is_read_only(self):
+    def is_read_only(self) -> bool:
         """
         Check if the given device is read-only.
         :return: Returns ``True`` if the device is read-only,
@@ -172,7 +189,7 @@ class StorageDevice(BlockDevice):
         return False
 
     @property
-    def is_media_available(self):
+    def is_media_available(self) -> bool:
         """
         Check if a medium is available.
         :return: Returns ``True`` if the medium is available,
@@ -182,7 +199,7 @@ class StorageDevice(BlockDevice):
         return True
 
     @property
-    def is_raid(self):
+    def is_raid(self) -> bool:
         """
         Check if the given device is a hardware/software RAID device.
         :return: Returns ``True`` if the device is a hardware/software
@@ -192,7 +209,7 @@ class StorageDevice(BlockDevice):
         return False
 
     @property
-    def has_smart_support(self):
+    def has_smart_support(self) -> bool:
         """
         Check if the given device has S.M.A.R.T. support.
         :return: Returns ``True`` if the device supports S.M.A.R.T.,
@@ -202,7 +219,7 @@ class StorageDevice(BlockDevice):
         return True
 
     @property
-    def smart_device_type(self):
+    def smart_device_type(self) -> str:
         """
         Identify the device type required by the smartctl utility
         program.
@@ -222,7 +239,7 @@ class StorageDevice(BlockDevice):
         )
 
     @classmethod
-    def from_device_file(cls, device_file):
+    def from_device_file(cls, device_file) -> 'StorageDevice':
         """
         Create a new instance from the given device file.
         :param device_file: The canonical path of a device file.
@@ -255,7 +272,7 @@ class StorageDevice(BlockDevice):
         return StorageDevice(device_file)
 
     @cached_property
-    def host_driver(self):
+    def host_driver(self) -> Optional[str]:
         """
         Get the driver name of the host device this storage device is
         connected to, e.g. 'hpsa', 'arcmsr' or 'ahci'.
@@ -291,7 +308,7 @@ class StorageDevice(BlockDevice):
 
 class IStorageDevicePlugin(abc.ABC):
     @abc.abstractmethod
-    def match(self, device_file):
+    def match(self, device_file) -> bool:
         """
         Check whether the given device is implemented by
         this class.
@@ -305,7 +322,7 @@ class IStorageDevicePlugin(abc.ABC):
         """
 
     @abc.abstractmethod
-    def from_device_file(self, device_file):
+    def from_device_file(self, device_file) -> 'StorageDevice':
         """
         Create a new instance from the given device file.
         :param device_file: The path of a device file, e.g.

--- a/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/device/utils.py
+++ b/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/device/utils.py
@@ -23,7 +23,7 @@ import re
 import stat
 
 
-def is_block_device(path):
+def is_block_device(path) -> bool:
     """
     Check if path is a block device, e.g. /dev/sda1.
     :param path: The path to check.
@@ -41,7 +41,7 @@ def is_block_device(path):
     return stat.S_ISBLK(st.st_mode)
 
 
-def is_char_device(path):
+def is_char_device(path) -> bool:
     """
     Check if path is a character device, e.g. /dev/sg0.
     :param path: The path to check.
@@ -59,7 +59,7 @@ def is_char_device(path):
     return stat.S_ISCHR(st.st_mode)
 
 
-def is_device_file(path):
+def is_device_file(path) -> bool:
     """
     Check if path describes a device file, e.g. /dev/sda1.
     :param path: The path to check.
@@ -73,7 +73,7 @@ def is_device_file(path):
     return True if re.match(r'^/dev/.+$', path) else False
 
 
-def is_device_file_by(path):
+def is_device_file_by(path) -> bool:
     """
     Check if path describes a device file, e.g.
 
@@ -92,7 +92,7 @@ def is_device_file_by(path):
     return True if re.match(r'^/dev/disk/by-\S+/.+$', path) else False
 
 
-def is_device_file_by_uuid(path):
+def is_device_file_by_uuid(path) -> bool:
     """
     Check if path describes a device file, e.g.
 
@@ -110,7 +110,7 @@ def is_device_file_by_uuid(path):
     return True if re.match(r'^/dev/disk/by-uuid/.+$', path) else False
 
 
-def is_device_file_by_id(path):
+def is_device_file_by_id(path) -> bool:
     """
     Check if path describes a device file, e.g.
 
@@ -128,7 +128,7 @@ def is_device_file_by_id(path):
     return True if re.match(r'^/dev/disk/by-id/.+$', path) else False
 
 
-def is_device_file_by_label(path):
+def is_device_file_by_label(path) -> bool:
     """
     Check if path describes a device file, e.g. /dev/disk/by-label/data
     :param path: The path to check.
@@ -142,7 +142,7 @@ def is_device_file_by_label(path):
     return True if re.match(r'^/dev/disk/by-label/.+$', path) else False
 
 
-def is_device_file_by_path(path):
+def is_device_file_by_path(path) -> bool:
     """
     Check if path describes a device file, e.g.
 

--- a/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/fs/__init__.py
+++ b/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/fs/__init__.py
@@ -20,16 +20,18 @@
 # along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
 import os
 import subprocess
+from typing import List, Optional
 
 import openmediavault.device
 import openmediavault.string
 import openmediavault.subprocess
 import pyudev
+from openmediavault.device import is_device_file_by_label
 
 import openmediavault
 
 
-def make_mount_path(id_):
+def make_mount_path(id_) -> str:
     """
     Build the mount path from any given string, device file or
     file system UUID.
@@ -49,30 +51,23 @@ def make_mount_path(id_):
 
 
 class Filesystem(openmediavault.device.BlockDevice):
-    def __init__(self, id_):
-        """
-        :param id_: The filesystem UUID or device file, e.g.
-
-        * 78b669c1-9183-4ca3-a32c-80a4e2c61e2d (EXT2/3/4, JFS, XFS)
-        * 7A48-BA97 (FAT)
-        * 2ED43920D438EC29 (NTFS)
-        * /dev/sde1
-        * /dev/disk/by-id/scsi-SATA_ST3200XXXX2AS_5XWXXXR6-part1
-        * /dev/disk/by-label/DATA
-        * /dev/disk/by-label/My\x20Passport\x20Blue
-        * /dev/disk/by-path/pci-0000:00:10.0-scsi-0:0:0:0-part2
-        * /dev/disk/by-uuid/ad3ee177-777c-4ad3-8353-9562f85c0895
-        * /dev/cciss/c0d0p2
-        * /dev/disk/by-id/md-name-vmpc01:data
-        * /dev/disk/by-id/md-uuid-75de9de9:6beca92e:8442575c:73eabbc9
-
-        :type id_: str
-        """
-        self._id = id_
-        super().__init__(None)
+    """
+    This class is a wrapper for filesystem devices.
+    """
 
     @classmethod
-    def from_mount_point(cls, path):
+    def list_devices(cls) -> List[str]:
+        """
+        Get a list of device files of all filesystem, e.g.
+        ['/dev/sdb1', '/dev/sdc1', '/dev/vda1']
+        :return: Returns a list of device files of all filesystems.
+        """
+        context = pyudev.Context()
+        return [device.device_node for device in context.list_devices(
+            subsystem='block', DEVTYPE='partition')]
+
+    @classmethod
+    def from_mount_point(cls, path: str) -> 'Filesystem':
         """
         Create a new :class:`Filesystem` object for the specified mount
         point.
@@ -119,6 +114,28 @@ class Filesystem(openmediavault.device.BlockDevice):
             device_file = output.decode().strip()
         return Filesystem(device_file)
 
+    def __init__(self, id_: str):
+        """
+        :param id_: The filesystem UUID or device file, e.g.
+
+        * 78b669c1-9183-4ca3-a32c-80a4e2c61e2d (EXT2/3/4, JFS, XFS)
+        * 7A48-BA97 (FAT)
+        * 2ED43920D438EC29 (NTFS)
+        * /dev/sde1
+        * /dev/disk/by-id/scsi-SATA_ST3200XXXX2AS_5XWXXXR6-part1
+        * /dev/disk/by-label/DATA
+        * /dev/disk/by-label/My\x20Passport\x20Blue
+        * /dev/disk/by-path/pci-0000:00:10.0-scsi-0:0:0:0-part2
+        * /dev/disk/by-uuid/ad3ee177-777c-4ad3-8353-9562f85c0895
+        * /dev/cciss/c0d0p2
+        * /dev/disk/by-id/md-name-vmpc01:data
+        * /dev/disk/by-id/md-uuid-75de9de9:6beca92e:8442575c:73eabbc9
+
+        :type id_: str
+        """
+        self._id = id_
+        super().__init__(None)
+
     @property
     def device_file(self):
         if self._device_file is None:
@@ -134,8 +151,58 @@ class Filesystem(openmediavault.device.BlockDevice):
                 self._device_file = self._id
         return super().device_file
 
+    def has_device_file_by_label(self) -> bool:
+        """
+        Check whether the device has a /dev/disk/by-label/xxx device path.
+        :return: Returns `True` if a disk/by-label device path exists,
+            otherwise `False`.
+        :rtype: bool
+        """
+        return is_device_file_by_label(self.device_file_by_label)
+
     @property
-    def uuid(self):
+    def device_file_by_label(self) -> Optional[str]:
+        """
+        Get the device file, e.g.
+
+        * /dev/disk/by-label/DATA
+        * /dev/disk/by-label/My\x20Passport\x20Blue
+
+        :return: Returns the escaped device file if available,
+            otherwise `None`.
+        :rtype: str | None
+        """
+        for device_link in self.device_links:
+            if is_device_file_by_label(device_link):
+                return device_link
+        return None
+
+    @property
+    def predictable_device_file(self) -> str:
+        """
+        Get a predictable device file in the following order:
+
+        * /dev/disk/by-uuid/xxx
+        * /dev/disk/by-label/xxx
+        * /dev/disk/by-id/xxx
+        * /dev/disk/by-path/xxx
+        * /dev/xxx
+
+        :return: Returns a device file.
+        :rtype: str
+        """
+        if self.has_device_file_by_uuid():
+            return self.device_file_by_uuid
+        elif self.has_device_file_by_label():
+            return self.device_file_by_label
+        elif self.has_device_file_by_id():
+            return self.device_file_by_id
+        elif self.has_device_file_by_path():
+            return self.device_file_by_path
+        return self.canonical_device_file
+
+    @property
+    def uuid(self) -> str:
         """
         Get the UUID of the filesystem.
         @see http://wiki.ubuntuusers.de/UUID
@@ -148,7 +215,7 @@ class Filesystem(openmediavault.device.BlockDevice):
         return self.udev_property('ID_FS_UUID')
 
     @property
-    def parent_device_file(self):
+    def parent_device_file(self) -> Optional[str]:
         """
         Get the parent device.
 
@@ -159,7 +226,7 @@ class Filesystem(openmediavault.device.BlockDevice):
 
         :return: Returns the device file of the underlying storage device
             or ``None`` in case of an error.
-        :rtype: str|None
+        :rtype: str | None
         """
         try:
             context = pyudev.Context()
@@ -183,7 +250,7 @@ class Filesystem(openmediavault.device.BlockDevice):
         # /dev/sdb => /dev/sdb
         return sd.device_file
 
-    def has_label(self):
+    def has_label(self) -> bool:
         """
         Check if the filesystem has a label.
         :return: Returns ``True`` if the filesystem has a label,
@@ -192,7 +259,7 @@ class Filesystem(openmediavault.device.BlockDevice):
         """
         return self.has_udev_property('ID_FS_LABEL_ENC')
 
-    def get_label(self):
+    def get_label(self) -> str:
         """
         Get the filesystem label.
         :return: Returns the label of the filesystem.
@@ -202,7 +269,7 @@ class Filesystem(openmediavault.device.BlockDevice):
             self.udev_property('ID_FS_LABEL_ENC', '')
         )
 
-    def get_type(self):
+    def get_type(self) -> str:
         """
         Get the filesystem type, e.g. 'ext3' or 'vfat'.
         :return: The filesystem type.
@@ -210,20 +277,20 @@ class Filesystem(openmediavault.device.BlockDevice):
         """
         return self.udev_property('ID_FS_TYPE')
 
-    def get_partition_scheme(self):
+    def get_partition_scheme(self) -> Optional[str]:
         """
         Get the partition scheme, e.g. 'gpt', 'mbr', 'apm' or 'dos'.
         :return: Returns the partition scheme, otherwise ``None`` on
             failure or if it does not exist.
-        :rtype: str|None
+        :rtype: str | None
         """
         return self.udev_property('ID_PART_ENTRY_SCHEME', None)
 
-    def get_mount_point(self):
+    def get_mount_point(self) -> Optional[str]:
         """
         Get the mount point of the filesystem.
         :return: The mount point of the filesystem or None.
-        :rtype: str|None
+        :rtype: str | None
         """
         try:
             output = openmediavault.subprocess.check_output(
@@ -246,7 +313,7 @@ class Filesystem(openmediavault.device.BlockDevice):
             pass
         return None
 
-    def is_mounted(self):
+    def is_mounted(self) -> bool:
         """
         Check if a filesystem is mounted.
         """

--- a/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/btrfs.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/btrfs.inc
@@ -83,6 +83,28 @@ class Btrfs extends Filesystem {
 	}
 
 	/**
+	 * Get the device file in the following order:
+	 * <ul>
+	 * \li /dev/disk/by-label/xxx
+	 * \li /dev/disk/by-id/xxx
+	 * \li /dev/disk/by-path/xxx
+	 * \li /dev/xxx
+	 * </ul>
+	 * Note, /dev/disk/by-uuid is not supported by this filesystem
+	 * because of reasons.
+	 * @return Returns a device file.
+	 */
+	public function getPredictableDeviceFile() {
+		if (TRUE === $this->hasDeviceFileByLabel())
+			return $this->getDeviceFileByLabel();
+		else if (TRUE === $this->hasDeviceFileById())
+			return $this->getDeviceFileById();
+		else if (TRUE === $this->hasDeviceFileByPath())
+			return $this->getDeviceFileByPath();
+		return $this->getCanonicalDeviceFile();
+	}
+
+	/**
 	 * See parent class definition.
 	 */
 	public function getDeviceFiles() {

--- a/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/filesystem.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/filesystem.inc
@@ -376,7 +376,8 @@ class Filesystem extends \OMV\System\BlockDevice
 	 * Get the device path by label, e.g. <ul>
 	 * \li /dev/disk/by-label/data
 	 * </ul>
-	 * @return The device path (/dev/disk/by-label/xxx).
+	 * @return Returns the escaped device path, e.g.
+	 *   '/dev/disk/by-label/My\x20Passport\x20Blue'.
 	 */
 	public function getDeviceFileByLabel() {
 		$this->getData();
@@ -442,6 +443,7 @@ class Filesystem extends \OMV\System\BlockDevice
 	/**
 	 * Get the device file in the following order:
 	 * <ul>
+	 * \li /dev/disk/by-uuid/xxx
 	 * \li /dev/disk/by-label/xxx
 	 * \li /dev/disk/by-id/xxx
 	 * \li /dev/disk/by-path/xxx
@@ -450,7 +452,9 @@ class Filesystem extends \OMV\System\BlockDevice
 	 * @return Returns a device file.
 	 */
 	public function getPredictableDeviceFile() {
-		if (TRUE === $this->hasDeviceFileByLabel())
+		if (TRUE === $this->hasDeviceFileByUuid())
+			return $this->getDeviceFileByUuid();
+		else if (TRUE === $this->hasDeviceFileByLabel())
 			return $this->getDeviceFileByLabel();
 		else if (TRUE === $this->hasDeviceFileById())
 			return $this->getDeviceFileById();


### PR DESCRIPTION
Improved PHP and Python block device and filesystem implementation. Re-add usage of /dev/disk/by-uuid device files for all filesystems (except BTRFS) to workaround problems with JMicron based USB enclosures.

* Add type hinting
* Enhance filesystem classes to support /dev/disk/by-uuid

Signed-off-by: Volker Theile <votdev@gmx.de>

<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
