### PR TITLE
Fix bug in BTRFS getStatistics()

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/btrfs.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/btrfs.inc
@@ -239,29 +239,37 @@ class Btrfs extends Filesystem {
 		// Allocated but unused space in Metadata alone (or System
 		// or GlobalReserve, although they are small) is not included
 		// as it is not directly available for data usage.
-		$available = bcadd($unallocated, array_sum(array_filter(
-		  $allocatedUnusedRaw, function($type) {
-			  return in_array($type, [ 'Data', 'Data+Metadata' ]);
-		  }, ARRAY_FILTER_USE_KEY)));
+		$available = bcadd(
+			$unallocated,
+			array_sum(array_filter($allocatedUnusedRaw, function($type) {
+				return in_array($type, [ 'Data', 'Data+Metadata' ]);
+			}, ARRAY_FILTER_USE_KEY)));
 		// Data ratio is calculated based only on Data (or Data+Metadata).
-		$dataRatio = bcdiv(array_sum(array_filter($usedRaw, function($type) {
-			  return in_array($type, [ 'Data', 'Data+Metadata' ]);
-		  }, ARRAY_FILTER_USE_KEY)),
-		  array_sum(array_filter($used, function($type) {
-			  return in_array($type, [ 'Data', 'Data+Metadata' ]);
-		  }, ARRAY_FILTER_USE_KEY)), 2);
+		$dataRatio = bcdiv(
+			array_sum(array_filter($usedRaw, function($type) {
+				return in_array($type, [ 'Data', 'Data+Metadata' ]);
+			}, ARRAY_FILTER_USE_KEY)),
+			array_sum(array_filter($used, function($type) {
+				return in_array($type, [ 'Data', 'Data+Metadata' ]);
+			}, ARRAY_FILTER_USE_KEY)),
+			2);
+		// Catch and fix division-by-zero.
+		if (is_null($dataRatio)) {
+			$dataRatio = "1.0";
+		}
 
 		// Update the information.
 		// Raw disk(s) size.
-		$stats['size'] = $totalBytes;
-		$stats['blocks'] = bcdiv($totalBytes, "1024", 0);
-		// Usage by all profiles (excluding redundancy).
-		$stats['used'] = array_sum($used);
-		// Space available for Data, adjusted for average data ratio.
-		$stats['available'] = bcdiv($available, $dataRatio, 0);
-		// Raw disk usage, all profiles, divided by raw size.
-		$stats['percentage'] = bcmul(bcdiv(array_sum($usedRaw),
-		  $stats['size'], 3), 100, 0);
+		$stats = array_merge($stats, [
+			"size" => $totalBytes,
+			"blocks" => bcdiv($totalBytes, "1024", 0),
+			// Usage by all profiles (excluding redundancy).
+			"used" => array_sum($used),
+			// Space available for Data, adjusted for average data ratio.
+			"available" => bcdiv($available, $dataRatio, 0),
+			// Raw disk usage, all profiles, divided by raw size.
+			"percentage" => bcmul(bcdiv(array_sum($usedRaw), $totalBytes, 3), 100, 0)
+		]);
 
 		return $stats;
 	}


### PR DESCRIPTION
In some situations the calculation of the ratio causes a division-by-zero. Catching and fixing that will fix the calculation of the `available` size value.

Signed-off-by: Volker Theile <votdev@gmx.de>

<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
