### PR TITLE
Hardening PHP code to prevent the following error related to BTRFS filesystem identification and processing

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/unittests/php/test_openmediavault_functions.php
+++ b/deb/openmediavault/usr/share/openmediavault/unittests/php/test_openmediavault_functions.php
@@ -125,6 +125,11 @@ class test_openmediavault_functions extends \PHPUnit\Framework\TestCase {
 		$this->assertEmpty($d_filtered);
 	}
 
+	public function test_array_filter_ex_fail() {
+		$d = array_filter_ex([1, 2, 3], "text", "b");
+		$this->assertNull($d);
+	}
+
 	public function test_boolvalEx() {
 		$this->assertTrue(boolvalEx(TRUE));
 		$this->assertTrue(boolvalEx("1"));
@@ -247,8 +252,7 @@ class test_openmediavault_functions extends \PHPUnit\Framework\TestCase {
 
 	public function test_array_unique_key_fail() {
 		$d = array_unique_key([1, 2, 3], "text");
-		$this->assertInternalType("bool", $d);
-		$this->assertFalse($d);
+		$this->assertNull($d);
 	}
 
 	public function test_escape_path() {

--- a/deb/openmediavault/usr/share/php/openmediavault/engine/module/moduleabstract.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/engine/module/moduleabstract.inc
@@ -148,6 +148,8 @@ abstract class ModuleAbstract {
 		$tasks = $jsonFile->read();
 		// Get list of tasks to be executed.
 		$runTasks = array_filter_ex($tasks, "id", $id);
+		if (is_null($runTasks))
+			return;
 		foreach ($runTasks as $taskk => $taskv) {
 			$this->debug("Executing task (callback=%s::%s)",
 				get_class($this), $taskv['func']);

--- a/deb/openmediavault/usr/share/php/openmediavault/engine/notify/dispatcher.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/engine/notify/dispatcher.inc
@@ -119,10 +119,10 @@ class Dispatcher {
 	function notify($type, $id /* [, $arg1 [, $... ]] */) {
 		// Filter list of registered listeners.
 		$listeners = array_filter_ex($this->listeners, "id", $id);
-		// Sort list of registered listeners.
-		array_sort_key($listeners, "seqnum");
 		// Call registered listeners.
-		if (!empty($listeners)) {
+		if (!is_null($listeners)) {
+			// Sort list of registered listeners.
+			array_sort_key($listeners, "seqnum");
 			foreach ($listeners as $listenerk => $listenerv) {
 				if ($listenerv['type'] & $type) {
 					$this->debug(sprintf("Notify listener (type=%s, " .
@@ -144,11 +144,14 @@ class Dispatcher {
 	function dumpListeners($id = "") {
 		$listeners = $this->listeners;
 		// Filter list of registered listeners.
-		if (!empty($id))
+		if (!empty($id)) {
 			$listeners = array_filter_ex($listeners, "id", $id);
-		// Sort list of registered listeners.
-		array_sort_key($listeners, "id");
-		// Dump registered listeners.
-		$this->debug($listeners);
+		}
+		if (!empty($listeners)) {
+			// Sort list of registered listeners.
+			array_sort_key($listeners, "id");
+			// Dump registered listeners.
+			$this->debug($listeners);
+		}
 	}
 }

--- a/deb/openmediavault/usr/share/php/openmediavault/functions.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/functions.inc
@@ -80,9 +80,10 @@ function array_expand(array $array, $separator = ".") {
  * @param key The key used as sort criteria.
  * @return Returns TRUE on success or FALSE on failure.
  */
-function array_sort_key(array &$array, $key) {
-	if (!is_multi_array($array))
+function array_sort_key(array &$array, $key): bool {
+	if (!is_multi_array($array)) {
 		return FALSE;
+	}
 	// Sort the array.
 	if (FALSE === uasort($array, function($a, $b) use($key) {
 		return strnatcmp(strval($a[$key]), strval($b[$key]));
@@ -108,26 +109,26 @@ function array_remove_key(array &$array, $key) {
 }
 
 /**
- * Filter an array of by key and values.
+ * Filter a multi-dimensional array by key and value.
  * @ingroup api
  * @param array $array The array to process.
  * @param string $key The key used as filter criteria.
  * @param string $value The value used as filter criteria.
- * @return Returns the filtered array.
+ * @return Returns a new array containing only that elements that match
+ *   the given filter arguments or NULL on failure.
  */
-function array_filter_ex($array, $key, $value) {
-	$result = [];
-	if (!is_multi_array($array))
-		return $result;
-	if (is_array($array) && count($array) > 0) {
-		foreach (array_keys($array) as $keyv) {
-			$temp[$keyv] = $array[$keyv][$key];
-			if ($temp[$keyv] == $value)
-				$result[$keyv] = $array[$keyv];
-		}
+function array_filter_ex($array, $key, $value): ?array {
+	if (!is_multi_array($array)) {
+		return NULL;
 	}
-	// Re-index the array.
-	return array_values($result);
+	// Re-index the filtered array.
+	return array_values(
+		array_filter($array, function($v) use($key, $value) {
+			if (!array_key_exists($key, $v)) {
+				return FALSE;
+			}
+			return $v[$key] == $value;
+		}, ARRAY_FILTER_USE_BOTH));
 }
 
 /**
@@ -149,11 +150,12 @@ function array_keys_exists(array $keys, array $search, &$missing = NULL) {
  * Note, the first found duplicate will be inserted to the result.
  * @param array $array The array to process.
  * @param string $key The key used as filter criteria.
- * @return Returns the filtered array or FALSE on failure.
+ * @return Returns a new array without duplicates or NULL on failure.
  */
-function array_unique_key(array $array, $key) {
-	if (!is_multi_array($array))
-		return FALSE;
+function array_unique_key(array $array, $key): ?array {
+	if (!is_multi_array($array)) {
+		return NULL;
+	}
 	$result = [];
 	$values = [];
 	foreach ($array as $arrayk => $arrayv) {
@@ -486,12 +488,13 @@ function is_ipaddr6($var) {
 }
 
 /**
- * Finds out whether a variable is a multidimensional array.
+ * Finds out whether a variable is a multi-dimensional array.
  * @ingroup api
  * @param mixed $var The variable being evaluated.
- * @return TRUE if the variable is a multidimensional array, otherwise FALSE.
+ * @return TRUE if the variable is a multi-dimensional array,
+ *   otherwise FALSE.
  */
-function is_multi_array($var) {
+function is_multi_array($var): bool {
 	if (FALSE === is_array($var))
 		return FALSE;
 	if (count($var, COUNT_RECURSIVE) !== count($var))
@@ -506,7 +509,7 @@ function is_multi_array($var) {
  * @param mixed $var The variable being evaluated.
  * @return TRUE if the variable is an associative array, otherwise FALSE.
  */
-function is_assoc_array($var) {
+function is_assoc_array($var): bool {
 	if (FALSE === is_array($var))
 		return FALSE;
 	$keys = array_keys($var);

--- a/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/backend/btrfs.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/backend/btrfs.inc
@@ -72,8 +72,14 @@ class Btrfs extends BackendAbstract {
 		foreach ($uniqueEnums as $uniqueEnumk => $uniqueEnumv) {
 			$canonicalDeviceFile = realpath(sprintf("/dev/disk/by-uuid/%s",
 				$uniqueEnumv['uuid']));
-			$result[] = array_filter_ex($enums, "devicefile",
-				$canonicalDeviceFile)[0];
+			$filtered = array_filter_ex($enums, "devicefile",
+				$canonicalDeviceFile);
+			if (empty($filtered)) {
+				// This should never happen. At least one element must
+				// be in the array.
+				continue;
+			}
+			$result[] = $filtered[0];
 		}
 		return $result;
 	}


### PR DESCRIPTION
PHP Fatal error: Uncaught TypeError: Argument 2 passed to array_keys_exists() must be of the type array, null given, called in /usr/share/php/openmediavault/system/filesystem/backend/manager.inc on line 286 and defined in /usr/share/php/openmediavault/functions.inc:142

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
