### PR TITLE
Add fallback for BTRFS when symlink to device file does not exist

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,6 @@
 openmediavault (5.5.21-1) stable; urgency=low
 
-  * 
+  * Fixing a bug related to BTRFS which crashed the filesystem UI page.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Tue, 29 Dec 2020 20:45:44 +0100
 

--- a/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/backend/btrfs.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/backend/btrfs.inc
@@ -75,9 +75,25 @@ class Btrfs extends BackendAbstract {
 			$filtered = array_filter_ex($enums, "devicefile",
 				$canonicalDeviceFile);
 			if (empty($filtered)) {
-				// This should never happen. At least one element must
-				// be in the array.
-				continue;
+				// It seems there are situations where the symlink from
+				// /dev/disk/by-uuid/<UUID> -> /dev/xxx does not exist.
+				//
+				// Example:
+				// $ realpath /dev/disk/by-uuid/9c2f26b0-209c-43e5-8316-84280b0ddbd7
+				// /dev/disk/by-uuid/9c2f26b0-209c-43e5-8316-84280b0ddbd7
+				// $ findfs UUID=9c2f26b0-209c-43e5-8316-84280b0ddbd7
+				// /dev/sda
+				//
+				// Because this fallback is a really expensive action,
+				// it would be great to have a final solution here. The
+				// problem seems to be related to BTRFS and/or UDEV.
+				$cmdArgs = [];
+				$cmdArgs[] = sprintf("UUID=%s", $uniqueEnumv['uuid']);
+				$cmd = new \OMV\System\Process("findfs", $cmdArgs);
+				$cmd->setRedirect2to1();
+				$filtered[] = array_merge($uniqueEnumv, [
+					"devicefile" => $cmd->execute()
+				]);
 			}
 			$result[] = $filtered[0];
 		}


### PR DESCRIPTION
It seems there are situations where the symlink from /dev/disk/by-uuid/<UUID> -> /dev/xxx does not exists.

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
