### PR TITLE
Issue #921: Prevent using WLAN NICs for bond and bridge interfaces.

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault (5.5.22-1) stable; urgency=low
+
+  * Issue #921: Prevent using WLAN NICs for bond and bridge interfaces.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Fri, 08 Jan 2021 16:10:43 +0100
+
 openmediavault (5.5.21-1) stable; urgency=low
 
   * Fixing a bug related to BTRFS which crashed the filesystem UI page.

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/bond.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/bond.j2
@@ -2,7 +2,7 @@
 {%- set mode_map = {0: "balance-rr", 1: "active-backup", 2: "balance-xor", 3: "broadcast", 4: "802.3ad", 5: "balance-tlb", 6: "balance-alb"} -%}
 {%- set primary_reselect_policy = salt['pillar.get']('default:OMV_SYSTEMD_NETWORKD_BOND_PRIMARYRESELECTPOLICY', 'always') -%}
 network:
-{%- for type in ['ethernet', 'wifi'] %}
+{%- for type in ['ethernet'] %}
 {%- set slaves = interface.slaves.split(',') | select('match_netif_type', type) | list %}
 {%- if slaves | length > 0 %}
   {{ type }}s:

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/bridge.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/bridge.j2
@@ -2,7 +2,7 @@
 {%- set mode_map = {0: "balance-rr", 1: "active-backup", 2: "balance-xor", 3: "broadcast", 4: "802.3ad", 5: "balance-tlb", 6: "balance-alb"} -%}
 {%- set primary_reselect_policy = salt['pillar.get']('default:OMV_SYSTEMD_NETWORKD_BOND_PRIMARYRESELECTPOLICY', 'always') -%}
 network:
-{%- for type in ['bond', 'ethernet', 'wifi'] %}
+{%- for type in ['bond', 'ethernet'] %}
 {%- set slaves = interface.slaves.split(',') | select('match_netif_type', type) | list %}
 {%- if slaves | length > 0 %}
   {{ type }}s:

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.network.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.network.json
@@ -154,7 +154,7 @@
 			   "type": "array",
 				"items": {
 					"type": "string",
-					"pattern": "^((eth|venet|wlan)\\d+|(en|veth|wl)\\S+)$"
+					"pattern": "^((eth|venet)\\d+|(en|veth)\\S+)$"
 				},
 			   "required": true
 		   },
@@ -436,7 +436,7 @@
 				"type": "array",
 				"items": {
 					"type": "string",
-					"pattern": "^((eth|venet|wlan)\\d+|(en|veth|wl)\\S+|(bond)\\d+)(\\.\\d+)?$"
+					"pattern": "^((eth|venet)\\d+|(en|veth)\\S+|(bond)\\d+)(\\.\\d+)?$"
 				},
 				"required": true
 			}

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/network.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/network.inc
@@ -484,18 +484,16 @@ class Network extends \OMV\Rpc\ServiceAbstract {
 			"role" => OMV_ROLE_ADMINISTRATOR
 		]);
 		$mngr = \OMV\System\Net\NetworkInterfaceBackend\Manager::getInstance();
-		// Get all unused network interface devices, except loopback and
-		// VLAN network interfaces.
+		// Get all unused ethernet network interface devices.
 		if (FALSE === ($devs = $mngr->enumerateUnused(
 				OMV_NETWORK_INTERFACE_TYPE_ETHERNET))) {
 			throw new \OMV\Exception(
-				"Failed to get list of unused network interface devices.");
+				"Failed to get list of network interface devices.");
 		}
-		// Get the network interface information.
+		// Process the identified devices and skip those that are
+		// already configured or in use.
 		$result = [];
 		foreach ($devs as $devk => $devv) {
-			// Does a configuration object exists for the given network
-			// interface device? In this case skip this device.
 			$db = \OMV\Config\Database::getInstance();
 			if ($db->exists("conf.system.network.interface", [
 				"operator" => "and",
@@ -572,17 +570,15 @@ class Network extends \OMV\Rpc\ServiceAbstract {
 		$db = \OMV\Config\Database::getInstance();
 		$result = [];
 		if (array_value($params, "unused", FALSE) === TRUE) {
-			// Get all existing ethernet and WiFi network interface
-			// devices.
+			// Get all existing ethernet network interface devices.
 			$mngr = \OMV\System\Net\NetworkInterfaceBackend\Manager::getInstance();
 			if (FALSE === ($devs = $mngr->enumerate(
-					OMV_NETWORK_INTERFACE_TYPE_ETHERNET |
-					OMV_NETWORK_INTERFACE_TYPE_WIFI))) {
+					OMV_NETWORK_INTERFACE_TYPE_ETHERNET))) {
 				throw new \OMV\Exception(
-					"Failed to get list of unused network interface devices.");
+					"Failed to get list of network interface devices.");
 			}
-			// Get a list of ethernet and WiFi network interfaces
-			// that are not used by any other config object.
+			// Process the identified devices and skip those that are
+			// already configured or in use.
 			foreach ($devs as $devk => $devv) {
 				// Is network interface device referenced somewhere:
 				// - Check if the interface is already used by a bond
@@ -624,9 +620,9 @@ class Network extends \OMV\Rpc\ServiceAbstract {
 				if ($db->exists("conf.system.network.interface", [
 					"operator" => "and",
 					"arg0" => [
-						"operator" => "stringEnum",
+						"operator" => "stringEquals",
 						"arg0" => "type",
-						"arg1" => [ "ethernet", "wifi" ]
+						"arg1" => "ethernet"
 					],
 					"arg1" => [
 						"operator" => "stringEquals",
@@ -827,19 +823,17 @@ class Network extends \OMV\Rpc\ServiceAbstract {
 		$this->validateMethodContext($context, [
 			"role" => OMV_ROLE_ADMINISTRATOR
 		]);
-		// Get all unused network interface devices, except loopback and
-		// VLAN network interfaces.
+		// Get all unused wifi network interface devices.
 		$mngr = \OMV\System\Net\NetworkInterfaceBackend\Manager::getInstance();
 		if (FALSE === ($devs = $mngr->enumerateUnused(
 				OMV_NETWORK_INTERFACE_TYPE_WIFI))) {
 			throw new \OMV\Exception(
-				"Failed to get list of unused network interface devices.");
+				"Failed to get list of network interface devices.");
 		}
-		// Get the network interface information.
+		// Process the identified devices and skip those that are
+		// already configured or in use.
 		$result = [];
 		foreach ($devs as $devk => $devv) {
-			// Does a configuration object exists for the given network
-			// interface device? In this case skip this device.
 			$db = \OMV\Config\Database::getInstance();
 			if ($db->exists("conf.system.network.interface", [
 				"operator" => "and",
@@ -918,18 +912,19 @@ class Network extends \OMV\Rpc\ServiceAbstract {
 		$db = \OMV\Config\Database::getInstance();
 		$result = [];
 		if (array_value($params, "unused", FALSE) === TRUE) {
-			// Get all unused network interface devices, except bridge
-			// and loopback network interfaces.
+			// Get all unused network interface devices, except bridge,
+			// wifi and loopback network interfaces.
 			$mngr = \OMV\System\Net\NetworkInterfaceBackend\Manager::getInstance();
 			if (FALSE === ($devs = $mngr->enumerateUnused(
 					OMV_NETWORK_INTERFACE_TYPE_ALL &
 					~(OMV_NETWORK_INTERFACE_TYPE_BRIDGE |
+					OMV_NETWORK_INTERFACE_TYPE_WIFI |
 					OMV_NETWORK_INTERFACE_TYPE_LOOPBACK)))) {
 				throw new \OMV\Exception(
-					"Failed to get list of unused network interface devices.");
+					"Failed to get list of network interface devices.");
 			}
-			// Get a list of configured ethernet network interfaces that are
-			// not used by any other config object.
+			// Process the identified devices and skip those that are
+			// already configured or in use.
 			foreach ($devs as $devk => $devv) {
 				// Is network interface device referenced somewhere:
 				// - Check if the interface is already used by a bond


### PR DESCRIPTION
There is no way to configure the WLAN credentials when a WiFi interface is used as slave in a bond or bridge interface. Because of that WiFi interfaces are not listed in the UI as candidates for those interface types.
To get this implemented the UI and the backend must be completely refactored. If this is a required feature, then it's up to the community to contribute it in OMV6.

Fixes: https://github.com/openmediavault/openmediavault/issues/921

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
