### PR TITLE
Issue #929: Set 'big_writes' as default mount option for NTFS filesystems

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -2,6 +2,8 @@ openmediavault (5.5.22-1) stable; urgency=low
 
   * Fix monit/proftpd issue when implicit TLS is enabled.
   * Issue #921: Prevent using WLAN NICs for bond and bridge interfaces.
+  * Issue #929: Set 'big_writes' as default mount option for NTFS
+    filesystems.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Fri, 08 Jan 2021 16:10:43 +0100
 

--- a/deb/openmediavault/usr/share/php/openmediavault/globals.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/globals.inc
@@ -83,7 +83,7 @@ define("OMV_NETWORK_INTERFACE_TYPE_ALL", 0xFF);
 \OMV\Environment::set("OMV_FSTAB_MNTOPS_XFS", "defaults,nofail,usrquota,grpquota");
 \OMV\Environment::set("OMV_FSTAB_MNTOPS_EXFAT", "defaults,nofail");
 \OMV\Environment::set("OMV_FSTAB_MNTOPS_VFAT", "defaults,nofail");
-\OMV\Environment::set("OMV_FSTAB_MNTOPS_NTFS", "defaults,nofail");
+\OMV\Environment::set("OMV_FSTAB_MNTOPS_NTFS", "defaults,nofail,big_writes");
 \OMV\Environment::set("OMV_FSTAB_MNTOPS_HFSPLUS", "defaults,nofail,force");
 \OMV\Environment::set("OMV_FSTAB_MNTOPS_BTRFS", "defaults,nofail");
 \OMV\Environment::set("OMV_FSTAB_MNTOPS_ISO9660", "ro");


### PR DESCRIPTION
Fixes: https://github.com/openmediavault/openmediavault/issues/929

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
