### PR TITLE
Issue #930: Add UDEV rule for OWC Mercury Elite Pro Dual mini enclosure to fix the random serial ID issue

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -4,6 +4,8 @@ openmediavault (5.5.22-1) stable; urgency=low
   * Issue #921: Prevent using WLAN NICs for bond and bridge interfaces.
   * Issue #929: Set 'big_writes' as default mount option for NTFS
     filesystems.
+  * Issue #930: Add UDEV rule for OWC Mercury Elite Pro Dual mini
+    enclosure to fix the random serial ID issue.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Fri, 08 Jan 2021 16:10:43 +0100
 

--- a/deb/openmediavault/debian/openmediavault.postinst
+++ b/deb/openmediavault/debian/openmediavault.postinst
@@ -283,6 +283,7 @@ case "$1" in
 		fi
 		if dpkg --compare-versions "$2" lt-nl "5.5.22"; then
 			omv_module_set_dirty monit
+			omv_module_set_dirty initramfs
 		fi
 
 		########################################################################

--- a/deb/openmediavault/etc/udev/rules.d/61-openmediavault-dev-disk-by-id.rules
+++ b/deb/openmediavault/etc/udev/rules.d/61-openmediavault-dev-disk-by-id.rules
@@ -367,6 +367,43 @@ ENV{ID_VENDOR_ID}=="152d", \
   SYMLINK="disk/by-path/$env{ID_PATH}", \
   SYMLINK+="disk/by-id/$env{ID_BUS}-$env{ID_SERIAL}"
 
+# https://www.owcdigital.com/products/mercury-elite-pro-dual-mini
+#
+# DEVPATH=/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb2/2-1/2-1:1.0/host3/target3:0:0/3:0:0:0/block/sdd
+# DEVNAME=/dev/sdd
+# DEVTYPE=disk
+# MAJOR=8
+# MINOR=48
+# SUBSYSTEM=block
+# USEC_INITIALIZED=8654497300
+# ID_VENDOR=Elite
+# ID_VENDOR_ENC=Elite\x20\x20\x20
+# ID_VENDOR_ID=1e91
+# ID_MODEL=Pro_Dual-R1
+# ID_MODEL_ENC=Pro\x20Dual-R1\x20\x20\x20\x20\x20
+# ID_MODEL_ID=a3a6
+# ID_REVISION=0105
+# ID_SERIAL=Elite_Pro_Dual-R1_RANDOM__D61B6A084014-0:0
+# ID_SERIAL_SHORT=RANDOM__D61B6A084014
+# ID_TYPE=disk
+# ID_INSTANCE=0:0
+# ID_BUS=usb
+# ID_USB_INTERFACES=:080650:080662:
+# ID_USB_INTERFACE_NUM=00
+# ID_USB_DRIVER=usb-storage
+# ID_PATH=platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1:1.0-scsi-0:0:0:0
+# ID_PATH_TAG=platform-fd500000_pcie-pci-0000_01_00_0-usb-0_1_1_0-scsi-0_0_0_0
+# ID_PART_TABLE_UUID=93568ccc
+# ID_PART_TABLE_TYPE=dos
+# DEVLINKS=/dev/disk/by-id/usb-Elite_Pro_Dual-R1_RANDOM__D61B6A084014-0:0 /dev/disk/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1:1.0-scsi-0:0:0:0
+# TAGS=:systemd:
+ENV{ID_VENDOR}=="Elite", \
+  ENV{ID_MODEL}=="Pro_Dual-R1", \
+  IMPORT{program}="serial_id %N", \
+  ENV{ID_SERIAL}="$env{ID_VENDOR}_$env{ID_MODEL}_$env{ID_SERIAL_SHORT}-$env{ID_INSTANCE}", \
+  SYMLINK="disk/by-path/$env{ID_PATH}", \
+  SYMLINK+="disk/by-id/$env{ID_BUS}-$env{ID_SERIAL}"
+
 # by-id (World Wide Name)
 SYMLINK=="*disk/by-id/wwn-*", GOTO="omv_skip_by_id_wwn"
 ENV{ID_WWN_WITH_EXTENSION}=="?*", SYMLINK+="disk/by-id/wwn-$env{ID_WWN_WITH_EXTENSION}"


### PR DESCRIPTION
Fixes: https://github.com/openmediavault/openmediavault/issues/930

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
