### PR TITLE
Issue #505: Prepend explanation to cron-apt notifications

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,5 +1,6 @@
 openmediavault (5.5.23-1) stable; urgency=low
 
+  * Issue #505: Prepend explanation to cron-apt notifications.
   * Issue #926: Refactor code that is responsible for sending the
     notification email on first UI log in.
 

--- a/deb/openmediavault/debian/openmediavault.postinst
+++ b/deb/openmediavault/debian/openmediavault.postinst
@@ -286,6 +286,9 @@ case "$1" in
 			omv_module_set_dirty monit
 			omv_module_set_dirty initramfs
 		fi
+		if dpkg --compare-versions "$2" lt-nl "5.5.23"; then
+			omv_module_set_dirty cronapt
+		fi
 
 		########################################################################
 		# Trigger the restart of the omv-engined daemon to load and use the

--- a/deb/openmediavault/srv/salt/omv/deploy/cronapt/default.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/cronapt/default.sls
@@ -42,3 +42,12 @@ create_cron-apt_config:
     - user: root
     - group: root
     - mode: 644
+
+create_cron-apt_download_msg:
+  file.managed:
+    - name: "/etc/cron-apt/mailmsg.d/3-download"
+    - source:
+      - salt://{{ tpldir }}/files/etc_cron-apt_mailmsgd_3-download.j2
+    - user: root
+    - group: root
+    - mode: 644

--- a/deb/openmediavault/srv/salt/omv/deploy/cronapt/files/etc_cron-apt_mailmsgd_3-download.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/cronapt/files/etc_cron-apt_mailmsgd_3-download.j2
@@ -1,0 +1,4 @@
+The following packages are already downloaded and ready to install. Go to the 'System | Update Management' page in the web interface or run 'omv-update' from the CLI to install them finally.
+
+You have received this notification because you have enabled software update notifications on this host. To change your notification preferences, please go to the 'System | Notification' page in the web interface.
+


### PR DESCRIPTION
A notification may look like this:
```
The following packages are already downloaded and ready to install. Go to the 'System | Update Management' page to to install them finally.

You have received this notification because you have enabled software update notifications on this host. To change your notification preferences, please go to the 'System | Notification' page in the web interface.

CRON-APT RUN [/etc/cron-apt/config]: Wed Jan 13 17:33:06 UTC 2021
CRON-APT ACTION: 3-download
CRON-APT LINE: /usr/bin/apt-get  dist-upgrade -d -y -o APT::Get::Show-Upgraded=true
Reading package lists...
Building dependency tree...
Reading state information...
Calculating upgrade...
The following packages will be upgraded:
  openmediavault
1 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/1715 kB of archives.
After this operation, 3072 B of additional disk space will be used.
Download complete and in download only mode
```

Fixes: https://github.com/openmediavault/openmediavault/issues/505

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
