### PR TITLE
Issue #720: Execute backup job only when filesystems are up

### DIFF
--- a/deb/openmediavault-usbbackup/debian/changelog
+++ b/deb/openmediavault-usbbackup/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-usbbackup (5.0.7-1) stable; urgency=low
+
+  * Issue #720: Execute backup job only when filesystems are up.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Tue, 19 Jan 2021 09:38:55 +0100
+
 openmediavault-usbbackup (5.0.6-1) stable; urgency=low
 
   * Issue #812: Cron script erroneously reports success though failed.

--- a/deb/openmediavault-usbbackup/debian/openmediavault-usbbackup.postinst
+++ b/deb/openmediavault-usbbackup/debian/openmediavault-usbbackup.postinst
@@ -59,6 +59,9 @@ case "$1" in
 		if dpkg --compare-versions "$2" lt-nl "5.0.6"; then
 		  omv_module_set_dirty usbbackup
 		fi
+		if dpkg --compare-versions "$2" lt-nl "5.0.7"; then
+		  omv_module_set_dirty usbbackup
+		fi
 	;;
 
 	abort-upgrade|abort-remove|abort-deconfigure)

--- a/deb/openmediavault-usbbackup/srv/salt/omv/deploy/usbbackup/files/systemd-unitfile.j2
+++ b/deb/openmediavault-usbbackup/srv/salt/omv/deploy/usbbackup/files/systemd-unitfile.j2
@@ -4,8 +4,8 @@
 [Unit]
 Description=Execute the rsync backup jobs when {{ devicefile }} is plugged in
 BindsTo={{ devicefile_escaped }}.device
-After={{ devicefile_escaped }}.device
-Requisite={{ devicefile_escaped }}.device
+After=local-fs.target {{ devicefile_escaped }}.device
+Requisite=local-fs.target {{ devicefile_escaped }}.device
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Fixes: https://github.com/openmediavault/openmediavault/issues/720

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
