### PR TITLE
[LXC] Avoid "Device '/dev/dm-0' does not exist." problem

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/backend/backendabstract.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/backend/backendabstract.inc
@@ -134,7 +134,9 @@ abstract class BackendAbstract {
 		foreach(file("/proc/partitions") as $outputk => $outputv) {
 			if (1 !== preg_match($regex, $outputv, $matches))
 				continue;
-			$result[] = sprintf("/dev/%s", $matches[4]);
+			$deviceName = sprintf("/dev/%s", $matches[4]);
+			if (file_exists($deviceName))
+				$result[] = $deviceName;
 		}
 		return $result;
 	}


### PR DESCRIPTION
#944 

In Linux LXC /proc/partitions is the same as host, not match /dev

avoid like `Device '/dev/dm-0' does not exist.` problem.

Signed-off-by: Shao Yu-Lung <bestlong168@gmail.com>

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
