### PR TITLE
Fix the config template file for forked-daapd

### DIFF
--- a/deb/openmediavault-forkeddaapd/srv/salt/omv/deploy/forked-daapd/files/etc-forked-daapd_conf.j2
+++ b/deb/openmediavault-forkeddaapd/srv/salt/omv/deploy/forked-daapd/files/etc-forked-daapd_conf.j2
@@ -184,7 +184,7 @@ audio {
     # negative correspond to delaying it. The unit is samples, where is
     # 44100 = 1 second. The offset must be between -44100 and 44100.
 #   offset = 0
-#}
+}
 
 # Pipe output
 # Allows forked-daapd to output audio data to a named pipe


### PR DESCRIPTION
The `audio` section was not closed.

