### PR TITLE
Various proftpd related issues

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -5,6 +5,10 @@ openmediavault (5.5.24-1) stable; urgency=low
   * Fix a SMB recycle bin cleanup script issue. Execute run-args with
     the '--new-session' option to ensure the scripts will run until
     completion. This should prevent subsequent locks.
+  * Remove 'No certificate request' option from 'FTP | SSL/TLS' page
+    because it is deprecated in proftpd.
+  * Improve monit/proftpd connection test. This should prevent errors
+    when SSL/TLS is enabled.
   * Enable NTP by default on new installations.
   * Issue #944: Hardening storage backend to prevent errors in LXC.
 

--- a/deb/openmediavault/srv/salt/omv/deploy/monit/services/files/proftpd.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/monit/services/files/proftpd.j2
@@ -5,7 +5,9 @@ check process proftpd with pidfile /run/proftpd.pid
     start program = "/etc/init.d/proftpd restart"
     stop program  = "/etc/init.d/proftpd stop"
     mode active
-    if failed port {{ proftpd_config.port }} protocol ftp {% if proftpd_config.modules.mod_tls.enable | to_bool %}with ssl {% endif %}for 3 cycles then restart
+    # Do not specify a protocol here, so Monit will use a default connection test
+    # where we do not need to take care about whether SSL/TLS is enabled or not.
+    if failed port {{ proftpd_config.port }} for 3 cycles then restart
 {%- if email_config.enable | to_bool and not notification_config.enable | to_bool %}
     noalert {{ email_config.primaryemail }}
 {%- endif %}

--- a/deb/openmediavault/srv/salt/omv/deploy/proftpd/modules/files/mod_tls.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/proftpd/modules/files/mod_tls.j2
@@ -8,9 +8,8 @@
   TLSEngine {% if config.enable | to_bool %}on{% else %}off{% endif %}
   TLSLog {{ tls_log }}
   TLSProtocol {{ tls_protocol }}
-{%- if config.nocertrequest | to_bool or config.nosessionreuserequired | to_bool or config.useimplicitssl | to_bool %}
+{%- if config.nosessionreuserequired | to_bool or config.useimplicitssl | to_bool %}
   TLSOptions
-{%- if config.nocertrequest | to_bool %} NoCertRequest{% endif -%}
 {%- if config.nosessionreuserequired | to_bool %} NoSessionReuseRequired{% endif -%}
 {%- if config.useimplicitssl | to_bool %} UseImplicitSSL{% endif -%}
 {%- endif %}

--- a/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_5.5.24.sh
+++ b/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_5.5.24.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2021 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+set -e
+
+. /usr/share/openmediavault/scripts/helper-functions
+
+omv_config_delete "/config/services/ftp/modules/mod_tls/nocertrequest"
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.ftp.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.ftp.json
@@ -220,10 +220,6 @@
 							}],
 							"default": ""
 						},
-						"nocertrequest": {
-							"type": "boolean",
-							"default": false
-						},
 						"nosessionreuserequired": {
 							"type": "boolean",
 							"default": false

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.ftp.modtls.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.ftp.modtls.json
@@ -25,10 +25,6 @@
 			}],
 			"default": ""
 		},
-		"nocertrequest": {
-			"type": "boolean",
-			"default": false
-		},
 		"nosessionreuserequired": {
 			"type": "boolean",
 			"default": false

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.ftp.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.ftp.json
@@ -213,10 +213,6 @@
 				}],
 				"required": true
 			},
-			"nocertrequest": {
-				"type": "boolean",
-				"required": true
-			},
 			"nosessionreuserequired": {
 				"type": "boolean",
 				"required": true

--- a/deb/openmediavault/usr/share/openmediavault/templates/config.xml
+++ b/deb/openmediavault/usr/share/openmediavault/templates/config.xml
@@ -436,7 +436,6 @@
 					<enable>0</enable>
 					<required>0</required>
 					<sslcertificateref></sslcertificateref>
-					<nocertrequest>0</nocertrequest>
 					<nosessionreuserequired>0</nosessionreuserequired>
 					<useimplicitssl>0</useimplicitssl>
 					<extraoptions></extraoptions>

--- a/deb/openmediavault/usr/share/openmediavault/unittests/data/config.xml
+++ b/deb/openmediavault/usr/share/openmediavault/unittests/data/config.xml
@@ -753,7 +753,6 @@ iSrj/B/KRCZkkrDdYcDAvqRs6dA+ScRZ
           <enable>1</enable>
           <required>1</required>
           <sslcertificateref>b7c10cca-d2b7-4651-a358-712410323ffe</sslcertificateref>
-          <nocertrequest>0</nocertrequest>
           <nosessionreuserequired>0</nosessionreuserequired>
           <useimplicitssl>0</useimplicitssl>
           <extraoptions></extraoptions>

--- a/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/service/ftp/Tls.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/service/ftp/Tls.js
@@ -87,12 +87,6 @@ Ext.define("OMV.module.admin.service.ftp.Tls", {
 				boxLabel: _("This option requires clients to use FTP over TLS when talking to this server.")
 			},{
 				xtype: "checkbox",
-				name: "nocertrequest",
-				fieldLabel: _("No certificate request"),
-				checked: false,
-				boxLabel: _("This option causes the server to not send a certificate request during a SSL handshake.")
-			},{
-				xtype: "checkbox",
 				name: "nosessionreuserequired",
 				fieldLabel: _("No session reuse required"),
 				checked: false,


### PR DESCRIPTION
- Use default Monit connection test for proftpd, so there is no need to take care about SSL/TLS settings.
- Remove 'NoCertRequest' option from 'FTP | SSL/TLS' page because it is deprecated in proftpd.

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
