### PR TITLE
Update to document faulty MB174U3S-4SB enclosure

### DIFF
--- a/deb/openmediavault/etc/udev/rules.d/61-openmediavault-dev-disk-by-id.rules
+++ b/deb/openmediavault/etc/udev/rules.d/61-openmediavault-dev-disk-by-id.rules
@@ -138,6 +138,9 @@ ATTRS{idVendor}=="0080", \
 # ORICO 3.5-Inch Multi-Bay Hard Drive Enclosure (9548U3)
 # https://www.orico.cc/us/product/detail/6764/9528U3-BK.html
 #
+# Icy Dock Black Vortex MB174U3S-4SB Quad Bay usb 3.0 eSATA external 3.5" SATA HDD Enclosure 
+# https://www.icydock.com/goods.php?id=191
+#
 # P: /devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb2/2-1/2-1.2/2-1.2:1.0/host1/target1:0:0/1:0:0:0/block/sdc
 # N: sdc
 # L: 0


### PR DESCRIPTION
Thanks for the effort in figuring out the workaround on this, I was able to use this stuff for my Linux Mint desktop. I came across the serial number handling for /dev/disk/by-id bug in an Icy Dock Black Vortex MB174U3S-4SB Quad Bay usb 3.0 eSATA external 3.5" SATA HDD Enclosure in the context of managing a ZFS pool including a few drives in this enclosure. 

Although I am not using the Openmediavault project, I figure a reference to another affected hardware might leave a couple more breadcrumbs for people in the future running this problem down.


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
