### PR TITLE
Issue #970: HPSA HBA improvements causing a regression when controller is in RAID mode

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,7 @@
 openmediavault (5.6.1-1) stable; urgency=low
 
-  *
+  * Issue #970: HPSA HBA improvements causing a regression when
+    controller is in RAID mode.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Sun, 21 Feb 2021 13:16:58 +0100
 

--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevicehpsa.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevicehpsa.inc
@@ -28,13 +28,18 @@ namespace OMV\System\Storage;
  */
 class StorageDeviceHPSA extends StorageDeviceSD {
 	public function isRaid() {
-		return TRUE;
+		return "RAID" == substr($this->getRaidLevel(), 0, 4);
 	}
 
 	/**
 	 * See \OMV\System\Storage\SmartInterface interface definition.
 	 */
 	public function getSmartDeviceType() {
+		// Note, we need to distinguish between RAID and HBA mode here.
+		if (TRUE === $this->isRaid()) {
+			return parent::getSmartDeviceType();
+		}
+		//
 		// $ hpssacli ctrl slot=0 pd all show detail
 		// ...
 		// physicaldrive 1I:1:5
@@ -54,5 +59,28 @@ class StorageDeviceHPSA extends StorageDeviceSD {
 		// controller is monitored.
 		$hctl = $this->getHCTL();
 		return sprintf("cciss,%d", $hctl['target'] - 1);
+	}
+
+	/**
+	 * Get the RAID level of the device. If it is a logical device,
+	 * then 'N/A' will be returned, otherwise 'RAID 0', 'RAID 1(+0)'
+	 * or 'RAID <N>'.
+	 *
+	 * @link https://www.kernel.org/doc/html/latest/scsi/hpsa.html#hpsa-specific-disk-attributes
+	 * @link https://github.com/torvalds/linux/blob/master/drivers/scsi/hpsa.c#L654
+	 * @link https://github.com/torvalds/linux/blob/master/drivers/scsi/hpsa.c#L694
+	 * @link https://github.com/torvalds/linux/blob/master/drivers/scsi/hpsa.c#L702
+	 *
+	 * @return string Returns the RAID level.
+	 */
+	public function getRaidLevel(): string {
+		$hctl = $this->getHCTL();
+		$filePath = sprintf(
+			"/sys/class/scsi_disk/%d:%d:%d:%d/device/raid_level",
+			$hctl['host'], $hctl['channel'], $hctl['target'],
+			$hctl['lun']);
+		if (!file_exists($filePath))
+			return "N/A";
+		return trim(file_get_contents($filePath));
 	}
 }

--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevicesd.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevicesd.inc
@@ -99,7 +99,7 @@ class StorageDeviceSD extends StorageDevice implements SmartInterface {
 		$parts = explode(":", basename($path));
 		return [
 			"host" => intval($parts[0]),
-			"bus" => intval($parts[1]),
+			"channel" => intval($parts[1]),
 			"target" => intval($parts[2]),
 			"lun" => intval($parts[3])
 		];


### PR DESCRIPTION
Fixes: https://github.com/openmediavault/openmediavault/issues/970

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
