### PR TITLE
"is selecting" -> "is selected" - small grammar change to read better in english

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/locale/ar_SA/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/ar_SA/openmediavault.po
@@ -1552,7 +1552,7 @@ msgstr "خمول"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "إذا تم تحديد' الضيوف المسموح لهم 'ولم يتم توفير بيانات اعتماد تسجيل الدخول ، فقم بالوصول كضيف. قم دائمًا بالوصول كضيف عند تحديد' الضيوف فقط '؛ وفي هذه الحالة لا يلزم كلمة مرور للاتصال بالمشاركة."
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/bg_BG/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/bg_BG/openmediavault.po
@@ -1551,7 +1551,7 @@ msgstr ""
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr ""
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/ca_ES/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/ca_ES/openmediavault.po
@@ -1553,7 +1553,7 @@ msgstr "Inactivo"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "Si selecciona 'Permetre convidats' i no es proporcionen credencials usuari/contrasenya, llavors s’accedirà com a convidat. Sempre s’accedeix com a convidat si s’ha seleccionat 'Només convidats', en aquest cas no caldrà usuari i contrasenya."
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/cs_CZ/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/cs_CZ/openmediavault.po
@@ -1552,7 +1552,7 @@ msgstr "Nečinnost"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "Pokud je zvoleno „Přístup hostům umožněn“ a při přístupu nejsou poskytnuty přihlašovací údaje, pak přistupovat jako host. Vždy přistupovat jako host, když je zvoleno „Pouze hosté“ – v takovém případě pro přístup ke sdílení není vyžadováno žádné heslo."
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/da_DA/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/da_DA/openmediavault.po
@@ -1551,7 +1551,7 @@ msgstr "Ledig"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "Hvis 'Gæster tilladt' er valgt og ingen log ind legitimationsoplysninger er fastsat vil tilgang være som gæst. Tilgå altid som gæst når 'Kun gæster' bliver valgt; i dette tilfælde er ingen adgangkode nødvendig for at forbinde til delingen."
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/de_DE/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/de_DE/openmediavault.po
@@ -1560,7 +1560,7 @@ msgstr "Leerlauf"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "Wenn 'Gäste sind zugelassen' ausgewählt und keine Anmeldeinformationen angegeben wurden, immer als Gast zugreifen. Immer als Gast zugreifen wenn 'Nur Gäste' ausgewählt ist; in diesem Fall wird kein Passwort benötigt um auf die Freigabe zuzugreifen."
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/el_GR/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/el_GR/openmediavault.po
@@ -1551,7 +1551,7 @@ msgstr "Αδρανές"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "Αν είναι επιλεγμένο το 'Επιτρέπονται επισκέπτες' και δεν δωθούν στοιχεία σύνδεσης, τότε η πρόσβαση γίνεται ως επισκέπτης. Αν είναι επιλεγμένο το 'Μόνο επισκέπτες' τότε η πρόσβαση γίνεται πάντα ως επισκέπτης, χωρίς να χρειάζεται συνθηματικό για την σύνδεση."
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/es_ES/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/es_ES/openmediavault.po
@@ -1554,7 +1554,7 @@ msgstr "Inactivo"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "Si se selecciona 'Permitir Invitados' y no se proporciona credenciales usuario/contraseña, entonces se accederá como invitado. Siempre se accede como invitado si se ha seleccionado 'Solo Invitados' , en ese caso no serán necesarios usuario y contraseña."
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/fr_FR/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/fr_FR/openmediavault.po
@@ -1559,7 +1559,7 @@ msgstr "Idle"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "Si 'Invités autorisés' est sélectionné et qu'aucun paramètre de connexion n'est fourni, alors l'accès ce fait en tant qu'invité. Si 'Invités uniquement' est sélectionné, l'accès se fait systématiquement en tant qu'invité. Dans ce cas, aucun mot de passe n'est requis pour se connecter au partage."
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/gl_ES/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/gl_ES/openmediavault.po
@@ -1554,7 +1554,7 @@ msgstr "Inactivo"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "Se selecciona «Permitidos os convidados» e non fornece credenciais, entón o acceso será como convidado. Cando seleccione «Só convidados» accederase sempre como convidado; neste caso non se require ningún contrasinal para conectarse ao recurso compartido."
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/hu_HU/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/hu_HU/openmediavault.po
@@ -1556,7 +1556,7 @@ msgstr "Tétlen"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "Ha az 'Engedélyezett vendégek' opció van kiválasztva és nem rendelkezik a bejelentkezéshez engedéllyel, akkor csak vendégként csatlakozhat. Vendégként mindig hozzáfér, ha a 'Csak vendégek' opció van kiválasztva. Ebben az esetben nincs szükség jelszóra a megosztások eléréséhez."
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/it_IT/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/it_IT/openmediavault.po
@@ -1556,7 +1556,7 @@ msgstr "Inattivo"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "Se l'opzione 'Ospiti consentiti' è selezionata e nessuna credenziale di accesso viene fornita, è possibile accedere come ospite. Si deve accedere sempre come ospite quando l'opzione 'Solo ospiti' è selezionata; in questo caso è richiesta la password per connettersi alla condivisione."
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/ja_JP/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/ja_JP/openmediavault.po
@@ -1551,7 +1551,7 @@ msgstr "Idle"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "'ゲストに許可'が選択され、ログイン資格情報が提供されない場合はゲストとしてアクセスします。'ゲストのみ'が選択された場合は、常にゲストとしてアクセスします。このケースでは共有に接続する際にパスワードは要求されません。"
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/ko_KR/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/ko_KR/openmediavault.po
@@ -1554,7 +1554,7 @@ msgstr "유휴"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "\"게스트 허용\"이 선택되고 로그인 자격 증명이 제공되지 않는 경우, 게스트로 접근됩니다. \"게스트만\"이 선택된 경우, 항상 게스트로 접근되며 공유에 연결하기 위한 암호가 필요하지 않습니다."
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/nl_NL/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/nl_NL/openmediavault.po
@@ -1556,9 +1556,9 @@ msgstr "Pauzestand"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
-msgstr "If 'Guests allowed' is selected and no login credential is provided, then access as guest. Always access as guest when 'Only guests' is selecting; in this case no password is required to connect to the share."
+msgstr "If 'Guests allowed' is selected and no login credential is provided, then access as guest. Always access as guest when 'Only guests' is selected; in this case no password is required to connect to the share."
 
 msgid ""
 "If set then the client will be challenged to supply a username and password "

--- a/deb/openmediavault/usr/share/openmediavault/locale/no_NO/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/no_NO/openmediavault.po
@@ -1552,7 +1552,7 @@ msgstr "Nøytral"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr ""
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/openmediavault.pot
+++ b/deb/openmediavault/usr/share/openmediavault/locale/openmediavault.pot
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "Idle"
 msgstr ""
 
-msgid "If 'Guests allowed' is selected and no login credential is provided, then access as guest. Always access as guest when 'Only guests' is selecting; in this case no password is required to connect to the share."
+msgid "If 'Guests allowed' is selected and no login credential is provided, then access as guest. Always access as guest when 'Only guests' is selected; in this case no password is required to connect to the share."
 msgstr ""
 
 msgid "If set then the client will be challenged to supply a username and password to connect to the module."

--- a/deb/openmediavault/usr/share/openmediavault/locale/pl_PL/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/pl_PL/openmediavault.po
@@ -1556,7 +1556,7 @@ msgstr "Zajęty"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "Jeśli zaznaczone jest \"Dopuść gości\" niepotrzebne jest logowanie, dostęp jako gość. Zawsze dopuszczanie jako gościa kiedy wybrane jest \"Tylko goście. Nie wymagane jest żadne hasło do zasobu\""
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/pt_PT/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/pt_PT/openmediavault.po
@@ -1552,7 +1552,7 @@ msgstr "Inativo"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "Se estiver seleccionado 'Permitido visitante' e nenhum dado de acesso foi fornecido, então entre como convidado. Aceda sempre como convidado quando 'Apenas Visitantes' está seleccionado; neste caso não será necessária senha de acesso para ligar à partilha."
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/ru_RU/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/ru_RU/openmediavault.po
@@ -1546,7 +1546,7 @@ msgstr "Бездействие"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "Если выбранно 'Гости разрешены' и не предусмотрено учетных пользователей, то доступ как гость. Всегда доступ в качестве гостя, когда выбранно «только гости»; в этом случае пароль не требуется для подключения к акции."
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/sl_SI/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/sl_SI/openmediavault.po
@@ -1551,7 +1551,7 @@ msgstr "Brezdelni način"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr ""
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/sv_SV/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/sv_SV/openmediavault.po
@@ -1553,7 +1553,7 @@ msgstr "Tomgångsläge"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "Om \"Gäster tillåtet\" är vald och inga inloggningsuppgifter lämnas, får du tillgång som gäst. Alltid tillgång som gäst när 'Endast gäster' är valt; I detta fall krävs inget lösenord för att ansluta till den delade resursen."
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/tr_TR/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/tr_TR/openmediavault.po
@@ -1551,7 +1551,7 @@ msgstr "Boş"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "Eğer 'Misafirler müsade edilmiştir' seçilmiş ve herhangi bir giriş bilgisi verilmemişse misafir olarak giriş yapınız. 'Sadece misafirler' seçili ise misafir olarak giriş yapınız; bu durumda paylaşıma ulaşmak için şifreye ihtiyacınız olmayacaktır."
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/uk_UK/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/uk_UK/openmediavault.po
@@ -1553,7 +1553,7 @@ msgstr "Неактивний"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "Якщо вибрати 'Гості дозволені' і не передбачено облікових користувачів, то доступ як гість. Завжди доступ в якості гостя, коли вибрано «тільки гості»; в цьому випадку пароль не потрібно для підключення до ресурсу."
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/zh_CN/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/zh_CN/openmediavault.po
@@ -1553,7 +1553,7 @@ msgstr "闲置"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "如果选择“允许访客”，用户没有提供登录凭证，那么让其以访客权限读写。如果选择“仅访客”，则全部用户以访客读写，用户不需要密码便可以连接共享。"
 

--- a/deb/openmediavault/usr/share/openmediavault/locale/zh_TW/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/zh_TW/openmediavault.po
@@ -1552,7 +1552,7 @@ msgstr "閒置"
 
 msgid ""
 "If 'Guests allowed' is selected and no login credential is provided, then "
-"access as guest. Always access as guest when 'Only guests' is selecting; in "
+"access as guest. Always access as guest when 'Only guests' is selected; in "
 "this case no password is required to connect to the share."
 msgstr "如果 '允許訪客' 被選用，但用戶沒提供登入憑證，則會讓他以訪客身分存取。當 '只允許訪客' 被選用，則永遠讓用戶以訪客身分存取；在這情況下，不需要密碼即可連接上共享。"
 

--- a/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/service/smb/Shares.js
+++ b/deb/openmediavault/var/www/openmediavault/js/omv/module/admin/service/smb/Shares.js
@@ -122,7 +122,7 @@ Ext.define("OMV.module.admin.service.smb.Share", {
 			value: "no",
 			plugins: [{
 				ptype: "fieldinfo",
-				text: _("If 'Guests allowed' is selected and no login credential is provided, then access as guest. Always access as guest when 'Only guests' is selecting; in this case no password is required to connect to the share.")
+				text: _("If 'Guests allowed' is selected and no login credential is provided, then access as guest. Always access as guest when 'Only guests' is selected; in this case no password is required to connect to the share.")
 			}]
 		},{
 			xtype: "checkbox",


### PR DESCRIPTION
<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->
This is a small text change

This changes locale strings from "is selecting" to "is selected". Is selecting is used incorrectly here, it's the present tense, whereas the sentence reads as though it should be past test "is selected". This is already present in the previous sentence in the locale files.

Thanks for your work on OMV!

Signed-off-by: Ryan Southgate <ryansouthgate8806@gmail.com>

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
