### PR TITLE
add code to skip adding debian-security on raspberrypi boards

### DIFF
--- a/deb/openmediavault-clamav/usr/share/openmediavault/workbench/route.d/services.clamav.scans.create.yaml
+++ b/deb/openmediavault-clamav/usr/share/openmediavault/workbench/route.d/services.clamav.scans.create.yaml
@@ -3,5 +3,5 @@ type: route
 data:
   url: "/services/clamav/scans/create"
   title: _("Create")
-  notificationTitle: _("Created on-access scan.")
+  notificationTitle: _("Created scheduled scan.")
   component: omv-services-clamav-scan-form-page

--- a/deb/openmediavault/srv/salt/omv/deploy/apt/default.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/apt/default.sls
@@ -20,7 +20,7 @@
 {% set config = salt['omv_conf.get']('conf.system.apt.distribution') %}
 {% set use_kernel_backports = salt['pillar.get']('default:OMV_APT_USE_KERNEL_BACKPORTS', True) -%}
 {% set proxy_config = salt['omv_conf.get']('conf.system.network.proxy') %}
-{% set use_os_security = salt['pillar.get']('default:OMV_APT_USE_OS_SECURITY', False) %}
+{% set use_os_security = salt['pillar.get']('default:OMV_APT_USE_OS_SECURITY', True) %}
 
 {% set pkg_repos = [] %}
 {% for value in salt['pkg.list_repos']().values() %}

--- a/deb/openmediavault/srv/salt/omv/deploy/apt/default.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/apt/default.sls
@@ -20,7 +20,7 @@
 {% set config = salt['omv_conf.get']('conf.system.apt.distribution') %}
 {% set use_kernel_backports = salt['pillar.get']('default:OMV_APT_USE_KERNEL_BACKPORTS', True) -%}
 {% set proxy_config = salt['omv_conf.get']('conf.system.network.proxy') %}
-{% set rpi = salt['pillar.get']('default:OMV_IS_RPI', False) %}
+{% set use_os_security = salt['pillar.get']('default:OMV_APT_USE_OS_SECURITY', False) %}
 
 {% set pkg_repos = [] %}
 {% for value in salt['pkg.list_repos']().values() %}

--- a/deb/openmediavault/srv/salt/omv/deploy/apt/default.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/apt/default.sls
@@ -111,7 +111,7 @@ remove_apt_sources_list_security_{{ loop.index0 }}:
       - repo: "{{ security_pkg_repo.line }}"
 {% endfor %}
 
-{% if not rpi | to_bool %}
+{% if not use_os_security | to_bool %}
 
 configure_apt_sources_list_os_security:
   file.managed:

--- a/deb/openmediavault/srv/salt/omv/deploy/apt/default.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/apt/default.sls
@@ -20,6 +20,7 @@
 {% set config = salt['omv_conf.get']('conf.system.apt.distribution') %}
 {% set use_kernel_backports = salt['pillar.get']('default:OMV_APT_USE_KERNEL_BACKPORTS', True) -%}
 {% set proxy_config = salt['omv_conf.get']('conf.system.network.proxy') %}
+{% set rpi = salt['pillar.get']('default:OMV_IS_RPI', False) %}
 
 {% set pkg_repos = [] %}
 {% for value in salt['pkg.list_repos']().values() %}
@@ -110,6 +111,8 @@ remove_apt_sources_list_security_{{ loop.index0 }}:
       - repo: "{{ security_pkg_repo.line }}"
 {% endfor %}
 
+{% if not rpi | to_bool %}
+
 configure_apt_sources_list_os_security:
   file.managed:
     - name: "/etc/apt/sources.list.d/openmediavault-os-security.list"
@@ -119,6 +122,8 @@ configure_apt_sources_list_os_security:
     - user: root
     - group: root
     - mode: 644
+
+{% endif %}
 
 refresh_apt_database:
   module.run:

--- a/deb/openmediavault/srv/salt/omv/deploy/apt/default.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/apt/default.sls
@@ -111,7 +111,7 @@ remove_apt_sources_list_security_{{ loop.index0 }}:
       - repo: "{{ security_pkg_repo.line }}"
 {% endfor %}
 
-{% if not use_os_security | to_bool %}
+{% if use_os_security | to_bool %}
 
 configure_apt_sources_list_os_security:
   file.managed:


### PR DESCRIPTION
Skip adding debian security on Raspbian

Raspbian and RaspberryPi OS (not 64bit) rebuild packages from debian-security.  If they do not change the version and the debian-security repo is enabled, apt will have a package checksum mismatch.

Fixes: package checksum mismatches

Signed-off-by: Aaron Murray <plugins@omv-extras.org>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
