### PR TITLE
Do not use {{ _selected[0].xyz }} for datatable actions

### DIFF
--- a/deb/openmediavault-clamav/debian/changelog
+++ b/deb/openmediavault-clamav/debian/changelog
@@ -1,4 +1,4 @@
-openmediavault-clamav (6.0-3) UNRELEASED; urgency=low
+openmediavault-clamav (6.0-4) UNRELEASED; urgency=low
 
   * Reimplement UI.
 

--- a/deb/openmediavault-clamav/usr/share/openmediavault/workbench/component.d/omv-services-clamav-onaccess-scan-datatable-page.yaml
+++ b/deb/openmediavault-clamav/usr/share/openmediavault/workbench/component.d/omv-services-clamav-onaccess-scan-datatable-page.yaml
@@ -40,4 +40,4 @@ data:
             service: ClamAV
             method: deleteOnAccessPath
             params:
-              uuid: "{{ _selected[0].uuid }}"
+              uuid: "{{ uuid }}"

--- a/deb/openmediavault-clamav/usr/share/openmediavault/workbench/component.d/omv-services-clamav-scan-datatable-page.yaml
+++ b/deb/openmediavault-clamav/usr/share/openmediavault/workbench/component.d/omv-services-clamav-scan-datatable-page.yaml
@@ -71,4 +71,4 @@ data:
             service: ClamAV
             method: deleteJob
             params:
-              uuid: "{{ _selected[0].uuid }}"
+              uuid: "{{ uuid }}"

--- a/deb/openmediavault-lvm2/debian/changelog
+++ b/deb/openmediavault-lvm2/debian/changelog
@@ -1,4 +1,4 @@
-openmediavault-lvm2 (6.0-1) UNRELEASED; urgency=low
+openmediavault-lvm2 (6.0-2) UNRELEASED; urgency=low
 
   * Reimplement UI.
 

--- a/deb/openmediavault-lvm2/usr/share/openmediavault/workbench/component.d/omv-storage-lvm-pv-datatable-page.yaml
+++ b/deb/openmediavault-lvm2/usr/share/openmediavault/workbench/component.d/omv-storage-lvm-pv-datatable-page.yaml
@@ -66,4 +66,4 @@ data:
             service: LogicalVolumeMgmt
             method: deletePhysicalVolume
             params:
-              devicefile: "{{ _selected[0].devicefile }}"
+              devicefile: "{{devicefile }}"

--- a/deb/openmediavault-lvm2/usr/share/openmediavault/workbench/component.d/omv-storage-lvm-vg-datatable-page.yaml
+++ b/deb/openmediavault-lvm2/usr/share/openmediavault/workbench/component.d/omv-storage-lvm-vg-datatable-page.yaml
@@ -83,4 +83,4 @@ data:
             service: LogicalVolumeMgmt
             method: deleteVolumeGroup
             params:
-              name: "{{ _selected[0].name }}"
+              name: "{{ name }}"

--- a/deb/openmediavault-usbbackup/debian/changelog
+++ b/deb/openmediavault-usbbackup/debian/changelog
@@ -1,4 +1,4 @@
-openmediavault-usbbackup (6.0-1) UNRELEASED; urgency=low
+openmediavault-usbbackup (6.0-2) UNRELEASED; urgency=low
 
   * Reimplement UI.
 

--- a/deb/openmediavault-usbbackup/usr/share/openmediavault/workbench/component.d/omv-services-usbbackup-job-datatable-page.yaml
+++ b/deb/openmediavault-usbbackup/usr/share/openmediavault/workbench/component.d/omv-services-usbbackup-job-datatable-page.yaml
@@ -63,4 +63,4 @@ data:
             service: UsbBackup
             method: delete
             params:
-              uuid: "{{ _selected[0].uuid }}"
+              uuid: "{{ uuid }}"

--- a/deb/openmediavault/workbench/src/app/pages/network/firewall/rules/firewall-rule-inet-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/firewall/rules/firewall-rule-inet-datatable-page.component.ts
@@ -135,7 +135,7 @@ export class FirewallRuleInetDatatablePageComponent {
             service: 'Iptables',
             method: 'deleteRule',
             params: {
-              uuid: '{{ _selected[0].uuid }}'
+              uuid: '{{ uuid }}'
             }
           }
         }

--- a/deb/openmediavault/workbench/src/app/pages/network/firewall/rules/firewall-rule-inet6-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/firewall/rules/firewall-rule-inet6-datatable-page.component.ts
@@ -135,7 +135,7 @@ export class FirewallRuleInet6DatatablePageComponent {
             service: 'Iptables',
             method: 'deleteRule',
             params: {
-              uuid: '{{ _selected[0].uuid }}'
+              uuid: '{{ uuid }}'
             }
           }
         }

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-datatable-page.component.ts
@@ -203,7 +203,7 @@ export class InterfaceDatatablePageComponent {
             service: 'Network',
             method: 'deleteInterface',
             params: {
-              uuid: '{{ _selected[0].uuid }}'
+              uuid: '{{ uuid }}'
             }
           }
         }

--- a/deb/openmediavault/workbench/src/app/pages/services/ftp/ftp-ban-rule-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/ftp/ftp-ban-rule-datatable-page.component.ts
@@ -55,7 +55,7 @@ export class FtpBanRuleDatatablePageComponent {
             service: 'FTP',
             method: 'deleteModBanRule',
             params: {
-              uuid: '{{ _selected[0].uuid }}'
+              uuid: '{{ uuid }}'
             }
           }
         }

--- a/deb/openmediavault/workbench/src/app/pages/services/ftp/ftp-share-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/ftp/ftp-share-datatable-page.component.ts
@@ -60,7 +60,7 @@ export class FtpShareDatatablePageComponent {
             service: 'FTP',
             method: 'deleteShare',
             params: {
-              uuid: '{{ _selected[0].uuid }}'
+              uuid: '{{ uuid }}'
             }
           }
         }

--- a/deb/openmediavault/workbench/src/app/pages/services/nfs/nfs-share-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/nfs/nfs-share-datatable-page.component.ts
@@ -63,7 +63,7 @@ export class NfsShareDatatablePageComponent {
             service: 'NFS',
             method: 'deleteShare',
             params: {
-              uuid: '{{ _selected[0].uuid }}'
+              uuid: '{{ uuid }}'
             }
           }
         }

--- a/deb/openmediavault/workbench/src/app/pages/services/rsync/rsync-module-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/rsync/rsync-module-datatable-page.component.ts
@@ -74,7 +74,7 @@ export class RsyncModuleDatatablePageComponent {
             service: 'Rsyncd',
             method: 'deleteModule',
             params: {
-              uuid: '{{ _selected[0].uuid }}'
+              uuid: '{{ uuid }}'
             }
           }
         }

--- a/deb/openmediavault/workbench/src/app/pages/services/rsync/rsync-task-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/rsync/rsync-task-datatable-page.component.ts
@@ -123,7 +123,7 @@ export class RsyncTaskDatatablePageComponent {
             service: 'Rsync',
             method: 'delete',
             params: {
-              uuid: '{{ _selected[0].uuid }}'
+              uuid: '{{ uuid }}'
             }
           }
         }

--- a/deb/openmediavault/workbench/src/app/pages/services/smb/smb-share-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/smb/smb-share-datatable-page.component.ts
@@ -88,7 +88,7 @@ export class SmbShareDatatablePageComponent {
             service: 'SMB',
             method: 'deleteShare',
             params: {
-              uuid: '{{ _selected[0].uuid }}'
+              uuid: '{{ uuid }}'
             }
           }
         }

--- a/deb/openmediavault/workbench/src/app/pages/storage/filesystems/filesystem-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/storage/filesystems/filesystem-datatable-page.component.ts
@@ -264,7 +264,7 @@ export class FilesystemDatatablePageComponent {
             service: 'FileSystemMgmt',
             method: 'umount',
             params: {
-              id: '{{ _selected[0].devicefile }}',
+              id: '{{ devicefile }}',
               fstab: true
             },
             progressMessage: gettext('Please wait, unmounting the file system ...')

--- a/deb/openmediavault/workbench/src/app/pages/storage/md/md-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/storage/md/md-datatable-page.component.ts
@@ -179,7 +179,7 @@ export class MdDatatablePageComponent {
             service: 'RaidMgmt',
             method: 'delete',
             params: {
-              devicefile: '{{ _selected[0].devicefile }}'
+              devicefile: '{{ devicefile }}'
             }
           }
         }

--- a/deb/openmediavault/workbench/src/app/pages/storage/smart/smart-task-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/storage/smart/smart-task-datatable-page.component.ts
@@ -91,7 +91,7 @@ export class SmartTaskDatatablePageComponent {
             service: 'Smart',
             method: 'deleteScheduledTest',
             params: {
-              uuid: '{{ _selected[0].uuid }}'
+              uuid: '{{ uuid }}'
             }
           }
         }

--- a/deb/openmediavault/workbench/src/app/pages/system/certificates/ssh/ssh-certificate-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/system/certificates/ssh/ssh-certificate-datatable-page.component.ts
@@ -143,7 +143,7 @@ export class SshCertificateDatatablePageComponent {
             service: 'CertificateMgmt',
             method: 'deleteSsh',
             params: {
-              uuid: '{{ _selected[0].uuid }}'
+              uuid: '{{ uuid }}'
             }
           }
         }

--- a/deb/openmediavault/workbench/src/app/pages/system/certificates/ssl/ssl-certificate-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/system/certificates/ssl/ssl-certificate-datatable-page.component.ts
@@ -69,7 +69,7 @@ export class SslCertificateDatatablePageComponent {
             service: 'CertificateMgmt',
             method: 'delete',
             params: {
-              uuid: '{{ _selected[0].uuid }}'
+              uuid: '{{ uuid }}'
             }
           }
         }

--- a/deb/openmediavault/workbench/src/app/pages/system/cron/cron-task-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/system/cron/cron-task-datatable-page.component.ts
@@ -118,7 +118,7 @@ export class CronTaskDatatablePageComponent {
             service: 'Cron',
             method: 'delete',
             params: {
-              uuid: '{{ _selected[0].uuid }}'
+              uuid: '{{ uuid }}'
             }
           }
         }

--- a/deb/openmediavault/workbench/src/app/pages/usermgmt/groups/group-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/usermgmt/groups/group-datatable-page.component.ts
@@ -96,7 +96,7 @@ export class GroupDatatablePageComponent {
             service: 'UserMgmt',
             method: 'deleteGroup',
             params: {
-              name: '{{ _selected[0].name }}'
+              name: '{{ name }}'
             }
           }
         }

--- a/deb/openmediavault/workbench/src/app/pages/usermgmt/users/user-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/usermgmt/users/user-datatable-page.component.ts
@@ -93,7 +93,7 @@ export class UserDatatablePageComponent {
             service: 'UserMgmt',
             method: 'deleteUser',
             params: {
-              name: '{{ _selected[0].name }}'
+              name: '{{ name }}'
             }
           }
         }


### PR DESCRIPTION
... that support multi-selection. Use `{{ xyz }}` instead. `{{ _selected[0].xyz }}` can still be used for actions that support only single-selection. The intention of using `_selected` was to show plugin devs how to process the values of the selected row(s).

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
