### PR TITLE
Adapt module.run calls to new syntax

### DIFF
--- a/deb/openmediavault-forkeddaapd/debian/changelog
+++ b/deb/openmediavault-forkeddaapd/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-forkeddaapd (5.0.4-1) stable; urgency=low
+
+  * Adapt SaltStack module.run calls to new syntax.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Sat, 24 Apr 2021 12:14:59 +0200
+
 openmediavault-forkeddaapd (5.0.3-2) stable; urgency=low
 
   * Backported #951 to fix bug in forked-daapd.conf.

--- a/deb/openmediavault-forkeddaapd/srv/salt/omv/deploy/forked-daapd/default.sls
+++ b/deb/openmediavault-forkeddaapd/srv/salt/omv/deploy/forked-daapd/default.sls
@@ -42,17 +42,16 @@ start_forked_daapd_service:
 
 monitor_forked_daapd_service:
   module.run:
-    - name: monit.monitor
-    - m_name: forked-daapd
+    - monit.monitor:
+      - name: forked-daapd
     - require:
       - service: start_forked_daapd_service
 
 {% else %}
 
 unmonitor_forked_daapd_service:
-  module.run:
-    - name: monit.unmonitor
-    - m_name: forked-daapd
+  cmd.run:
+    - name: monit unmonitor forked-daapd || true
 
 stop_forked_daapd_service:
   service.dead:

--- a/deb/openmediavault-nut/debian/changelog
+++ b/deb/openmediavault-nut/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-nut (5.2.1-1) stable; urgency=low
+
+  * Adapt SaltStack module.run calls to new syntax.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Sat, 24 Apr 2021 14:26:48 +0200
+
 openmediavault-nut (5.2.0-1) stable; urgency=low
 
   * Adapt to modified OMV Python API.

--- a/deb/openmediavault-nut/srv/salt/omv/deploy/nut/default.sls
+++ b/deb/openmediavault-nut/srv/salt/omv/deploy/nut/default.sls
@@ -175,8 +175,9 @@ start_nut_server_service:
       - file: configure_nut_upsmon_conf
 
 monitor_nut_server_service:
-  monit.monitor:
-    - name: nut-server
+  module.run:
+    - monit.monitor:
+      - name: nut-server
 
 {% endif %}
 
@@ -188,8 +189,9 @@ start_nut_monitor_service:
       - file: configure_nut_upsmon_conf
 
 monitor_nut_monitor_service:
-  monit.monitor:
-    - name: nut-monitor
+  module.run:
+    - monit.monitor:
+      - name: nut-monitor
 
 {% else %}
 
@@ -198,12 +200,12 @@ remove_nut_udev_serialups_rule:
   - name: "/etc/udev/rules.d/99-openmediavault-nut-serialups.rules"
 
 unmonitor_nut_monitor_service:
-  monit.unmonitor:
-    - name: nut-monitor
+  cmd.run:
+    - name: monit unmonitor nut-monitor || true
 
 unmonitor_nut_server_service:
-  monit.unmonitor:
-    - name: nut-server
+  cmd.run:
+    - name: monit unmonitor nut-server || true
 
 stop_nut_monitor_service:
   service.dead:

--- a/deb/openmediavault-shairport/debian/changelog
+++ b/deb/openmediavault-shairport/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-shairport (5.0.3-1) stable; urgency=low
+
+  * Adapt SaltStack module.run calls to new syntax.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Sat, 24 Apr 2021 12:16:31 +0200
+
 openmediavault-shairport (5.0.2-1) stable; urgency=low
 
   * Update locales.

--- a/deb/openmediavault-shairport/srv/salt/omv/deploy/shairport-sync/default.sls
+++ b/deb/openmediavault-shairport/srv/salt/omv/deploy/shairport-sync/default.sls
@@ -42,17 +42,16 @@ start_shairport_sync_service:
 
 monitor_shairport_sync_service:
   module.run:
-    - name: monit.monitor
-    - m_name: shairport-sync
+    - monit.monitor:
+      - name: shairport-sync
     - require:
       - service: start_shairport_sync_service
 
 {% else %}
 
 unmonitor_shairport_sync_service:
-  module.run:
-    - name: monit.unmonitor
-    - m_name: shairport-sync
+  cmd.run:
+    - name: monit unmonitor shairport-sync || true
 
 stop_shairport_sync_service:
   service.dead:

--- a/deb/openmediavault-usbbackup/debian/changelog
+++ b/deb/openmediavault-usbbackup/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-usbbackup (5.0.8-1) stable; urgency=low
+
+  * Adapt SaltStack module.run calls to new syntax.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Sat, 24 Apr 2021 12:17:13 +0200
+
 openmediavault-usbbackup (5.0.7-1) stable; urgency=low
 
   * Issue #720: Execute backup job only when filesystems are up.

--- a/deb/openmediavault-usbbackup/srv/salt/omv/deploy/usbbackup/default.sls
+++ b/deb/openmediavault-usbbackup/srv/salt/omv/deploy/usbbackup/default.sls
@@ -107,7 +107,7 @@ configure_usbbackup_systemd_unitfile_{{ job.devicefile | md5 }}:
 
 usbbackup_systemctl_daemon_reload:
   module.run:
-    - name: service.systemctl_reload
+    - service.systemctl_reload:
 
 {% for job in jobs %}
 enable_usbbackup_systemd_unitfile_{{ job.devicefile | md5 }}:

--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -2,6 +2,7 @@ openmediavault (5.6.5-1) stable; urgency=low
 
   * Update locales.
   * Fix permission-policy configuration in nginx.
+  * Adapt SaltStack module.run calls to new syntax.
   * Issue #1007: Run postfix notification scripts with dedicated user
     openmediavault-notify.
 

--- a/deb/openmediavault/srv/salt/omv/deploy/apt/default.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/apt/default.sls
@@ -127,4 +127,4 @@ configure_apt_sources_list_os_security:
 
 refresh_apt_database:
   module.run:
-    - name: pkg.refresh_db
+    - pkg.refresh_db:

--- a/deb/openmediavault/srv/salt/omv/deploy/collectd/default.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/collectd/default.sls
@@ -51,8 +51,8 @@ start_collectd_service:
 
 monitor_collectd_service:
   module.run:
-    - name: monit.monitor
-    - m_name: collectd
+    - monit.monitor:
+      - name: collectd
     - require:
       - service: start_collectd_service
 
@@ -78,9 +78,8 @@ remove_mkrrdgraph_cron_job:
     - name: "/etc/cron.d/openmediavault-mkrrdgraph"
 
 unmonitor_collectd_service:
-  module.run:
-    - name: monit.unmonitor
-    - m_name: collectd
+  cmd.run:
+    - name: monit unmonitor collectd || true
 
 stop_collectd_service:
   service.dead:

--- a/deb/openmediavault/srv/salt/omv/deploy/iptables/10firewall.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/iptables/10firewall.sls
@@ -70,7 +70,7 @@ configure_firewall_unit_file:
 
 iptables_systemctl_daemon_reload:
   module.run:
-    - name: service.systemctl_reload
+    - service.systemctl_reload:
 
 enable_firewall_service:
   service.enabled:

--- a/deb/openmediavault/srv/salt/omv/deploy/nginx/default.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/nginx/default.sls
@@ -42,7 +42,7 @@ restart_nginx_service:
 
 monitor_nginx_service:
   module.run:
-    - name: monit.monitor
-    - m_name: nginx
+    - monit.monitor:
+      - name: nginx
     - require:
       - service: restart_nginx_service

--- a/deb/openmediavault/srv/salt/omv/deploy/phpfpm/default.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/phpfpm/default.sls
@@ -42,7 +42,7 @@ restart_phpfpm_service:
 
 monitor_phpfpm_service:
   module.run:
-    - name: monit.monitor
-    - m_name: php-fpm
+    - monit.monitor:
+      - name: php-fpm
     - require:
       - service: restart_phpfpm_service

--- a/deb/openmediavault/srv/salt/omv/deploy/proftpd/default.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/proftpd/default.sls
@@ -37,8 +37,8 @@ start_proftpd_service:
 
 monitor_proftpd_service:
   module.run:
-    - name: monit.monitor
-    - m_name: proftpd
+    - monit.monitor:
+      - name: proftpd
     - require:
       - service: start_proftpd_service
 
@@ -48,9 +48,8 @@ start_proftpd_service:
   test.nop
 
 unmonitor_proftpd_service:
-  module.run:
-    - name: monit.unmonitor
-    - m_name: proftpd
+  cmd.run:
+    - name: monit unmonitor proftpd || true
 
 stop_proftpd_service:
   service.dead:

--- a/deb/openmediavault/srv/salt/omv/deploy/rrdcached/default.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/rrdcached/default.sls
@@ -82,17 +82,16 @@ start_rrdcached_service:
 
 monitor_rrdcached_service:
   module.run:
-    - name: monit.monitor
-    - m_name: rrdcached
+    - monit.monitor:
+      - name: rrdcached
     - require:
       - service: start_rrdcached_service
 
 {% else %}
 
 unmonitor_rrdcached_service:
-  module.run:
-    - name: monit.unmonitor
-    - m_name: rrdcached
+  cmd.run:
+    - name: monit unmonitor rrdcached || true
 
 stop_rrdcached_service:
   service.dead:

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd/10sharedfolders.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd/10sharedfolders.sls
@@ -78,7 +78,7 @@ configure_sharedfolder_{{ sharedfolder.name }}_mount_unit_file:
 
 sharedfolder_mount_units_systemctl_daemon_reload:
   module.run:
-    - name: service.systemctl_reload
+    - service.systemctl_reload:
 
 {% if sharedfolders_dir_enabled | to_bool %}
 {% for sharedfolder in sharedfolder_config %}

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd/20tmp.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd/20tmp.sls
@@ -37,6 +37,6 @@ configure_tmp_mount_unit_file:
 
 tmp_mount_unit_systemctl_daemon_reload:
   module.run:
-    - name: service.systemctl_reload
+    - service.systemctl_reload:
     - onchanges:
       - file: configure_tmp_mount_unit_file

--- a/deb/openmediavault/srv/salt/omv/refresh/default.sls
+++ b/deb/openmediavault/srv/salt/omv/refresh/default.sls
@@ -17,10 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
 
-refresh_pillar:
-  module.run:
-    - name: saltutil.refresh_pillar
-
 refresh_grains:
   module.run:
-    - name: saltutil.refresh_grains
+    - saltutil.refresh_grains:
+      - refresh_pillar: True


### PR DESCRIPTION
- Adapt module.run calls to new syntax
- Remove useless call of saltutil.refresh_pillar
- Use cmd.run to monit.unmonitor services. Sadly it is not possible to use the monit state to unmonitor a service because monit.summary module has a bug (https://github.com/saltstack/salt/issues/54753).

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
