### PR TITLE
Issue #1025: User names that are pure numbers are not displayed.

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -8,6 +8,15 @@ openmediavault (6.0-6) UNRELEASED; urgency=low
 
  -- Volker Theile <volker.theile@openmediavault.org>  Mon, 14 Dec 2020 20:28:37 +0100
 
+openmediavault (5.6.6-1) stable; urgency=low
+
+  * Issue #1025: User names that are pure numbers are not displayed.
+    Numeric user/group names are allowed in Debian, because of that
+    the user import dialog does not support GIDs in the <group> field
+    anymore, all specified groups are interpreted as names now.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Fri, 07 May 2021 15:24:25 +0200
+
 openmediavault (5.6.5-2) stable; urgency=low
 
   * Update locales.

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/usermgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/usermgmt.inc
@@ -114,8 +114,8 @@ finish:
 	}
 
 	/**
-	 * Return info about an user by name or id.
-	 * @param id The user identifier.
+	 * Return info about an user by their name or UID.
+	 * @param id The user identifier; name or UID.
 	 * @return Returns an associative array with the user information
 	 *   or FALSE if the user does not exist.
 	 */
@@ -230,8 +230,8 @@ finish:
 	}
 
 	/**
-	 * Return info about a group by name or id.
-	 * @param id The group identifier.
+	 * Return info about a group by their name or GID.
+	 * @param id The group identifier; name or GID.
 	 * @return Returns an associative array with the group information
 	 *   or FALSE if the group does not exist.
 	 */
@@ -545,7 +545,10 @@ finish:
 		}
 		if (array_key_exists("groups", $params) &&
 				!empty($params['groups'])) {
-			// Make sure the specified groups exists.
+			// Make sure the specified groups exists. Note, the groups
+			// are handled as group names and NOT as GIDs. This is the
+			// only way to support numeric group names.
+			// https://manpages.debian.org/buster/passwd/groupadd.8.en.html#CAVEATS
 			foreach ($params['groups'] as $groupk => $groupv) {
 				$group = new \OMV\System\Group($groupv);
 				$group->assertExists();

--- a/deb/openmediavault/usr/share/php/openmediavault/system/group.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/group.inc
@@ -34,10 +34,14 @@ class Group {
 	/**
 	 * Constructor
 	 * @param id The name or GID of the system group.
+	 *   If \em id is an integer, then it is assumed to be a GID,
+	 *   otherwise it is handled as a group name. Numeric strings
+	 *   are always handled as group names.
+	 * @see https://manpages.debian.org/buster/passwd/groupadd.8.en.html#CAVEATS
 	 */
 	public function __construct($id) {
-		if (is_numeric($id))
-			$this->gid = intval($id);
+		if (is_int($id))
+			$this->gid = $id;
 		else
 			$this->name = $id;
 	}

--- a/deb/openmediavault/usr/share/php/openmediavault/system/user.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/user.inc
@@ -45,10 +45,14 @@ class User {
 	/**
 	 * Constructor
 	 * @param id The name or UID of the system user.
+	 *   If \em id is an integer, then it is assumed to be an UID,
+	 *   otherwise it is handled as an user name. Numeric strings
+	 *   are always handled as user names.
+	 * @see https://manpages.debian.org/buster/passwd/useradd.8.en.html#CAVEATS
 	 */
 	public function __construct($id) {
-		if (is_numeric($id))
-			$this->uid = intval($id);
+		if (is_int($id))
+			$this->uid = $id;
 		else
 			$this->name = $id;
 	}

--- a/deb/openmediavault/workbench/src/app/pages/usermgmt/groups/group-import-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/usermgmt/groups/group-import-form-page.component.ts
@@ -36,7 +36,7 @@ export class GroupImportFormPageComponent {
       {
         type: 'textarea',
         name: 'csv',
-        value: '# <name>;<gid>;<comment>',
+        value: '# <groupname>;<gid>;<comment>',
         hint: gettext('Each line represents a group.'),
         monospaced: true
       }

--- a/deb/openmediavault/workbench/src/app/pages/usermgmt/users/user-import-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/usermgmt/users/user-import-form-page.component.ts
@@ -37,7 +37,7 @@ export class UserImportFormPageComponent {
         type: 'textarea',
         name: 'csv',
         value:
-          '# <name>;<uid>;<comment>;<email>;<password>;<shell>;<group,group,...>;<disallowusermod>',
+          '# <username>;<uid>;<comment>;<email>;<password>;<shell>;<groupname,groupname,...>;<disallowusermod>',
         hint: gettext(
           'Each line represents a user. Note, the password must be entered in plain text.'
         ),


### PR DESCRIPTION
This also affects:
https://github.com/openmediavault/openmediavault/commit/a975de8af0c3005ecb3331f47e37dd130b67cffa.
https://forum.openmediavault.org/index.php?thread/38298-cannot-assign-imported-user-to-groups-error-message-the-group-does-not-exist/

Fixes: https://github.com/openmediavault/openmediavault/issues/1025

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
