### PR TITLE
Allow bridges without slave interface

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/bridge.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/bridge.j2
@@ -68,7 +68,9 @@ network:
 {%- if interface.mtu > 0 %}
       mtu: {{ interface.mtu }}
 {%- endif %}
+{%- if interface.slaves | length > 0 %}
       interfaces:
 {%- for slave in interface.slaves.split(',') %}
       - {{ slave }}
 {%- endfor %}
+{%- endif %}

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-bridge-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-bridge-form-page.component.ts
@@ -78,22 +78,6 @@ export class InterfaceBridgeFormPageComponent {
               prop: 'devicename'
             }
           ]
-        },
-        validators: {
-          required: true,
-          custom: [
-            {
-              constraint: {
-                operator: '>=',
-                arg0: {
-                  operator: 'length',
-                  arg0: { prop: 'slaves' }
-                },
-                arg1: 1
-              },
-              errorData: gettext('At least one network interface is required.')
-            }
-          ]
         }
       },
       {


### PR DESCRIPTION
With a nice KVM plugin now available, i was trying to move some of my Desktop's VMs over to my NAS so i can access them from anywhere. In some cases, it's useful (or necessary) to have a network between guests that is not tied to any physical interface, i.e. a guest-only network. I typically achieve this by simply creating an empty bridge and then connecting VM interfaces to it as necessary.

This PR removes the requirement of having at least one slave interface on a bridge, making it possible to fully manage such setups via the OMV webinterface, rather than manually tweaking netplan settings (which is prone to error and contains the risk of being overwritten when changing settings in the GUI)

The change seems fairly straightforward. I tested this locally and the main bump in the road was that the webinterface wouldn't allow me to supply an empty list of slave interfaces. I'm not deep into the codebase, but the places i looked through didn't seem to require any other changes than the ones in this commit.