### PR TITLE
Issue #920: Add postfix throttling

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,3 +1,15 @@
+openmediavault (5.6.9-1) stable; urgency=low
+
+  * Issue #920: Add postfix throttling. The maximal number of parallel
+    deliveries to the same destination is limited to 2. A delay of 1s
+    between each message to the same receiving domain is set. Both
+    can be customized by the following environment variables:
+    - OMV_POSTFIX_MAIN_DEFAULT_DESTINATION_CONCURRENCY_LIMIT
+    - OMV_POSTFIX_MAIN_DEFAULT_DESTINATION_RATE_DELAY
+    Throttling can be disabled via OMV_POSTFIX_MAIN_THROTTLING_ENABLED.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Thu, 10 Jun 2021 07:39:23 +0200
+
 openmediavault (5.6.8-1) stable; urgency=low
 
   * Update locales.

--- a/deb/openmediavault/debian/openmediavault.postinst
+++ b/deb/openmediavault/debian/openmediavault.postinst
@@ -315,6 +315,9 @@ case "$1" in
 		if dpkg --compare-versions "$2" lt-nl "5.6.8"; then
 		  omv_module_set_dirty hostname
 		fi
+		if dpkg --compare-versions "$2" lt-nl "5.6.9"; then
+		  omv_module_set_dirty postfix
+		fi
 
 		########################################################################
 		# Trigger the restart of the omv-engined daemon to load and use the

--- a/deb/openmediavault/srv/salt/omv/deploy/postfix/files/main.cf.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/postfix/files/main.cf.j2
@@ -17,6 +17,9 @@
 {%- set alias_maps = salt['pillar.get']('default:OMV_POSTFIX_MAIN_ALIAS_MAPS', 'hash:/etc/aliases') -%}
 {%- set transport_maps = salt['pillar.get']('default:OMV_POSTFIX_MAIN_TRANSPORT_MAPS', 'hash:/etc/postfix/transport') -%}
 {%- set message_size_limit = salt['pillar.get']('default:OMV_POSTFIX_MAIN_MESSAGE_SIZE_LIMIT', 10240000) -%}
+{%- set throttling_enabled = salt['pillar.get']('default:OMV_POSTFIX_MAIN_THROTTLING_ENABLED', 'yes') -%}
+{%- set default_destination_concurrency_limit = salt['pillar.get']('default:OMV_POSTFIX_MAIN_DEFAULT_DESTINATION_CONCURRENCY_LIMIT', 2) -%}
+{%- set default_destination_rate_delay = salt['pillar.get']('default:OMV_POSTFIX_MAIN_DEFAULT_DESTINATION_RATE_DELAY', '1s') -%}
 {{ pillar['headers']['multiline'] }}
 compatibility_level = {{ compatibility_level }}
 {%- if grains['domain'] | length > 0 %}
@@ -50,3 +53,7 @@ smtp_header_checks = regexp:{{ smtp_header_checks }}
 alias_maps = {{ alias_maps }}
 transport_maps = {{ transport_maps }}
 message_size_limit = {{ message_size_limit }}
+{%- if throttling_enabled | to_bool %}
+default_destination_concurrency_limit = {{ default_destination_concurrency_limit }}
+default_destination_rate_delay = {{ default_destination_rate_delay }}
+{%- endif %}


### PR DESCRIPTION
The maximal number of parallel deliveries to the same destination is limited to 2. A delay of 1s between each message to the same receiving domain is set. Both can be customized by the following environment variables:

- OMV_POSTFIX_MAIN_DEFAULT_DESTINATION_CONCURRENCY_LIMIT
- OMV_POSTFIX_MAIN_DEFAULT_DESTINATION_RATE_DELAY

Throttling can be disabled via OMV_POSTFIX_MAIN_THROTTLING_ENABLED.

Fixes: https://github.com/openmediavault/openmediavault/issues/920

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
