### PR TITLE
Include FQDN in local host entry

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/hosts/10default.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/hosts/10default.sls
@@ -36,7 +36,7 @@ configure_hosts_default_ipv4:
         {{ pillar['headers']['auto_generated'] }}
         {{ pillar['headers']['warning'] }}
         127.0.0.1 localhost.localdomain localhost
-        127.0.1.1 {{ dns_config.hostname }}
+        127.0.1.1 {{ fqdn }} {{ alias }}
     - user: root
     - group: root
     - mode: 644


### PR DESCRIPTION
Generated /etc/hosts file pointed 127.0.1.1 to bare hostname causing
`hostname -f` to return only that instead of FQDN for systems with
defined domain.

Signed-off-by: Jacek Tomasiak <jacek.tomasiak@gmail.com>
