### PR TITLE
Add option to show the path of the shared folder or mount point with which this field is associated

### DIFF
--- a/deb/openmediavault/workbench/src/app/core/components/limn-ui/form/components/form-folderbrowser/form-folderbrowser.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/limn-ui/form/components/form-folderbrowser/form-folderbrowser.component.html
@@ -1,3 +1,16 @@
+<mat-form-field *ngIf="config.dirVisible"
+                fxFlex="25"
+                [formGroup]="formGroup">
+  <mat-label translate>Base path</mat-label>
+  <input *ngIf="config.dirVisible"
+         matInput
+         type="text"
+         class="omv-text-no-wrap"
+         [ngClass]="{'omv-text-monospaced': config.monospaced}"
+         disabled="true"
+         [matTooltip]="dirPath"
+         [value]="dirPath">
+</mat-form-field>
 <mat-form-field #origin="cdkOverlayOrigin"
                 #trigger
                 cdkOverlayOrigin
@@ -8,8 +21,7 @@
     <mat-icon [svgIcon]="config.icon"></mat-icon>&nbsp;
   </div>
   <mat-label>{{ config.label | translate }}</mat-label>
-  <input
-         matInput
+  <input matInput
          type="text"
          [ngClass]="{'omv-text-monospaced': config.monospaced}"
          [formControlName]="config.name"

--- a/deb/openmediavault/workbench/src/app/core/components/limn-ui/form/components/form-folderbrowser/form-folderbrowser.component.scss
+++ b/deb/openmediavault/workbench/src/app/core/components/limn-ui/form/components/form-folderbrowser/form-folderbrowser.component.scss
@@ -12,3 +12,7 @@ $mat-typography-config: mat.define-typography-config();
   font-size: mat.font-size($mat-typography-config, body-1);
   padding: $omv-padding;
 }
+
+.mat-form-field + .mat-form-field {
+  padding-left: 12px;
+}

--- a/deb/openmediavault/workbench/src/app/core/components/limn-ui/models/form-field-config.type.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/limn-ui/models/form-field-config.type.ts
@@ -208,6 +208,9 @@ export type FormFieldConfig = {
   // The name of the field that contains the UUID of the
   // shared folder or mount point configuration object.
   dirRefIdField?: string;
+  // Set to `true` to show the path of the database object
+  // specified with `dirType` and `dirRefIdField`.
+  dirVisible?: boolean;
 
   // --- numberInput | slider ---
   step?: number;


### PR DESCRIPTION
![Peek 2021-07-10 18-48](https://user-images.githubusercontent.com/1897962/125170446-67af4c00-e1af-11eb-87a3-da174f875893.gif)

Signed-off-by: Volker Theile <votdev@gmx.de>

<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
