### PR TITLE
Add option to enable showing users home in FTP folder list.

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -10,6 +10,8 @@ openmediavault (6.0-23) UNRELEASED; urgency=low
   * Introduce environment variable OMV_POSTFIX_MAIN_DEFAULT_TRANSPORT.
     To deactivate the sending of emails without affecting the
     additional notification sinks set it to 'discard'.
+  * Add option to FTP settings to display the home directory of the
+    user in the browse list.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Mon, 14 Dec 2020 20:28:37 +0100
 

--- a/deb/openmediavault/srv/salt/omv/deploy/proftpd/modules/10mod_core.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/proftpd/modules/10mod_core.sls
@@ -1,5 +1,6 @@
 {% set dns_config = salt['omv_conf.get']('conf.system.network.dns') %}
 {% set ftp_config = salt['omv_conf.get']('conf.service.ftp') %}
+{% set homedir_config = salt['omv_conf.get']('conf.system.usermngmnt.homedir') %}
 
 configure_proftpd_mod_core:
   file.managed:
@@ -10,6 +11,7 @@ configure_proftpd_mod_core:
     - context:
         dns_config: {{ dns_config | json }}
         ftp_config: {{ ftp_config | json }}
+        homedir_config: {{ homedir_config | json }}
     - user: root
     - group: root
     - mode: 644

--- a/deb/openmediavault/srv/salt/omv/deploy/proftpd/modules/20mod_vroot.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/proftpd/modules/20mod_vroot.sls
@@ -18,6 +18,7 @@
 # along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
 
 {% set config = salt['omv_conf.get']('conf.service.ftp') %}
+{% set homedir_config = salt['omv_conf.get']('conf.system.usermngmnt.homedir') %}
 
 configure_proftpd_mod_vroot:
   file.append:
@@ -27,5 +28,6 @@ configure_proftpd_mod_vroot:
     - template: jinja
     - context:
         config: {{ config | json }}
+        homedir_config: {{ homedir_config | json }}
     - watch_in:
       - service: start_proftpd_service

--- a/deb/openmediavault/srv/salt/omv/deploy/proftpd/modules/files/mod_core.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/proftpd/modules/files/mod_core.j2
@@ -154,3 +154,15 @@ DisplayLogin {{ display_login }}
 {%- endif %}
 </Directory>
 {% endfor -%}
+{%- if ftp_config.homesenable | to_bool and homedir_config.enable | to_bool -%}
+<Directory ~/%u>
+  <Limit ALL>
+    AllowUser OR %u
+    DenyAll
+  </Limit>
+  <Limit READ DIRS>
+    AllowUser OR %u
+    DenyAll
+  </Limit>
+</Directory>
+{%- endif %}

--- a/deb/openmediavault/srv/salt/omv/deploy/proftpd/modules/files/mod_vroot.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/proftpd/modules/files/mod_vroot.j2
@@ -6,9 +6,13 @@ LoadModule mod_vroot.c
   VRootLog {{ v_root_log }}
 {%- for share in config.shares.share -%}
 {%- if share.enable | to_bool -%}
-{%- set sfname = salt['omv_conf.get_sharedfolder_path'](share.sharedfolderref) -%}
-{%- set sfpath = salt['omv_conf.get_sharedfolder_name'](share.sharedfolderref) %}
-  VRootAlias "{{ sfname }}" "{{ sfpath.rstrip('/') }}"
+{%- set sfpath = salt['omv_conf.get_sharedfolder_path'](share.sharedfolderref) -%}
+{%- set sfname = salt['omv_conf.get_sharedfolder_name'](share.sharedfolderref) %}
+  VRootAlias "{{ sfpath }}" "/{{ sfname.rstrip('/') }}"
 {%- endif -%}
 {%- endfor %}
+{%- if config.homesenable | to_bool and homedir_config.enable | to_bool -%}
+{%- set sfpath = salt['omv_conf.get_sharedfolder_path'](homedir_config.sharedfolderref) %}
+  VRootAlias "{{ sfpath.rstrip('/') }}/%u/" "/%u"
+{%- endif %}
 </IfModule>

--- a/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_6.0.0.sh
+++ b/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_6.0.0.sh
@@ -23,6 +23,7 @@ set -e
 
 . /usr/share/openmediavault/scripts/helper-functions
 
+omv_config_add_key "/config/services/ftp" "homesenable" "0"
 omv_config_add_key "/config/system/fstab/mntent" "comment" ""
 omv_config_add_key "/config/system/fstab/mntent" "usagewarnthreshold" "85"
 

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.ftp.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.ftp.json
@@ -112,6 +112,10 @@
 			"type": "boolean",
 			"default": false
 		},
+		"homesenable": {
+			"type": "boolean",
+			"default": false
+		},
 		"extraoptions": {
 			"type": "string",
 			"default": ""

--- a/deb/openmediavault/usr/share/openmediavault/locale/openmediavault.pot
+++ b/deb/openmediavault/usr/share/openmediavault/locale/openmediavault.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-07 10:41+0200\n"
+"POT-Creation-Date: 2021-09-08 19:36+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -278,7 +278,7 @@ msgstr ""
 msgid "Allow clients to resume interrupted uploads and downloads."
 msgstr ""
 
-msgid "Allow this server to advertise itself as a time server to Windows clients"
+msgid "Allow this server to advertise itself as a time server to Windows clients."
 msgstr ""
 
 msgid "Allowed clients"
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Denmark"
 msgstr ""
 
-msgid "Deny logins which do not have a valid shell"
+msgid "Deny logins which do not have a valid shell."
 msgstr ""
 
 msgid "Description"
@@ -882,6 +882,9 @@ msgid "Disk Usage"
 msgstr ""
 
 msgid "Disks"
+msgstr ""
+
+msgid "Display the home directory of the user in the browse list."
 msgstr ""
 
 msgid "Djibouti"
@@ -1019,7 +1022,7 @@ msgstr ""
 msgid "Enable this option to keep partially transferred files, otherwise they will be deleted if the transfer is interrupted."
 msgstr ""
 
-msgid "Enable user home directories"
+msgid "Enable user home directories."
 msgstr ""
 
 msgid "Enable write-cache"

--- a/deb/openmediavault/usr/share/openmediavault/templates/config.xml
+++ b/deb/openmediavault/usr/share/openmediavault/templates/config.xml
@@ -411,6 +411,7 @@
 			<anonymous>0</anonymous>
 			<requirevalidshell>1</requirevalidshell>
 			<transferlog>0</transferlog>
+			<homesenable>0</homesenable>
 			<extraoptions></extraoptions>
 			<shares>
 				<!--

--- a/deb/openmediavault/workbench/src/app/pages/services/ftp/ftp-settings-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/ftp/ftp-settings-form-page.component.ts
@@ -117,6 +117,17 @@ export class FtpSettingsFormPageComponent {
       },
       {
         type: 'paragraph',
+        text: gettext('Home directories')
+      },
+      {
+        type: 'checkbox',
+        name: 'homesenable',
+        label: gettext('Enabled'),
+        hint: gettext('Display the home directory of the user in the browse list.'),
+        value: false
+      },
+      {
+        type: 'paragraph',
         text: gettext('Advanced settings')
       },
       {
@@ -130,7 +141,7 @@ export class FtpSettingsFormPageComponent {
         type: 'checkbox',
         name: 'requirevalidshell',
         label: gettext('Require valid shell'),
-        hint: gettext('Deny logins which do not have a valid shell'),
+        hint: gettext('Deny logins which do not have a valid shell.'),
         value: true
       },
       {

--- a/deb/openmediavault/workbench/src/app/pages/services/smb/smb-settings-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/smb/smb-settings-form-page.component.ts
@@ -66,7 +66,7 @@ export class SmbSettingsFormPageComponent {
         type: 'checkbox',
         name: 'timeserver',
         label: gettext('Time server'),
-        hint: gettext('Allow this server to advertise itself as a time server to Windows clients'),
+        hint: gettext('Allow this server to advertise itself as a time server to Windows clients.'),
         value: false
       },
       {
@@ -77,7 +77,7 @@ export class SmbSettingsFormPageComponent {
         type: 'checkbox',
         name: 'homesenable',
         label: gettext('Enabled'),
-        hint: gettext('Enable user home directories'),
+        hint: gettext('Enable user home directories.'),
         value: false
       },
       {


### PR DESCRIPTION
See https://forum.openmediavault.org/index.php?thread/40184-add-automatic-users-home-to-ftp-folders-list/

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
