### PR TITLE
Fix SMART issue when requesting information from a NVMe device

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,5 +1,6 @@
 openmediavault (5.6.16-1) stable; urgency=low
 
+  * Fix SMART issue when requesting information from a NVMe device.
   * Issue #1095: Fixed a bug when escaping the password in rsync
     shell scripts.
 

--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevicenvm.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevicenvm.inc
@@ -34,6 +34,9 @@ class StorageDeviceNVM extends StorageDevice implements SmartInterface {
 	}
 
 	public function getSmartDeviceType() {
-		return "nvme";
+		// The broadcast namespace is specified if SMART/health and error
+		// information logs are requested.
+		// See https://www.smartmontools.org/ticket/1134
+		return "nvme,0xffffffff";
 	}
 }


### PR DESCRIPTION
This command line is necessary for smartctl < r4671.

See https://www.smartmontools.org/ticket/1134 for more information.

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
