### PR TITLE
Configure WebUI to listen on specific IP address instead of all

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -12,6 +12,9 @@ openmediavault (6.0-26) UNRELEASED; urgency=low
     additional notification sinks set it to 'discard'.
   * Add option to FTP settings to display the home directory of the
     user in the browse list.
+  * Issue #1099: Add environment variables OMV_NGINX_SITE_WEBGUI_LISTEN_IPV4_ADDRESS
+    and OMV_NGINX_SITE_WEBGUI_LISTEN_IPV6_ADDRESS to configure the
+    WebUI to listen on a specific IP address only instead of all.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Mon, 14 Dec 2020 20:28:37 +0100
 

--- a/deb/openmediavault/srv/salt/omv/deploy/nginx/files/site-webgui.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/nginx/files/site-webgui.j2
@@ -10,6 +10,8 @@
 {%- set ssl_cert_dir = salt['pillar.get']('default:OMV_SSL_CERTIFICATE_DIR', '/etc/ssl') -%}
 {%- set ssl_cert_prefix = salt['pillar.get']('default:OMV_SSL_CERTIFICATE_PREFIX', 'openmediavault') -%}
 {%- set include_dir = salt['pillar.get']('default:OMV_NGINX_SITE_WEBGUI_INCLUDE_DIR', '/etc/nginx/openmediavault-webgui.d') -%}
+{%- set listen_ipv4_addr = salt['pillar.get']('default:OMV_NGINX_SITE_WEBGUI_LISTEN_IPV4_ADDRESS', '*') -%}
+{%- set listen_ipv6_addr = salt['pillar.get']('default:OMV_NGINX_SITE_WEBGUI_LISTEN_IPV6_ADDRESS', '::') -%}
 {{ pillar['headers']['multiline'] }}
 server {
     server_name {{ server_name }};
@@ -41,8 +43,8 @@ server {
 {%- endif %}
     }
 {%- if ipv6_enabled | to_bool %}
-    listen *:{{ config.port }} default_server;
-    listen [::]:{{ config.port }} default_server;
+    listen {{ listen_ipv4_addr }}:{{ config.port }} default_server;
+    listen [{{ listen_ipv6_addr }}]:{{ config.port }} default_server;
 {%- else %}
     listen {{ config.port }} default_server;
 {%- endif %}
@@ -54,8 +56,8 @@ server {
 {%- endif %}
 {%- if config.enablessl | to_bool %}
 {%- if ipv6_enabled | to_bool %}
-    listen *:{{ config.sslport }} default_server ssl deferred;
-    listen [::]:{{ config.sslport }} default_server ssl deferred;
+    listen {{ listen_ipv4_addr }}:{{ config.sslport }} default_server ssl deferred;
+    listen [{{ listen_ipv6_addr }}]:{{ config.sslport }} default_server ssl deferred;
 {%- else %}
     listen {{ config.sslport }} default_server ssl deferred;
 {%- endif %}


### PR DESCRIPTION
Add environment variables OMV_NGINX_SITE_WEBGUI_LISTEN_IPV4_ADDRESS and OMV_NGINX_SITE_WEBGUI_LISTEN_IPV6_ADDRESS to configure the WebUI to listen on a specific IP address only instead of all.

Fixes: https://github.com/openmediavault/openmediavault/issues/1099

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
