### PR TITLE
Allow configuration of SMART temperature per monitored device.

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -12,6 +12,10 @@ openmediavault (6.0-26) UNRELEASED; urgency=low
     additional notification sinks set it to 'discard'.
   * Add option to FTP settings to display the home directory of the
     user in the browse list.
+  * Enhance the SMART temperature monitoring configuration.
+    Global settings can be overwritten per device. Please check
+    your settings whether the migration was correct or reconfigure
+    them if necessary.
   * Issue #1099: Add environment variables OMV_NGINX_SITE_WEBGUI_LISTEN_IPV4_ADDRESS
     and OMV_NGINX_SITE_WEBGUI_LISTEN_IPV6_ADDRESS to configure the
     WebUI to listen on a specific IP address only instead of all.

--- a/deb/openmediavault/srv/salt/omv/deploy/smartmontools/files/etc-smartd_conf.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/smartmontools/files/etc-smartd_conf.j2
@@ -8,12 +8,12 @@
   {'operator': 'stringEquals', 'arg0': 'id', 'arg1': 'smartmontools'})[0] -%}
 {%- set default_directives = salt['pillar.get']('default:OMV_SMARTMONTOOLS_DEFAULTDIRECTIVES', '-a -o on -S on -T permissive') -%}
 {{ pillar['headers']['multiline'] }}
-DEFAULT {{ default_directives }} -W {{ smart_config.tempdiff }},{{ smart_config.tempinfo }},{{ smart_config.tempcrit }}{% if smart_config.tempdiff == 0 and smart_config.tempinfo == 0 and smart_config.tempcrit == 0 %} -I 190 -I 194 -I 231{% endif %} -n {{ smart_config.powermode }},q
+DEFAULT {{ default_directives }} -W {{ smart_config.tempdiff }},{{ smart_config.tempinfo }},{{ smart_config.tempcrit }} -n {{ smart_config.powermode }},q
 {%- for device in smart_devices -%}
 {%- set smart_jobs = salt['omv_conf.get_by_filter'](
   'conf.service.smartmontools.job',
   {'operator': 'and', 'arg0': {'operator': 'stringEquals', 'arg0': 'devicefile', 'arg1': device.devicefile}, 'arg1': {'operator': 'equals', 'arg0': 'enable', 'arg1': '1'}}) %}
-{{ device.devicefile }}{% if device.devicetype | length > 0 %} -d {{ device.devicetype }}{% endif %}
+{{ device.devicefile }}{% if device.devicetype | length > 0 %} -d {{ device.devicetype }}{% endif %}{% if device.tempdiff > 0 or device.tempinfo > 0 or device.tempcrit > 0 %} -W {{ device.tempdiff }},{{ device.tempinfo }},{{ device.tempcrit }}{% endif %}
 {%- for job in smart_jobs -%}
 {% if loop.first %} \
   -s (

--- a/deb/openmediavault/srv/salt/omv/deploy/smartmontools/files/etc-smartd_conf.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/smartmontools/files/etc-smartd_conf.j2
@@ -7,13 +7,14 @@
   'conf.system.notification.notification',
   {'operator': 'stringEquals', 'arg0': 'id', 'arg1': 'smartmontools'})[0] -%}
 {%- set default_directives = salt['pillar.get']('default:OMV_SMARTMONTOOLS_DEFAULTDIRECTIVES', '-a -o on -S on -T permissive') -%}
+{%- set temp_crit_diff = salt['pillar.get']('default:OMV_SMARTMONTOOLS_TEMP_CRIT_DIFF', 5) -%}
 {{ pillar['headers']['multiline'] }}
-DEFAULT {{ default_directives }} -W {{ smart_config.tempdiff }},{{ smart_config.tempinfo }},{{ smart_config.tempcrit }} -n {{ smart_config.powermode }},q
+DEFAULT {{ default_directives }} -W {{ smart_config.tempdiff }},{{ smart_config.tempmax }},{{ smart_config.tempmax + temp_crit_diff if smart_config.tempmax else 0 }} -n {{ smart_config.powermode }},q
 {%- for device in smart_devices -%}
 {%- set smart_jobs = salt['omv_conf.get_by_filter'](
   'conf.service.smartmontools.job',
   {'operator': 'and', 'arg0': {'operator': 'stringEquals', 'arg0': 'devicefile', 'arg1': device.devicefile}, 'arg1': {'operator': 'equals', 'arg0': 'enable', 'arg1': '1'}}) %}
-{{ device.devicefile }}{% if device.devicetype | length > 0 %} -d {{ device.devicetype }}{% endif %}{% if device.tempdiff > 0 or device.tempinfo > 0 or device.tempcrit > 0 %} -W {{ device.tempdiff }},{{ device.tempinfo }},{{ device.tempcrit }}{% endif %}
+{{ device.devicefile }}{% if device.devicetype | length > 0 %} -d {{ device.devicetype }}{% endif %}{% if device.tempdiff > 0 or device.tempmax > 0 %} -W {{ device.tempdiff or smart_config.tempdiff }},{{ device.tempmax or smart_config.tempmax }},{{ device.tempmax + temp_crit_diff if device.tempmax else (smart_config.tempmax + temp_crit_diff if smart_config.tempmax else 0) }}{% endif %}
 {%- for job in smart_jobs -%}
 {% if loop.first %} \
   -s (

--- a/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_6.0.0.sh
+++ b/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_6.0.0.sh
@@ -26,5 +26,8 @@ set -e
 omv_config_add_key "/config/services/ftp" "homesenable" "0"
 omv_config_add_key "/config/system/fstab/mntent" "comment" ""
 omv_config_add_key "/config/system/fstab/mntent" "usagewarnthreshold" "85"
+omv_config_add_key "/config/services/smart/monitor/device" "tempdiff" "0"
+omv_config_add_key "/config/services/smart/monitor/device" "tempinfo" "0"
+omv_config_add_key "/config/services/smart/monitor/device" "tempcrit" "0"
 
 exit 0

--- a/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_6.0.0.sh
+++ b/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_6.0.0.sh
@@ -27,7 +27,9 @@ omv_config_add_key "/config/services/ftp" "homesenable" "0"
 omv_config_add_key "/config/system/fstab/mntent" "comment" ""
 omv_config_add_key "/config/system/fstab/mntent" "usagewarnthreshold" "85"
 omv_config_add_key "/config/services/smart/monitor/device" "tempdiff" "0"
-omv_config_add_key "/config/services/smart/monitor/device" "tempinfo" "0"
-omv_config_add_key "/config/services/smart/monitor/device" "tempcrit" "0"
+omv_config_add_key "/config/services/smart/monitor/device" "tempmax" "0"
+
+omv_config_delete "/config/services/smart/tempcrit"
+omv_config_rename "/config/services/smart/tempinfo" "tempmax"
 
 exit 0

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smartmontools.device.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smartmontools.device.json
@@ -31,13 +31,7 @@
 			"maximum": 255,
 			"default": 0
 		},
-		"tempinfo":{
-			"type": "integer",
-			"minimum": 0,
-			"maximum": 255,
-			"default": 0
-		},
-		"tempcrit":{
+		"tempmax":{
 			"type": "integer",
 			"minimum": 0,
 			"maximum": 255,

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smartmontools.device.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smartmontools.device.json
@@ -24,6 +24,24 @@
 		"devicetype": {
 			"type": "string",
 			"default": ""
+		},
+		"tempdiff":{
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 255,
+			"default": 0
+		},
+		"tempinfo":{
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 255,
+			"default": 0
+		},
+		"tempcrit":{
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 255,
+			"default": 0
 		}
 	}
 }

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smartmontools.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smartmontools.json
@@ -27,13 +27,7 @@
 			"maximum": 255,
 			"default": 0
 		},
-		"tempinfo":{
-			"type": "integer",
-			"minimum": 0,
-			"maximum": 255,
-			"default": 0
-		},
-		"tempcrit":{
+		"tempmax":{
 			"type": "integer",
 			"minimum": 0,
 			"maximum": 255,
@@ -70,13 +64,7 @@
 								"maximum": 255,
 								"default": 0
 							},
-							"tempinfo":{
-								"type": "integer",
-								"minimum": 0,
-								"maximum": 255,
-								"default": 0
-							},
-							"tempcrit":{
+							"tempmax":{
 								"type": "integer",
 								"minimum": 0,
 								"maximum": 255,

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smartmontools.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smartmontools.json
@@ -63,6 +63,24 @@
 							"devicetype": {
 								"type": "string",
 								"default": ""
+							},
+							"tempdiff":{
+								"type": "integer",
+								"minimum": 0,
+								"maximum": 255,
+								"default": 0
+							},
+							"tempinfo":{
+								"type": "integer",
+								"minimum": 0,
+								"maximum": 255,
+								"default": 0
+							},
+							"tempcrit":{
+								"type": "integer",
+								"minimum": 0,
+								"maximum": 255,
+								"default": 0
 							}
 						}
 					}

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.smart.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.smart.json
@@ -23,12 +23,7 @@
 			    "minimum": 0,
 				"required": true
 			},
-			"tempinfo": {
-			    "type": "integer",
-			    "minimum": 0,
-				"required": true
-			},
-			"tempcrit": {
+			"tempmax": {
 			    "type": "integer",
 			    "minimum": 0,
 				"required": true

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/smart.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/smart.inc
@@ -296,6 +296,12 @@ class Smart extends \OMV\Rpc\ServiceAbstract {
 	 *     \li /dev/sdb
 	 *     \li /dev/disk/by-id/ata-ST31000528AS_8VI5C2AZ
 	 *   \em enable Enable/disable S.M.A.R.T. monitoring.
+	 *   \em tempdiff Report if the temperature had changed by at
+	 *     least N degrees Celsius since last report.
+	 *   \em tempinfo Report if the temperature is greater than or
+	 *     equal to N degrees Celsius.
+	 *   \em tempcrit Report if the temperature is greater than or
+	 *     equal to N degrees Celsius.
 	 * @param context The context of the caller.
 	 * @return The stored configuration object.
 	 */
@@ -318,7 +324,10 @@ class Smart extends \OMV\Rpc\ServiceAbstract {
 			"uuid" => $params['uuid'],
 			"enable" => $params['enable'],
 			"devicefile" => $sd->getPredictableDeviceFile(),
-			"devicetype" => $sd->getSmartDeviceType()
+			"devicetype" => $sd->getSmartDeviceType(),
+			"tempdiff" => $params['tempdiff'],
+			"tempinfo" => $params['tempinfo'],
+			"tempcrit" => $params['tempcrit']
 		]);
 		// Set the configuration object.
 		$db = \OMV\Config\Database::getInstance();

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/smart.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/smart.inc
@@ -298,9 +298,7 @@ class Smart extends \OMV\Rpc\ServiceAbstract {
 	 *   \em enable Enable/disable S.M.A.R.T. monitoring.
 	 *   \em tempdiff Report if the temperature had changed by at
 	 *     least N degrees Celsius since last report.
-	 *   \em tempinfo Report if the temperature is greater than or
-	 *     equal to N degrees Celsius.
-	 *   \em tempcrit Report if the temperature is greater than or
+	 *   \em tempmax Report if the temperature is greater than or
 	 *     equal to N degrees Celsius.
 	 * @param context The context of the caller.
 	 * @return The stored configuration object.
@@ -326,8 +324,7 @@ class Smart extends \OMV\Rpc\ServiceAbstract {
 			"devicefile" => $sd->getPredictableDeviceFile(),
 			"devicetype" => $sd->getSmartDeviceType(),
 			"tempdiff" => $params['tempdiff'],
-			"tempinfo" => $params['tempinfo'],
-			"tempcrit" => $params['tempcrit']
+			"tempmax" => $params['tempmax']
 		]);
 		// Set the configuration object.
 		$db = \OMV\Config\Database::getInstance();

--- a/deb/openmediavault/usr/share/openmediavault/templates/config.xml
+++ b/deb/openmediavault/usr/share/openmediavault/templates/config.xml
@@ -462,6 +462,9 @@
 					<enable>0|1</enable>
 					<devicefile>/dev/xxx</devicefile>
 					<devicetype>|sat|cciss|xxx</devicetype>
+					<tempdiff>0</tempdiff>
+					<tempinfo>0</tempinfo>
+					<tempcrit>0</tempcrit>
 				</device>
 				-->
 			</monitor>

--- a/deb/openmediavault/usr/share/openmediavault/templates/config.xml
+++ b/deb/openmediavault/usr/share/openmediavault/templates/config.xml
@@ -453,8 +453,7 @@
 			<interval>1800</interval>
 			<powermode>never</powermode>
 			<tempdiff>0</tempdiff>
-			<tempinfo>0</tempinfo>
-			<tempcrit>0</tempcrit>
+			<tempmax>0</tempmax>
 			<monitor>
 				<!--
 				<device>
@@ -463,8 +462,7 @@
 					<devicefile>/dev/xxx</devicefile>
 					<devicetype>|sat|cciss|xxx</devicetype>
 					<tempdiff>0</tempdiff>
-					<tempinfo>0</tempinfo>
-					<tempcrit>0</tempcrit>
+					<tempmax>0</tempmax>
 				</device>
 				-->
 			</monitor>

--- a/deb/openmediavault/usr/share/openmediavault/unittests/data/config.xml
+++ b/deb/openmediavault/usr/share/openmediavault/unittests/data/config.xml
@@ -767,8 +767,7 @@ iSrj/B/KRCZkkrDdYcDAvqRs6dA+ScRZ
       <interval>1800</interval>
       <powermode>never</powermode>
       <tempdiff>0</tempdiff>
-      <tempinfo>0</tempinfo>
-      <tempcrit>0</tempcrit>
+      <tempmax>0</tempmax>
       <monitor>
         <!--
 				<device>
@@ -776,6 +775,8 @@ iSrj/B/KRCZkkrDdYcDAvqRs6dA+ScRZ
 					<enable>0|1</enable>
 					<devicefile>/dev/xxx</devicefile>
 					<devicetype>|sat|cciss|xxx</devicetype>
+					<tempdiff>0</tempdiff>
+					<tempmax>0</tempmax>
 				</device>
 				-->
         <device>

--- a/deb/openmediavault/workbench/src/app/pages/storage/smart/smart-device-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/storage/smart/smart-device-form-page.component.ts
@@ -61,9 +61,118 @@ export class SmartDeviceFormPageComponent {
       {
         type: 'checkbox',
         name: 'enable',
-        label: gettext('Monitored'),
-        hint: gettext('Activate S.M.A.R.T. monitoring.'),
+        label: gettext('Monitoring enabled'),
         value: false
+      },
+
+      {
+        type: 'paragraph',
+        text: gettext('Temperature monitoring')
+      },
+      {
+        type: 'select',
+        name: 'tempdiff',
+        label: gettext('Difference'),
+        hint: gettext(
+          'Report if the temperature had changed by at least N degrees Celsius since last report.'
+        ),
+        value: 0,
+        store: {
+          data: [
+            [0, gettext('Use global settings')],
+            [1, '1°C'],
+            [2, '2°C'],
+            [3, '3°C'],
+            [4, '4°C'],
+            [5, '5°C'],
+            [6, '6°C'],
+            [7, '7°C'],
+            [8, '8°C'],
+            [9, '9°C'],
+            [10, '10°C'],
+            [11, '11°C'],
+            [12, '12°C'],
+            [13, '13°C'],
+            [14, '14°C'],
+            [15, '15°C']
+          ]
+        },
+        validators: {
+          min: 0,
+          required: true
+        }
+      },
+      {
+        type: 'select',
+        name: 'tempinfo',
+        label: gettext('Informal'),
+        hint: gettext('Report if the temperature is greater than or equal to N degrees Celsius.'),
+        value: 0,
+        store: {
+          data: [
+            [0, gettext('Use global settings')],
+            [5, '5°C'],
+            [10, '10°C'],
+            [15, '15°C'],
+            [20, '20°C'],
+            [25, '25°C'],
+            [30, '30°C'],
+            [35, '35°C'],
+            [40, '40°C'],
+            [45, '45°C'],
+            [50, '50°C'],
+            [55, '55°C'],
+            [60, '60°C'],
+            [65, '65°C'],
+            [70, '70°C'],
+            [75, '75°C'],
+            [80, '80°C'],
+            [85, '85°C'],
+            [90, '90°C'],
+            [95, '95°C'],
+            [100, '100°C']
+          ]
+        },
+        validators: {
+          min: 0,
+          required: true
+        }
+      },
+      {
+        type: 'select',
+        name: 'tempcrit',
+        label: gettext('Critical'),
+        hint: gettext('Report if the temperature is greater than or equal to N degrees Celsius.'),
+        value: 0,
+        store: {
+          data: [
+            [0, gettext('Use global settings')],
+            [5, '5°C'],
+            [10, '10°C'],
+            [15, '15°C'],
+            [20, '20°C'],
+            [25, '25°C'],
+            [30, '30°C'],
+            [35, '35°C'],
+            [40, '40°C'],
+            [45, '45°C'],
+            [50, '50°C'],
+            [55, '55°C'],
+            [60, '60°C'],
+            [65, '65°C'],
+            [70, '70°C'],
+            [75, '75°C'],
+            [80, '80°C'],
+            [85, '85°C'],
+            [90, '90°C'],
+            [95, '95°C'],
+            [100, '100°C']
+          ]
+        },
+        validators: {
+          min: 0,
+          required: true
+        }
       }
     ],
     buttons: [

--- a/deb/openmediavault/workbench/src/app/pages/storage/smart/smart-device-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/storage/smart/smart-device-form-page.component.ts
@@ -64,7 +64,6 @@ export class SmartDeviceFormPageComponent {
         label: gettext('Monitoring enabled'),
         value: false
       },
-
       {
         type: 'paragraph',
         text: gettext('Temperature monitoring')
@@ -104,44 +103,8 @@ export class SmartDeviceFormPageComponent {
       },
       {
         type: 'select',
-        name: 'tempinfo',
-        label: gettext('Informal'),
-        hint: gettext('Report if the temperature is greater than or equal to N degrees Celsius.'),
-        value: 0,
-        store: {
-          data: [
-            [0, gettext('Use global settings')],
-            [5, '5°C'],
-            [10, '10°C'],
-            [15, '15°C'],
-            [20, '20°C'],
-            [25, '25°C'],
-            [30, '30°C'],
-            [35, '35°C'],
-            [40, '40°C'],
-            [45, '45°C'],
-            [50, '50°C'],
-            [55, '55°C'],
-            [60, '60°C'],
-            [65, '65°C'],
-            [70, '70°C'],
-            [75, '75°C'],
-            [80, '80°C'],
-            [85, '85°C'],
-            [90, '90°C'],
-            [95, '95°C'],
-            [100, '100°C']
-          ]
-        },
-        validators: {
-          min: 0,
-          required: true
-        }
-      },
-      {
-        type: 'select',
-        name: 'tempcrit',
-        label: gettext('Critical'),
+        name: 'tempmax',
+        label: gettext('Maximum'),
         hint: gettext('Report if the temperature is greater than or equal to N degrees Celsius.'),
         value: 0,
         store: {

--- a/deb/openmediavault/workbench/src/app/pages/storage/smart/smart-settings-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/storage/smart/smart-settings-form-page.component.ts
@@ -111,44 +111,8 @@ export class SmartSettingsFormPageComponent {
       },
       {
         type: 'select',
-        name: 'tempinfo',
-        label: gettext('Informal'),
-        hint: gettext('Report if the temperature is greater than or equal to N degrees Celsius.'),
-        value: 0,
-        store: {
-          data: [
-            [0, gettext('Disabled')],
-            [5, '5°C'],
-            [10, '10°C'],
-            [15, '15°C'],
-            [20, '20°C'],
-            [25, '25°C'],
-            [30, '30°C'],
-            [35, '35°C'],
-            [40, '40°C'],
-            [45, '45°C'],
-            [50, '50°C'],
-            [55, '55°C'],
-            [60, '60°C'],
-            [65, '65°C'],
-            [70, '70°C'],
-            [75, '75°C'],
-            [80, '80°C'],
-            [85, '85°C'],
-            [90, '90°C'],
-            [95, '95°C'],
-            [100, '100°C']
-          ]
-        },
-        validators: {
-          min: 0,
-          required: true
-        }
-      },
-      {
-        type: 'select',
-        name: 'tempcrit',
-        label: gettext('Critical'),
+        name: 'tempmax',
+        label: gettext('Maximum'),
         hint: gettext('Report if the temperature is greater than or equal to N degrees Celsius.'),
         value: 0,
         store: {


### PR DESCRIPTION
- Allow configuration of SMART temperature per monitored device.
- Simplify SMART temperature monitoring. Remove the critical temperature setting and calculate it via temp_info+5. The critical temperature difference can be customized via OMV_SMARTMONTOOLS_TEMP_CRIT_DIFF.

Signed-off-by: Volker Theile <votdev@gmx.de>

<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
