### PR TITLE
Update etc-exports.j2

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/nfs/files/etc-exports.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/nfs/files/etc-exports.j2
@@ -18,7 +18,7 @@
 {%- for share in shares %}
 {%- set sharedfolder = salt['omv_conf.get']('conf.system.sharedfolder', share.sharedfolderref) %}
 {%- if loop.first %}{{ export_dir | path_join(sharedfolder.name) }}{% endif -%}
-{{ separator }}{{ share.client | trim }}(fsid={{ v3_loop.index }},{{ share.options }}{% if share.extraoptions | length > 0 %},{{ share.extraoptions }}{% endif %})
+{{ separator }}{{ share.client | trim }}(fsid={{ share.uuid }},{{ share.options }}{% if share.extraoptions | length > 0 %},{{ share.extraoptions }}{% endif %})
 {%- endfor %}
 {%- endfor %}
 


### PR DESCRIPTION
use share's uuid as fsid. This leads to consistend fsid entries across restarts and configuration changes of other shares. Clients will now not have any stale file handles any more.

https://forum.openmediavault.org/index.php?thread/40749-fsid-seems-seems-to-be-applied-dynamically/&postID=286858#post286858

Signed-off-by: Ralf Dragon <rd-comm@lindra.de>

thanks to votdev for the actual code!

<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
