### PR TITLE
Fix lock file issue in SMB recycle script.

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/samba/files/cron-recyclebin-script.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/samba/files/cron-recyclebin-script.j2
@@ -33,5 +33,7 @@ trap "rm -rf ${lockfile}; exit" 0 1 2 5 15
 [ ! -e "${recycle_repository}" ] && exit 0
 omv_log "Please wait, empty recyle bin of <{{ sf_path }}> ..."
 find "${recycle_repository}" -mindepth 1 -amin +${amin} -print0 | xargs -0r rm -rfv
+wait $!
 # Do a second run to remove empty directories.
 find "${recycle_repository}" -mindepth 1 -type d -empty -print0 | xargs -0r rm -rfv
+wait $!


### PR DESCRIPTION
Reference: https://forum.openmediavault.org/index.php?thread/37514-auto-emptying-of-recycle-bin-not-working/&postID=287406#post287406
 
Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
