### PR TITLE
Issue #1151: Increase user password strength.

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,7 +1,8 @@
-openmediavault (6.0.5-1) unstable; urgency=low
+openmediavault (6.0.5-2) unstable; urgency=low
 
   * Improved IPv6 detection. This will fix various issues, e.g.
     DNS issues and undeliverable emails with Postfix.
+  * Issue #1151: Increase user password strength.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Fri, 26 Nov 2021 13:15:00 +0100
 

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/usermgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/usermgmt.inc
@@ -563,7 +563,8 @@ finish:
 			$hdsobject = $db->get("conf.system.usermngmnt.homedir");
 			// Append additional arguments.
 			$cmdArgs[] = "--password";
-			$cmdArgs[] = escapeshellarg(crypt($params['password']));
+			$cmdArgs[] = escapeshellarg(\OMV\System\User::mkPassword(
+				$params['password']));
 			if (array_key_exists("uid", $params)) {
 				$cmdArgs[] = "--uid";
 				$cmdArgs[] = $params['uid'];
@@ -588,7 +589,8 @@ finish:
 			if (array_key_exists("password", $params) &&
 					!empty($params['password'])) {
 				$cmdArgs[] = "--password";
-				$cmdArgs[] = escapeshellarg(crypt($params['password']));
+				$cmdArgs[] = escapeshellarg(\OMV\System\User::mkPassword(
+					$params['password']));
 			}
 			$cmdArgs[] = escapeshellarg($params['name']);
 			// Modify the existing user.

--- a/deb/openmediavault/usr/share/php/openmediavault/system/user.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/user.inc
@@ -371,7 +371,7 @@ class User {
 	public function changePassword($newPassword) {
 		$cmdArgs = [];
 		$cmdArgs[] = sprintf("--password %s", escapeshellarg(
-			crypt($newPassword)));
+			$this->mkPassword($newPassword)));
 		$cmdArgs[] = escapeshellarg($this->getName());
 		$cmd = new \OMV\System\Process("usermod", $cmdArgs);
 		$cmd->setRedirect2to1();
@@ -402,5 +402,15 @@ class User {
 			$list[] = $data[0]; // User name
 		}
 		return $list;
+	}
+
+	/**
+	 * Encrypt the given password using the system crypt(3) settings.
+	 */
+	public static function mkPassword($password): string {
+		$cmdArgs = [];
+		$cmdArgs[] = escapeshellarg($password);
+		$cmd = new \OMV\System\Process("mkpasswd", $cmdArgs);
+		return $cmd->execute();
 	}
 }


### PR DESCRIPTION
Use mkpasswd to generate the encrypted password. Thus the Debian PAM/crypt settings are used.

Fixes: https://github.com/openmediavault/openmediavault/issues/1151

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
