### PR TITLE
remove space that causes watchdog to not be set correctly on armhf systems

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/watchdog/default.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/watchdog/default.sls
@@ -41,7 +41,7 @@
 # Make sure the watchdog timeout is correct. E.g. there are problems
 # on ARM, e.g. RPi, devices.
 # https://forums.raspberrypi.com/viewtopic.php?f=29&t=147501
-{% if (grains['osarch'] in [' armhf', 'arm64']) and (watchdog_kernel_module_name in ['softdog', 'bcm2835_wdt']) and (watchdog_systemd_runtimewatchdogsec | to_sec > 15) %}
+{% if (grains['osarch'] in ['armhf', 'arm64']) and (watchdog_kernel_module_name in ['softdog', 'bcm2835_wdt']) and (watchdog_systemd_runtimewatchdogsec | to_sec > 15) %}
 {% set watchdog_systemd_runtimewatchdogsec = 15 %}
 {% endif %}
 


### PR DESCRIPTION
remove space that causes watchdog to not be set correctly on armhf systems

[A longer multiline description]

Fixes: https://github.com/OpenMediaVault-Plugin-Developers/installScript/issues/71

Signed-off-by: [Aaron Murray] <[plugins@omv-extras.org]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
