### PR TITLE
Issue #1196: Improve to_sec() Jinja filter to handle values without unit

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,4 +1,4 @@
-openmediavault (6.0.9-3) unstable; urgency=low
+openmediavault (6.0.9-4) unstable; urgency=low
 
   * Update locale files.
   * Use systemd watchdog instead of separate daemon.

--- a/deb/openmediavault/srv/salt/_modules/omv_utils.py
+++ b/deb/openmediavault/srv/salt/_modules/omv_utils.py
@@ -418,7 +418,7 @@ def to_sec(value):
         unit = matches.group(2)
         if unit == 'ms':
             value = num * 0.001
-        elif unit == 's':
+        elif unit in [None, 's']:
             value = num
         elif unit == 'min':
             value = num * 60


### PR DESCRIPTION
Fixes: https://github.com/openmediavault/openmediavault/issues/1196

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
