### PR TITLE
Disable autocapitalize

### DIFF
--- a/deb/openmediavault/workbench/src/app/core/pages/login-page/login-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/core/pages/login-page/login-page.component.ts
@@ -53,6 +53,7 @@ export class LoginPageComponent implements OnInit {
         label: gettext('User name'),
         autofocus: true,
         autocomplete: 'username',
+        autocapitalize: 'none',
         icon: Icon.user,
         validators: {
           required: true


### PR DESCRIPTION
 Disable autocapitalize  for the user field on the login page.

Allows to avoid that the virtual keyboards put a capital letter to the first word by default. 
This doesn't prevent you from changing the case of the virtual keyboard.
[https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize)

Fixes: None

Signed-off-by: Trivial patch, CLA not needed

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
