### PR TITLE
change Link to Blog (to avoid loading subdomain with invalid SSL-cert)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A detailed instruction about how to install openmediavault can be found [here](h
 ## Resources
 - [Documentation](https://docs.openmediavault.org)
 - [Forum](https://forum.openmediavault.org)
-- [Blog](https://blog.openmediavault.org)
+- [Blog](https://www.openmediavault.org/blog.html)
 
 ## Donation
 


### PR DESCRIPTION
There seems to be an old(?) invalid subdomain mentioned in README.md.
https://blog.openmediavault.org leads to an SSL error because *.1blu.de wildcard cert is used.
Instead please use the link to blog that is already mentioned on OMV-Website navigation: https://www.openmediavault.org/blog.html

And what also needs to be told:
BIIIIG THANKS to Volker and all the contributors to this fantastic project!


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
