### PR TITLE
Added npm in install section

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -32,7 +32,7 @@ clean binary omv_tx_pull_po omv_tx_push_pot omv_build_pot:
 
 install:
 	echo "Installing required packages ..."
-	sudo apt-get install debhelper fakeroot gettext python3-pip
+	sudo apt-get install debhelper fakeroot gettext npm python3-pip
 	pip3 install --upgrade autopep8 isort pylint
 
 .PHONY: install clean binary omv_tx_pull_po omv_tx_push_pot omv_build_pot


### PR DESCRIPTION
"""
[Short description]
Added npm in install section of openmediavault/deb/Makefile

[Long description]
npm is required to build OMV, and should be installed when running make install

Fixes: #1231

Signed-off-by: Antoine Besnier <besnier_antoine@yahoo.fr>
"""

- [X ] References issue
- [~ ] Includes tests for new functionality or reproducer for bug  N/A
