### PR TITLE
Update 61-openmediavault-dev-disk-by-id.rules

### DIFF
--- a/deb/openmediavault/etc/udev/rules.d/61-openmediavault-dev-disk-by-id.rules
+++ b/deb/openmediavault/etc/udev/rules.d/61-openmediavault-dev-disk-by-id.rules
@@ -457,6 +457,49 @@ ENV{ID_VENDOR_ID}=="152d", \
   SYMLINK="disk/by-path/$env{ID_PATH}", \
   SYMLINK+="disk/by-id/$env{ID_BUS}-$env{ID_SERIAL}"
 
+# GENESYS USB2.0/SATA ADAPTER
+# https://devicehunt.com/view/type/usb/vendor/05E3/device/0718
+# P: /devices/platform/soc/3f980000.usb/usb1/1-1/1-1.2/1-1.2:1.0/host0/target0:0:0/0:0:0:0/block/sda
+# N: sda
+# L: 0
+# S: disk/by-path/platform-3f980000.usb-usb-0:1.2:1.0-scsi-0:0:0:0
+# S: disk/by-id/usb-TOSHIBA_MQ01ABF050_000000000033-0:0
+# E: DEVPATH=/devices/platform/soc/3f980000.usb/usb1/1-1/1-1.2/1-1.2:1.0/host0/target0:0:0/0:0:0:0/block/sda
+# E: DEVNAME=/dev/sda
+# E: DEVTYPE=disk
+# E: MAJOR=8
+# E: MINOR=0
+# E: SUBSYSTEM=block
+# E: USEC_INITIALIZED=14055486
+# E: ID_VENDOR=TOSHIBA
+# E: ID_VENDOR_ENC=TOSHIBA\x20
+# E: ID_VENDOR_ID=05e3
+# E: ID_MODEL=MQ01ABF050
+# E: ID_MODEL_ENC=MQ01ABF050\x20\x20\x20\x20\x20\x20
+# E: ID_MODEL_ID=0718
+# E: ID_REVISION=0009
+# E: ID_SERIAL=TOSHIBA_MQ01ABF050_000000000033-0:0
+# E: ID_SERIAL_SHORT=000000000033
+# E: ID_TYPE=disk
+# E: ID_INSTANCE=0:0
+# E: ID_BUS=usb
+# E: ID_USB_INTERFACES=:080650:
+# E: ID_USB_INTERFACE_NUM=00
+# E: ID_USB_DRIVER=usb-storage
+# E: ID_PATH=platform-3f980000.usb-usb-0:1.2:1.0-scsi-0:0:0:0
+# E: ID_PATH_TAG=platform-3f980000_usb-usb-0_1_2_1_0-scsi-0_0_0_0
+# E: ID_PART_TABLE_UUID=7d9ff90a-4dc0-410b-a6ac-ed6015b53faa
+# E: ID_PART_TABLE_TYPE=gpt
+# E: DEVLINKS=/dev/disk/by-path/platform-3f980000.usb-usb-0:1.2:1.0-scsi-0:0:0:0 /dev/disk/by-id/usb-TOSHIBA_M$
+# E: TAGS=:systemd:
+
+ENV{ID_VENDOR_ID}=="05e3", \
+  ENV{ID_MODEL_ID}=="0718", \
+  IMPORT{program}="serial_id %N", \
+  ENV{ID_SERIAL}="$env{ID_VENDOR}_$env{ID_MODEL}_$env{ID_SERIAL_SHORT}-$env{ID_INSTANCE}", \
+  SYMLINK="disk/by-path/$env{ID_PATH}", \
+  SYMLINK+="disk/by-id/$env{ID_BUS}-$env{ID_SERIAL}"
+
 # by-id (World Wide Name)
 SYMLINK=="*disk/by-id/wwn-*", GOTO="omv_skip_by_id_wwn"
 ENV{ID_WWN_WITH_EXTENSION}=="?*", SYMLINK+="disk/by-id/wwn-$env{ID_WWN_WITH_EXTENSION}"


### PR DESCRIPTION
Add Genesys USB2.0/SATA adapter to avoid the problem explained in  #746 PR.

Fixes: [#1229]

Signed-off-by: Max Faber maxfb87@yahoo.it

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug