### PR TITLE
Fix getRootDeviceFile not returning the correct parent device when the OS is installed on an LVM or full disk encrypted drive

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/system/system.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/system.inc
@@ -29,6 +29,27 @@ require_once("openmediavault/functions.inc");
  */
 class System {
 	/**
+	 * Get a partition parent block device
+	 * @return Returns the storage parent device file of the partiton of where the
+	 * operating system is installed
+	 * @throw \OMV\ExecException
+	 */
+	public static function getBlockParentDevice($blockdevices, $partiton, &$rootDeviceFile) {
+		foreach ($blockdevices as $blocks => &$block) {
+			foreach ($block->children as $children => &$child) {
+				$child->name = $block->name . ":" . $child->name ;
+			}
+			$items = explode(":",$block->name);
+			if (strpos($partiton, end($items)) === 0) {
+				$rootDeviceFile = $items[0];
+			} else if(!is_null($block->children)) {
+				self::getBlockParentDevice(
+					$block->children, $partiton, $rootDeviceFile);
+			}
+		}
+	}
+
+	/**
 	 * Get the device file where the operating system is installed on (e.g.
 	 * /dev/sda1). To avoid further useless process calls to determine the
 	 * root device file the value is cached in a static variable when this
@@ -49,7 +70,14 @@ class System {
 		//if (is_block_device("/dev/root"))
 		//	return realpath("/dev/root");
 		$mp = new \OMV\System\MountPoint("/");
-		return $mp->getDeviceFile();
+		$cmd = new \OMV\System\Process("lsblk", "-J", "-o NAME");
+		$cmd->setRedirect2to1();
+		$cmd->execute($output);
+		$blockDevicesObject = json_decode(implode($output));
+		$blockParentDevice = self::getBlockParentDevice(
+			$blockDevicesObject->blockdevices,
+			basename($mp->getDeviceFile()), $rootDeviceFile);
+		return $blockParentDevice;
 	}
 
 	/**
@@ -70,7 +98,8 @@ class System {
 				($rootDeviceFile == realpath($deviceFile))) ?
 				TRUE : FALSE;
 		}
-		return ((0 === strpos($rootDeviceFile, $deviceFile)) ||
+		return ((0 === strpos(basename($rootDeviceFile), basename($deviceFile))) ||
+		    (0 === strpos($rootDeviceFile, $deviceFile)) ||
 			(0 === strpos($rootDeviceFile, realpath($deviceFile)))) ?
 			TRUE : FALSE;
 	}


### PR DESCRIPTION
Hello Everyone,

This pull request goal is to fix the function getRootDeviceFile not returning the correct parent device when the OS is installed on a full disk encrypted drive.
The previous implmenetation returns the partition name of the root directory not the device a the function name implies.:
```
public static function getRootDeviceFile() {
...
...
return $mp->getDeviceFile();  -> this just returns the parition of the mount point not the device file
```

it's optimal in a case where the OS is installed on top of a normal parition not an LVM :
![image](https://user-images.githubusercontent.com/53077134/163660712-d0258b65-d33a-4869-8bab-cd3b7a735b25.png)

Now when you install OMV on a full disk encrypted disk, debian installer creates an LVM group on top of a partiton and then makes differnet volumes to serve different purposes ( swap, root, ..) :
![image](https://user-images.githubusercontent.com/53077134/163660819-0a6a38c4-c0da-41e2-aa61-8e72a8fa3298.png)

What I did is to navigate through the tree up to the parent device not just a parition of the mount point.

I intrduced a new function getPartitionParentDevice and modified the getRootDeviceFile function to return a device not a partiton.


Thank you


**This is a PR against master with less modification on OMV.
Prevous PR was closed due to reverting back  changes on 5.x  and adding them master.
https://github.com/openmediavault/openmediavault/pull/1279**
