### PR TITLE
Add automatic dark mode support in UI.

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,7 @@
 openmediavault (6.0.28-1) stable; urgency=low
 
   * Various improvements in the Workbench UI.
+  * Add automatic dark mode support in UI.
   * Use HTTP/2 by default for HTTPS connections to the Workbench UI.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Thu, 12 May 2022 07:45:19 +0200

--- a/deb/openmediavault/usr/share/openmediavault/workbench/dashboard.d/network_interfaces_grid.yaml
+++ b/deb/openmediavault/usr/share/openmediavault/workbench/dashboard.d/network_interfaces_grid.yaml
@@ -11,7 +11,7 @@ data:
   description: _("Displays information about the network interfaces in a grid.")
   grid:
     item:
-      class: 'omv-background-color-theme-whitesmoke'
+      class: 'omv-color-text omv-background-color-selected-button'
       title: '{{ devicename }}'
       titleClass: 'omv-text-truncate'
       content: '{{ address | default("-", true) }}<br>{{ address6 | default("-", true) }}'

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-folderbrowser/form-folderbrowser.component.scss
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-folderbrowser/form-folderbrowser.component.scss
@@ -13,6 +13,10 @@
   .mat-button-base:not(:last-child) {
     margin-right: 0.5rem;
   }
+
+  .mat-icon {
+    @extend .omv-color-disabled-text;
+  }
 }
 
 .mat-form-field + .mat-form-field {

--- a/deb/openmediavault/workbench/src/app/shared/components/datatable/datatable.component.scss
+++ b/deb/openmediavault/workbench/src/app/shared/components/datatable/datatable.component.scss
@@ -171,17 +171,21 @@
         vertical-align: middle;
 
         &.disabled a {
-          color: rgba(0, 0, 0, 0.26) !important;
+          @extend .omv-color-disabled-text;
+
           background-color: transparent !important;
         }
 
         &.active a {
-          background-color: rgba(158, 158, 158, 0.2);
+          @extend .omv-background-color-hover;
+
           font-weight: bold;
         }
       }
 
       a {
+        @extend .omv-color-text;
+
         height: 22px;
         min-width: 24px;
         line-height: 22px;
@@ -189,13 +193,12 @@
         border-radius: 3px;
         margin: 6px 3px;
         text-align: center;
-        color: rgba(0, 0, 0, 0.54);
         text-decoration: none;
         vertical-align: bottom;
 
         &:hover {
-          color: rgba(0, 0, 0, 0.75);
-          background-color: rgba(158, 158, 158, 0.2);
+          @extend .omv-color-primary;
+          @extend .omv-background-color-hover;
         }
       }
 

--- a/deb/openmediavault/workbench/src/styles.scss
+++ b/deb/openmediavault/workbench/src/styles.scss
@@ -27,27 +27,41 @@ $omv-typography-config: mat.define-typography-config($omv-font-family-default);
 
 @include mat.core($omv-typography-config);
 
-$omv-light-theme-primary-palette: mat.define-palette($omv-color-corporate-palette);
-$omv-light-theme-accent-palette: map-merge(
+$omv-theme-primary-palette: mat.define-palette($omv-color-corporate-palette);
+$omv-theme-accent-palette: map-merge(
   mat.define-palette($omv-color-yellow-palette),
   (
     // https://paletton.com/#uid=11v0u0kw0v7jRCppdxByzopDWj8
     default-contrast: #988200
   )
 );
-$omv-light-theme-warn-palette: mat.define-palette($omv-color-red-palette);
+$omv-theme-warn-palette: mat.define-palette($omv-color-red-palette);
 
 $omv-light-theme: mat.define-light-theme(
   (
     color: (
-      primary: $omv-light-theme-primary-palette,
-      accent: $omv-light-theme-accent-palette,
-      warn: $omv-light-theme-warn-palette
+      primary: $omv-theme-primary-palette,
+      accent: $omv-theme-accent-palette,
+      warn: $omv-theme-warn-palette
+    )
+  )
+);
+
+$omv-dark-theme: mat.define-dark-theme(
+  (
+    color: (
+      primary: $omv-theme-primary-palette,
+      accent: $omv-theme-accent-palette,
+      warn: $omv-theme-warn-palette
     )
   )
 );
 
 @include mat.all-component-themes($omv-light-theme);
+
+@media (prefers-color-scheme: dark) {
+  @include mat.all-component-colors($omv-dark-theme);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Variables
@@ -283,6 +297,30 @@ $omv-color-themes: (
 
 ////////////////////////////////////////////////////////////////////////////////
 // Colors
+@mixin foreground-color-from-theme-palette($hue) {
+  $palette: map-get($omv-light-theme, foreground);
+
+  color: mat.get-color-from-palette($palette, $hue);
+
+  @media (prefers-color-scheme: dark) {
+    $palette: map-get($omv-dark-theme, foreground);
+
+    color: mat.get-color-from-palette($palette, $hue);
+  }
+}
+
+@mixin background-color-from-theme-palette($hue) {
+  $palette: map-get($omv-light-theme, background);
+
+  background-color: mat.get-color-from-palette($palette, $hue);
+
+  @media (prefers-color-scheme: dark) {
+    $palette: map-get($omv-dark-theme, background);
+
+    background-color: mat.get-color-from-palette($palette, $hue);
+  }
+}
+
 .omv-color-primary {
   color: $omv-color-primary;
 }
@@ -332,11 +370,43 @@ $omv-color-themes: (
   color: $omv-color-transparent-black;
 }
 
+.omv-color-text {
+  @include foreground-color-from-theme-palette(text);
+}
+
+.omv-color-secondary-text {
+  @include foreground-color-from-theme-palette(secondary-text);
+}
+
+.omv-color-disabled-text {
+  @include foreground-color-from-theme-palette(disabled-text);
+}
+
+.omv-color-hint-text {
+  @include foreground-color-from-theme-palette(hint-text);
+}
+
 @each $name, $map in $omv-color-themes {
   .omv-background-color-theme-#{$name} {
     color: map-get($map, color);
     background-color: map-get($map, background-color);
   }
+}
+
+.omv-background-color-hover {
+  @include background-color-from-theme-palette(hover);
+}
+
+.omv-background-color-button {
+  @include background-color-from-theme-palette(button);
+}
+
+.omv-background-color-selected-button {
+  @include background-color-from-theme-palette(selected-button);
+}
+
+.omv-background-color-card {
+  @include background-color-from-theme-palette(card);
 }
 
 .omv-background-color-theme-transparent {
@@ -445,7 +515,7 @@ $omv-color-themes: (
 }
 
 .omv-text-muted {
-  color: $omv-color-transparent-black;
+  @extend .omv-color-disabled-text;
 }
 
 .omv-text-capitalize {
@@ -629,6 +699,10 @@ img.loading {
 // Sidenav
 .mat-sidenav {
   background-color: map-get(mat.$blue-grey-palette, 900);
+
+  @media (prefers-color-scheme: dark) {
+    background-color: mat.get-color-from-palette(map-get($omv-dark-theme, background), background);
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -695,7 +769,8 @@ img.loading {
 
 .mat-form-field-suffix .mat-icon,
 .mat-form-field-prefix .mat-icon {
-  color: $omv-color-transparent-black;
+  @extend .omv-color-secondary-text;
+
   // Suffix/Prefix icons are aligned too high by default.
   vertical-align: bottom;
 }


### PR DESCRIPTION
Automatically switch to dark mode UI if the desktop environment mode has been switched. This should also work on mobile devices if the dark mode is enabled.

![Bildschirmfoto vom 2022-05-30 00-20-36](https://user-images.githubusercontent.com/1897962/170893642-eb749f4e-e10b-4857-9b43-9efb814955f5.png)

![Bildschirmfoto vom 2022-05-30 00-21-05](https://user-images.githubusercontent.com/1897962/170893645-153879b2-81a9-4174-b4db-ec13ada466f9.png)

![Bildschirmfoto vom 2022-05-30 08-34-15](https://user-images.githubusercontent.com/1897962/170931285-460c9d35-57be-4325-8434-a31885ce4a3a.png)

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
