### PR TITLE
salt: proftpd: remove option MultilineRFC2228 by default

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/proftpd/modules/files/mod_core.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/proftpd/modules/files/mod_core.j2
@@ -3,7 +3,6 @@
 {%- set use_ipv6 = salt['pillar.get']('default:OMV_PROFTPD_USEIPV6', 'on') -%}
 {%- set server_type = salt['pillar.get']('default:OMV_PROFTPD_SERVERTYPE', 'standalone') -%}
 {%- set defer_welcome = salt['pillar.get']('default:OMV_PROFTPD_DEFERWELCOME', 'on') -%}
-{%- set multi_line_rfc2228 = salt['pillar.get']('default:OMV_PROFTPD_MULTILINERFC2228', 'on') -%}
 {%- set default_server = salt['pillar.get']('default:OMV_PROFTPD_DEFAULTSERVER', 'on') -%}
 {%- set show_symlinks = salt['pillar.get']('default:OMV_PROFTPD_SHOWSYMLINKS', 'on') -%}
 {%- set list_options = salt['pillar.get']('default:OMV_PROFTPD_LISTOPTIONS', '-l') -%}
@@ -32,7 +31,6 @@ UseIPv6 {{ use_ipv6 }}
 ServerName {{ dns_config.hostname }}
 ServerType {{ server_type }}
 DeferWelcome {{ defer_welcome }}
-MultilineRFC2228 {{ multi_line_rfc2228 }}
 DefaultServer {{ default_server }}
 ShowSymlinks {{ show_symlinks }}
 DisplayChdir .message true


### PR DESCRIPTION
MultilineRFC2228 will break RFC2389 FEAT function.
It will cause incorrect format output of RFC2389. [1]
MultilineRFC2228 is removed from Proftpd's default config in debian after version 1.3.7a-2. [2]
MultilineRFC2228 will also be deprecated after proftpd v1.3.8rc1 [3,4]

We should remove default ON config from salt template and leave it to users' custom config if users need it.

related issue:
[1] https://github.com/proftpd/proftpd/issues/1085
[2] https://salsa.debian.org/debian-proftpd-team/proftpd/-/commit/171fa0a83e138b1237c9afe09370c54679c1e29e
[3] https://github.com/proftpd/proftpd/issues/1089
[4] https://github.com/proftpd/proftpd/commit/dbe279b209e18fee117a0030111b4d0d698f0c5d

Signed-off-by: Date Huang <tjjh89017@hotmail.com>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
