### PR TITLE
Smaller default dialog width

### DIFF
--- a/deb/openmediavault/workbench/src/app/shared/services/dialog.service.ts
+++ b/deb/openmediavault/workbench/src/app/shared/services/dialog.service.ts
@@ -41,7 +41,7 @@ export class DialogService {
       component,
       _.defaultsDeep(config, {
         disableClose: true,
-        width: '50%'
+        width: '30rem'
       })
     );
   }


### PR DESCRIPTION
Just a very small adjustment that makes the default dialog width (used mostly by just confirmations) to be `30rem`. Why `30rem`? Doing some basic testing the width is enough to comfortably fit the message. Why `rem`? This unit scales with user-set font size. When a user with a bigger default font size opens the dialog, it should be wider to fit the text. Not sure if material UI actually interferes with the usability of `rem`. If that's the case, the width should be probably set to absolute pixels.

Also, on screens smaller than `30rem` the dialog width will fit the screen, probably a feature of the material UI design system.

Fixes #1335

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug

![image](https://user-images.githubusercontent.com/2076742/176941096-ec265065-f77e-4bbd-b27f-8d6ae19b9596.png)


_sorry for the double PR, got confused_