### PR TITLE
 Add iOS webapp support

### DIFF
--- a/deb/openmediavault/workbench/src/index.html
+++ b/deb/openmediavault/workbench/src/index.html
@@ -8,6 +8,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="ROBOTS" content="NOINDEX, NOFOLLOW">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+  <meta name="apple-mobile-web-app-capable" content="yes" />
 
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="apple-touch-icon" href="favicon_180x180.png">


### PR DESCRIPTION
This way when pinned to Springboard, Openmediavault opens in its own
instance instead of a Safari tab.
