### PR TITLE
Print more details of SSL certificates

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/certificatemgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/certificatemgmt.inc
@@ -218,19 +218,44 @@ class CertificateMgmt extends \OMV\Rpc\ServiceAbstract {
 		// that the certificate has not been created or updated until now.
 		if ($this->isModuleDirty("certificates"))
 			throw new \OMV\Config\ConfigDirtyException();
+		$output = []
+		// Private key path.
+		$keyPath = sprintf(
+			"%s/private/%s%s.key",
+			\OMV\Environment::get("OMV_SSL_CERTIFICATE_DIR"),
+			\OMV\Environment::get("OMV_SSL_CERTIFICATE_PREFIX"),
+			$params['uuid']
+		)
+		$output[] = sprintf("Private Key Path: %s", $keyPath)
+		// Certificate path.
+		$certPath = sprintf(
+			"%s/certs/%s%s.crt",
+			\OMV\Environment::get("OMV_SSL_CERTIFICATE_DIR"),
+			\OMV\Environment::get("OMV_SSL_CERTIFICATE_PREFIX"),
+			$params['uuid']
+		)
+		$output[] = sprintf("Certificate Path: %s", $certPath)
 		// Get certificate details.
 		$cmdArgs = [];
 		$cmdArgs[] = "x509";
 		$cmdArgs[] = "-text";
 		$cmdArgs[] = "-noout";
-		$cmdArgs[] = sprintf("-in %s", escapeshellarg(sprintf(
-			"%s/certs/%s%s.crt",
-			\OMV\Environment::get("OMV_SSL_CERTIFICATE_DIR"),
-			\OMV\Environment::get("OMV_SSL_CERTIFICATE_PREFIX"),
-			$params['uuid'])));
+		$cmdArgs[] = sprintf("-in %s", escapeshellarg($certPath));
 		$cmd = new \OMV\System\Process("openssl", $cmdArgs);
 		$cmd->setRedirect2to1();
 		$cmd->execute($output);
+		// Get certificate fingerprints.
+		foreach ([ "sha1", "sha256", "sha512" ] as $alg) {
+			$cmd = new \OMV\System\Process("openssl", [
+				"x509",
+				"-noout",
+				sprintf("-in %s", escapeshellarg($certPath)),
+				"-fingerprint",
+				sprintf("-%s", $alg),
+			]);
+			$cmd->setRedirect2to1();
+			$cmd->execute($output);
+		}
 		return implode("\n", $output);
 	}
 

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/certificatemgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/certificatemgmt.inc
@@ -218,23 +218,24 @@ class CertificateMgmt extends \OMV\Rpc\ServiceAbstract {
 		// that the certificate has not been created or updated until now.
 		if ($this->isModuleDirty("certificates"))
 			throw new \OMV\Config\ConfigDirtyException();
-		$output = []
+		$output = [];
 		// Private key path.
 		$keyPath = sprintf(
 			"%s/private/%s%s.key",
 			\OMV\Environment::get("OMV_SSL_CERTIFICATE_DIR"),
 			\OMV\Environment::get("OMV_SSL_CERTIFICATE_PREFIX"),
-			$params['uuid']
-		)
-		$output[] = sprintf("Private Key Path: %s", $keyPath)
+			$params['uuid'],
+		);
+		$output[] = sprintf("Private Key Path: %s", $keyPath);
 		// Certificate path.
 		$certPath = sprintf(
 			"%s/certs/%s%s.crt",
 			\OMV\Environment::get("OMV_SSL_CERTIFICATE_DIR"),
 			\OMV\Environment::get("OMV_SSL_CERTIFICATE_PREFIX"),
-			$params['uuid']
-		)
-		$output[] = sprintf("Certificate Path: %s", $certPath)
+			$params['uuid'],
+		);
+		$output[] = sprintf("Certificate Path: %s", $certPath);
+		$output[] = "\n";
 		// Get certificate details.
 		$cmdArgs = [];
 		$cmdArgs[] = "x509";
@@ -245,6 +246,7 @@ class CertificateMgmt extends \OMV\Rpc\ServiceAbstract {
 		$cmd->setRedirect2to1();
 		$cmd->execute($output);
 		// Get certificate fingerprints.
+		$output[] = "\n";
 		foreach ([ "sha1", "sha256", "sha512" ] as $alg) {
 			$cmd = new \OMV\System\Process("openssl", [
 				"x509",

--- a/deb/openmediavault/usr/share/php/openmediavault/system/process.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/process.inc
@@ -201,6 +201,8 @@ class Process {
 	 * Execute the command.
 	 * @param output If the output argument is present, then the specified
 	 *   array will be filled with every line of output from the command.
+	 *   Note that if it already contains some elements, execute() will
+	 *   append to the end of this array.
 	 * @param exitStatus If the argument is present along with the output
 	 *   argument, then the return status of the executed command will be
 	 *   written to this variable.


### PR DESCRIPTION
Print more details of SSL certificates

Some server program requires path / fingerprints to SSL certificates.
Having these information in the UI simplifies the setup process.

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>



- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
