### PR TITLE
Issue #1241: Use BTRFS subvolumes for shared folders on BTRFS file systems.

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -4,6 +4,15 @@ openmediavault (6.3.0-1) stable; urgency=low
     file systems to the file system creation page in the UI.
   * Enhance the BTRFS file system creation page by adding support
     of profiles to create various RAID levels.
+  * Issue #1241: Use BTRFS subvolumes for shared folders on BTRFS
+    file systems. Snapshots can be created per shared folder.
+    The snapshot management UI allows to create and delete those
+    snapshots. A restore feature has not been implemented by
+    intention because those shared folders need to be unreferenced
+    from every service beforehand. Instead a shared folders should
+    be created from these snapshots, which is a less error-prone
+    approach. The snapshots are stored in the `.snapshots` folder
+    in the root subvolume of the BTRFS file system.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Tue, 31 Jan 2023 12:31:57 +0100
 

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.filesystemmgmt.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.filesystemmgmt.json
@@ -43,7 +43,7 @@
 			},
 			"profile":{
 				"type": "string",
-				"enum": [ "single", "raid0", "raid1", "raid10" ],
+				"enum": [ "single", "dup", "raid0", "raid1", "raid10" ],
 				"required": true
 			},
 			"devicefiles": {

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.sharemgmt.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.sharemgmt.json
@@ -253,4 +253,55 @@
 			}
 		}
 	}
+},{
+	"type": "rpc",
+	"id": "rpc.sharemgmt.deletesnapshot",
+	"params": {
+		"type": "object",
+		"properties": {
+			"uuid": {
+				"type": "string",
+				"format": "uuidv4",
+				"required": true
+			},
+			"id": {
+				"type": [ "string", "integer" ],
+				"required": true
+			}
+		}
+	}
+},{
+	"type": "rpc",
+	"id": "rpc.sharemgmt.restoresnapshot",
+	"params": {
+		"type": "object",
+		"properties": {
+			"uuid": {
+				"type": "string",
+				"format": "uuidv4",
+				"required": true
+			},
+			"id": {
+				"type": [ "string", "integer" ],
+				"required": true
+			}
+		}
+	}
+},{
+	"type": "rpc",
+	"id": "rpc.sharemgmt.fromsnapshot",
+	"params": {
+		"type": "object",
+		"properties": {
+			"uuid": {
+				"type": "string",
+				"format": "uuidv4",
+				"required": true
+			},
+			"id": {
+				"type": [ "string", "integer" ],
+				"required": true
+			}
+		}
+	}
 }]

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/filesystemmgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/filesystemmgmt.inc
@@ -741,6 +741,8 @@ class OMVRpcServiceFileSystemMgmt extends \OMV\Rpc\ServiceAbstract {
 			}
 			// Create the Btrfs volume. We do not need to create an
 			// partition on each associated device.
+			// https://btrfs.readthedocs.io/en/latest/mkfs.btrfs.html#
+			// https://btrfs.readthedocs.io/en/latest/mkfs.btrfs.html#profiles
 			$cmdArgs = [];
 			$cmdArgs[] = "--force";
 			if (!empty($params['label'])) {

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/sharemgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/sharemgmt.inc
@@ -49,6 +49,11 @@ class ShareMgmt extends \OMV\Rpc\ServiceAbstract {
 		$this->registerMethod("getFileACL");
 		$this->registerMethod("setFileACL");
 		$this->registerMethod("getPath");
+		$this->registerMethod("enumerateSnapshots");
+		$this->registerMethod("createSnapshot");
+		$this->registerMethod("deleteSnapshot");
+		$this->registerMethod("restoreSnapshot");
+		$this->registerMethod("fromSnapshot");
 	}
 
 	/**
@@ -132,7 +137,7 @@ class ShareMgmt extends \OMV\Rpc\ServiceAbstract {
 		foreach ($objects as $objectk => $objectv) {
 			$objectDict = new \OMV\Dictionary($objectv->getAssoc());
 			// Set the default values.
-			$objectDict->set("_used", false);
+			$objectDict->set("_used", FALSE);
 			$objectDict->set("device", "");
 			$objectDict->copy("name", "description");
 			$objectDict->set("mntent", [
@@ -142,6 +147,7 @@ class ShareMgmt extends \OMV\Rpc\ServiceAbstract {
 				"type" => "",
 				"posixacl" => FALSE
 			]);
+			$objectDict->set("snapshots", FALSE);
 			// Get the mount point configuration object to append additional
 			// information to the returned objects, e.g. the devicefile or
 			// a modified description.
@@ -190,9 +196,16 @@ class ShareMgmt extends \OMV\Rpc\ServiceAbstract {
 						$objectDict->get("device"),
 						$objectDict->get("reldirpath")));
 				}
+				// Are snapshots supported?
+				$sfAbsPath = build_path(DIRECTORY_SEPARATOR,
+					$meObject->get("dir"), $objectv->get("reldirpath"));
+				if (("btrfs" == $meObject->get("type")) &&
+						$fs->isSubvolume($sfAbsPath)) {
+					$objectDict->set("snapshots", TRUE);
+				}
 			}
-			// Is the shared folder referenced by any object? Shared folder
-			// references are named 'sharedfolderref'.
+			// Is the shared folder referenced by any object? Shared
+			// folder references are named 'sharedfolderref'.
 			$objectDict->set("_used", $db->isReferenced($objectv));
 			// Append the configuration object to the result list.
 			$result[] = $objectDict->getData();
@@ -261,10 +274,10 @@ class ShareMgmt extends \OMV\Rpc\ServiceAbstract {
 	 *   \em name The name of the shared folder.
 	 *   \em reldirpath The relative directory path.
 	 *   \em comment The comment.
-	 *   \em mntentref The UUID of the mount point configuration object wherein
-	 *   the shared folder is located.
+	 *   \em mntentref The UUID of the mount point configuration object
+	 *     wherein the shared folder is located.
 	 *   \em mode The file mode of the shared folder directory. This field
-	 *   is optional. Defaults to 775.
+	 *     is optional. Defaults to 775.
 	 * @param context The context of the caller.
 	 * @return The stored configuration object.
 	 */
@@ -280,16 +293,16 @@ class ShareMgmt extends \OMV\Rpc\ServiceAbstract {
 		// path MUST be below the given mount point.
 		if (1 == preg_match("/\.\./", $params['reldirpath'])) {
 			throw new \InvalidArgumentException(sprintf(
-			  "The field '%s' contains forbidden two-dot symbols.",
-			  "reldirpath"));
+				"The field '%s' contains forbidden two-dot symbols.",
+				"reldirpath"));
 		}
 		// Prepare the configuration object. Use the name of the shared
 		// folder as the relative directory name of the share.
 		$object = new \OMV\Config\ConfigObject("conf.system.sharedfolder");
 		$object->setAssoc($params, TRUE, TRUE);
 		$object->set("reldirpath", build_path(DIRECTORY_SEPARATOR,
-		  ...explode(DIRECTORY_SEPARATOR, $params['reldirpath'])).
-		  DIRECTORY_SEPARATOR);
+			...explode(DIRECTORY_SEPARATOR, $params['reldirpath'])).
+			DIRECTORY_SEPARATOR);
 		// Set the configuration object.
 		$db = \OMV\Config\Database::getInstance();
 		// Check uniqueness:
@@ -324,40 +337,62 @@ class ShareMgmt extends \OMV\Rpc\ServiceAbstract {
 			$oldObject = $db->get("conf.system.sharedfolder",
 				$object->getIdentifier());
 			// Copy the privileges.
-			if (FALSE === $oldObject->isEmpty("privileges"))
+			if (FALSE === $oldObject->isEmpty("privileges")) {
 				$object->set("privileges", $oldObject->get("privileges"));
+			}
 		}
 		$db->set($object);
 		// Append the file mode field to the notification object if set.
 		// Defaults to 775.
 		$object->add("mode", "string", "775");
-		if (array_key_exists("mode", $params))
+		if (array_key_exists("mode", $params)) {
 			$object->set("mode", $params['mode']);
+		}
 		// Get the mount point configuration object to build the absolute
 		// shared folder path.
 		$meObject = $db->get("conf.system.filesystem.mountpoint",
-		  $object->get("mntentref"));
+			$object->get("mntentref"));
 		// Build the absolute shared folder path.
 		$pathName = build_path(DIRECTORY_SEPARATOR, $meObject->get("dir"),
-		  $object->get("reldirpath"));
+			$object->get("reldirpath"));
 		// Create the shared folder directory if necessary.
 		if (FALSE === file_exists($pathName)) {
-			// Create the directory. Note, the function seems to have a bug
-			// when using the mask parameter. E.g. octdec("777") does not
-			// create the correct permissions as expected, thus change the
-			// mode using chmod.
-			if (FALSE === mkdir($pathName, 0700, TRUE)) {
-				$error = error_get_last();
-				throw new \OMV\Exception(
-				  "Failed to create the directory '%s': %s",
-				  $pathName, $error['message']);
+			// Create the directory.
+			switch ($meObject->get("type")) {
+			case "btrfs":
+				$parentDir = dirname($pathName);
+				// Ensure the whole path exists, otherwise the Btrfs
+				// subvolume can't be created.
+				if (FALSE === is_dir($parentDir)) {
+					if (FALSE === mkdir($parentDir, 0700, TRUE)) {
+						$error = error_get_last();
+						throw new \OMV\Exception(
+							"Failed to create the directory '%s': %s",
+							$parentDir, $error['message']);
+					}
+				}
+				// Create the Btrfs subvolume.
+				\OMV\System\Filesystem\Btrfs::createSubvolume($pathName);
+				break;
+			default:
+				// Note, the `mkdir` function seems to have a bug when
+				// using the mask parameter, e.g. `octdec("777")` does
+				// not create the correct permissions as expected, thus
+				// change the mode using chmod.
+				if (FALSE === mkdir($pathName, 0700, TRUE)) {
+					$error = error_get_last();
+					throw new \OMV\Exception(
+						"Failed to create the directory '%s': %s",
+						$pathName, $error['message']);
+				}
+				break;
 			}
-			// Change the directory mode.
+			// Adapt the directory mode.
 			if (FALSE === chmod($pathName, octdec($object->get("mode")))) {
 				$error = error_get_last();
 				throw new \OMV\Exception(
-				  "Failed to set file mode to '%s' for '%s': %s",
-				  $object->get("mode"), $pathName, $error['message']);
+					"Failed to set file mode to '%s' for '%s': %s",
+					$object->get("mode"), $pathName, $error['message']);
 			}
 		}
 		// Change group owner of directory to configured default group,
@@ -367,8 +402,8 @@ class ShareMgmt extends \OMV\Rpc\ServiceAbstract {
 		if (FALSE === chgrp($pathName, $defaultGroup)) {
 			$error = error_get_last();
 			throw new \OMV\Exception(
-			  "Failed to set file group to '%s' for '%s': %s",
-			  $defaultGroup, $pathName, $error['message']);
+				"Failed to set file group to '%s' for '%s': %s",
+				$defaultGroup, $pathName, $error['message']);
 		}
 		// Set the setgid bit. Setting this permission means that all files
 		// created in the folder will inherit the group of the folder rather
@@ -377,8 +412,8 @@ class ShareMgmt extends \OMV\Rpc\ServiceAbstract {
 		if (FALSE === chmod($pathName, $mode)) {
 			$error = error_get_last();
 			throw new \OMV\Exception(
-			  "Failed to set file mode to '%o' for '%s': %s",
-			  $mode, $pathName, $error['message']);
+				"Failed to set file mode to '%o' for '%s': %s",
+				$mode, $pathName, $error['message']);
 		}
 		// Walk through the directory path to make sure group 'users' can
 		// access all subdirectories.
@@ -1120,9 +1155,244 @@ class ShareMgmt extends \OMV\Rpc\ServiceAbstract {
 		// Get the mount point configuration object to build the absolute
 		// shared folder path.
 		$meObject = $db->get("conf.system.filesystem.mountpoint",
-		  $sfObject->get("mntentref"));
+			$sfObject->get("mntentref"));
 		// Return the absolute shared folder path.
 		return build_path(DIRECTORY_SEPARATOR, $meObject->get("dir"),
-		  $sfObject->get("reldirpath"));
+			$sfObject->get("reldirpath"));
+	}
+
+	/**
+	 * Get the snapshots of the specified shared folder.
+	 * @param params An array containing the following fields:
+	 *   \em uuid The UUID of the shared folder configuration object.
+	 * @param context The context of the caller.
+	 * @return An array containing the snapshot information.
+	 */
+	public function enumerateSnapshots($params, $context) {
+		// Validate the RPC caller context.
+		$this->validateMethodContext($context, [
+			"role" => OMV_ROLE_ADMINISTRATOR
+		]);
+		// Validate the parameters of the RPC service method.
+		$this->validateMethodParams($params, "rpc.common.objectuuid");
+		// Get the shared folder and mount point configuration objects.
+		$db = \OMV\Config\Database::getInstance();
+		$sfObject = $db->get("conf.system.sharedfolder", $params['uuid']);
+		$meObject = $db->get("conf.system.filesystem.mountpoint",
+			$sfObject->get("mntentref"));
+		// Get the list of snapshots of this shared folder.
+		if ("btrfs" !== $meObject->get("type")) {
+			return [];
+		}
+		$fs = \OMV\System\Filesystem\Filesystem::getImplByMountPoint(
+			$meObject->get("dir"));
+		$sfAbsPath = build_path(DIRECTORY_SEPARATOR, $meObject->get("dir"),
+			$sfObject->get("reldirpath"));
+		if (FALSE === $fs->isSubvolume($sfAbsPath)) {
+			return [];
+		}
+		$result = [];
+		$svInfo = $fs->getSubvolumeInfo($sfAbsPath);
+		// The snapshots of the subvolumes are stored in the root pool of
+		// the mounted file system.
+		$allSnapshots = $fs->listSnapshots($meObject->get("dir"));
+		$result = array_filter_ex($allSnapshots, "parent_uuid",
+			$svInfo['uuid']);
+		// Check if the snapshot is referenced by a shared folder.
+		$db = \OMV\Config\Database::getInstance();
+		foreach ($result as $snapshotk => &$snapshotv) {
+			$snapshotv['otimets'] = strpdate($snapshotv['otime'],
+				"Y-m-d H:i:s");
+			$snapshotv['abspath'] = build_path(DIRECTORY_SEPARATOR,
+				$meObject->get("dir"), $snapshotv['path']);
+			$snapshotv['_used'] = $db->exists(
+				"conf.system.sharedfolder", [
+					"operator" => "stringEquals",
+					"arg0" => "reldirpath",
+					"arg1" => build_path(DIRECTORY_SEPARATOR,
+						$snapshotv['path'], DIRECTORY_SEPARATOR)
+				]);
+		}
+		return $result;
+	}
+
+	/**
+	 * Get the snapshots of the specified shared folder.
+	 * @param params An array containing the following fields:
+	 *   \em uuid The UUID of the shared folder configuration object.
+	 * @param context The context of the caller.
+	 * @return void
+	 * @throw \OMV\Exception
+	 */
+	public function createSnapshot($params, $context) {
+		// Validate the RPC caller context.
+		$this->validateMethodContext($context, [
+			"role" => OMV_ROLE_ADMINISTRATOR
+		]);
+		// Validate the parameters of the RPC service method.
+		$this->validateMethodParams($params, "rpc.common.objectuuid");
+		// Get the shared folder and mount point configuration objects.
+		$db = \OMV\Config\Database::getInstance();
+		$sfObject = $db->get("conf.system.sharedfolder", $params['uuid']);
+		$meObject = $db->get("conf.system.filesystem.mountpoint",
+			$sfObject->get("mntentref"));
+		// Does the shared folder support snapshots?
+		if ("btrfs" !== $meObject->get("type")) {
+			throw new \OMV\Exception(
+				"The shared folder '%s' does not support snapshots.",
+				$sfObject->get("name"));
+		}
+		$fs = \OMV\System\Filesystem\Filesystem::getImplByMountPoint(
+			$meObject->get("dir"));
+		$sfAbsPath = build_path(DIRECTORY_SEPARATOR, $meObject->get("dir"),
+			$sfObject->get("reldirpath"));
+		if (FALSE === $fs->isSubvolume($sfAbsPath)) {
+			throw new \OMV\Exception(
+				"The shared folder '%s' does not support snapshots.",
+				$sfObject->get("name"));
+		}
+		// Build the target of the snapshot. This includes the name of
+		// the shared folder + the current time in ISO 8601 format.
+		// Make sure the `.snapshots` directory/subvolume exists.
+		$snapshotsDir = build_path(DIRECTORY_SEPARATOR,
+			$meObject->get("dir"), ".snapshots");
+		$snapshotPath = build_path(DIRECTORY_SEPARATOR, $snapshotsDir,
+			sprintf("%s_%s", $sfObject->get("name"), date('c')));
+		if (FALSE === is_dir($snapshotsDir)) {
+			$fs->createSubvolume($snapshotsDir);
+		}
+		$fs->createSnapshot($sfAbsPath, $snapshotPath);
+	}
+
+	/**
+	 * Delete a snapshots of a shared folder.
+	 * @param params An array containing the following fields:
+	 *   \em uuid The UUID of the shared folder configuration object.
+	 *   \em id The ID of the subvolume to delete.
+	 * @param context The context of the caller.
+	 * @return void
+	 * @throw \OMV\Exception
+	 */
+	public function deleteSnapshot($params, $context) {
+		// Validate the RPC caller context.
+		$this->validateMethodContext($context, [
+			"role" => OMV_ROLE_ADMINISTRATOR
+		]);
+		// Validate the parameters of the RPC service method.
+		$this->validateMethodParams($params, "rpc.sharemgmt.deletesnapshot");
+		// Get the shared folder and mount point configuration objects.
+		$db = \OMV\Config\Database::getInstance();
+		$sfObject = $db->get("conf.system.sharedfolder",
+			$params['uuid']);
+		$meObject = $db->get("conf.system.filesystem.mountpoint",
+			$sfObject->get("mntentref"));
+		$fs = \OMV\System\Filesystem\Filesystem::getImplByMountPoint(
+			$meObject->get("dir"));
+		$sfAbsPath = build_path(DIRECTORY_SEPARATOR, $meObject->get("dir"),
+			$sfObject->get("reldirpath"));
+		if (FALSE === $fs->isSubvolume($sfAbsPath)) {
+			throw new \OMV\Exception(
+				"The shared folder '%s' does not support snapshots.",
+				$sfObject->get("name"));
+		}
+		$fs->deleteSnapshot($sfAbsPath, $params['id']);
+	}
+
+	/**
+	 * Restore a snapshots of a shared folder.
+	 * @param params An array containing the following fields:
+	 *   \em uuid The UUID of the shared folder configuration object.
+	 *   \em id The ID of the subvolume to restore.
+	 * @param context The context of the caller.
+	 * @return void
+	 * @throw \OMV\Exception
+	 */
+	public function restoreSnapshot($params, $context) {
+		// Validate the RPC caller context.
+		$this->validateMethodContext($context, [
+			"role" => OMV_ROLE_ADMINISTRATOR
+		]);
+		// Validate the parameters of the RPC service method.
+		$this->validateMethodParams($params, "rpc.sharemgmt.restoresnapshot");
+		// Get the shared folder and mount point configuration objects.
+		$db = \OMV\Config\Database::getInstance();
+		$sfObject = $db->get("conf.system.sharedfolder",
+			$params['uuid']);
+		$meObject = $db->get("conf.system.filesystem.mountpoint",
+			$sfObject->get("mntentref"));
+		$fs = \OMV\System\Filesystem\Filesystem::getImplByMountPoint(
+			$meObject->get("dir"));
+		$sfAbsPath = build_path(DIRECTORY_SEPARATOR, $meObject->get("dir"),
+			$sfObject->get("reldirpath"));
+		if (FALSE === $fs->isSubvolume($sfAbsPath)) {
+			throw new \OMV\Exception(
+				"The shared folder '%s' does not support snapshots.",
+				$sfObject->get("name"));
+		}
+		// Get the list of snapshots.
+		$snapshots = array_filter_ex($fs->listSnapshots($sfAbsPath),
+			"id", $params['id']);
+		if (is_null($snapshots) || empty($snapshots)) {
+			throw new \OMV\Exception(
+				"The snapshot '%s' from '%s' does not exist.",
+				$params['id'], $sfObject->get("name"));
+		}
+		// Delete current subvolume.
+		$fs->deleteSubvolume($sfAbsPath);
+		// Restore the snapshot.
+		$sourcePath = build_path(DIRECTORY_SEPARATOR, $meObject->get("dir"),
+			$snapshots[0]['path']);
+		$fs->createSnapshot($sourcePath, $sfAbsPath);
+	}
+
+	/**
+	 * Create a shared folder from a snapshots.
+	 * @param params An array containing the following fields:
+	 *   \em uuid The UUID of the shared folder configuration object.
+	 *   \em id The ID of the subvolume.
+	 * @param context The context of the caller.
+	 * @return The stored configuration object.
+	 * @throw \OMV\Exception
+	 */
+	public function fromSnapshot($params, $context) {
+		// Validate the RPC caller context.
+		$this->validateMethodContext($context, [
+			"role" => OMV_ROLE_ADMINISTRATOR
+		]);
+		// Validate the parameters of the RPC service method.
+		$this->validateMethodParams($params, "rpc.sharemgmt.fromsnapshot");
+		// Get the shared folder and mount point configuration objects.
+		$db = \OMV\Config\Database::getInstance();
+		$sfObject = $db->get("conf.system.sharedfolder",
+			$params['uuid']);
+		$meObject = $db->get("conf.system.filesystem.mountpoint",
+			$sfObject->get("mntentref"));
+		$fs = \OMV\System\Filesystem\Filesystem::getImplByMountPoint(
+			$meObject->get("dir"));
+		$sfAbsPath = build_path(DIRECTORY_SEPARATOR, $meObject->get("dir"),
+			$sfObject->get("reldirpath"));
+		// Get the list of snapshots.
+		$snapshots = array_filter_ex($fs->listSnapshots($sfAbsPath),
+			"id", $params['id']);
+		if (is_null($snapshots) || empty($snapshots)) {
+			throw new \OMV\Exception(
+				"The snapshot '%s' from '%s' does not exist.",
+				$params['id'], $sfObject->get("name"));
+		}
+		// Get the `mode` settings from the origin shared folder.
+		if (FALSE === ($stat = stat($sfAbsPath))) {
+			throw new \OMV\Exception(
+				"Failed to get file stats from '%s'.", $sfAbsPath);
+		}
+		// Create a new shared folder object.
+		return $this->callMethod("set", [
+			"uuid" => \OMV\Environment::get("OMV_CONFIGOBJECT_NEW_UUID"),
+			"name" => $snapshots[0]['name'],
+			"reldirpath" => $snapshots[0]['path'],
+			"mntentref" => $meObject->get("uuid"),
+			"mode" => decoct($stat['mode'] & 000777),
+			"privileges" => $sfObject->get("privileges"),
+			"comment" => "Snapshot"
+		], $context);
 	}
 }

--- a/deb/openmediavault/usr/share/openmediavault/locale/openmediavault.pot
+++ b/deb/openmediavault/usr/share/openmediavault/locale/openmediavault.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-01 12:18+0100\n"
+"POT-Creation-Date: 2023-02-08 23:14+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -798,6 +798,9 @@ msgid "Created wired network connection."
 msgstr ""
 
 msgid "Created wireless network connection."
+msgstr ""
+
+msgid "Creation Time"
 msgstr ""
 
 msgid "Croatia"
@@ -2105,6 +2108,9 @@ msgstr ""
 msgid "Parent Device"
 msgstr ""
 
+msgid "Parent UUID"
+msgstr ""
+
 msgid "Parent device"
 msgstr ""
 
@@ -2447,9 +2453,6 @@ msgstr ""
 msgid "Reset UI to defaults"
 msgstr ""
 
-msgid "Resize"
-msgstr ""
-
 msgid "Result"
 msgstr ""
 
@@ -2738,6 +2741,9 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+msgid "Share"
+msgstr ""
+
 msgid "Shared Folders"
 msgstr ""
 
@@ -2799,6 +2805,9 @@ msgid "Slovakia"
 msgstr ""
 
 msgid "Slovenia"
+msgstr ""
+
+msgid "Snapshots"
 msgstr ""
 
 msgid "Software Failure.   Press left mouse button to continue."
@@ -3122,6 +3131,9 @@ msgstr ""
 msgid "The shared folder from which the privileges are copied."
 msgstr ""
 
+msgid "The shared folder {{ _selected[0].name }} was successfully created."
+msgstr ""
+
 msgid "The source remote server, e.g. [USER@]HOST:SRC, [USER@]HOST::SRC or rsync://[USER@]HOST[:PORT]/SRC."
 msgstr ""
 
@@ -3354,6 +3366,9 @@ msgid "UID"
 msgstr ""
 
 msgid "UNKNOWN"
+msgstr ""
+
+msgid "UUID"
 msgstr ""
 
 msgid "Uganda"

--- a/deb/openmediavault/usr/share/openmediavault/workbench/component.d/omv-storage-filesystem-btrfs-create-form-page.yaml
+++ b/deb/openmediavault/usr/share/openmediavault/workbench/component.d/omv-storage-filesystem-btrfs-create-form-page.yaml
@@ -19,6 +19,8 @@ data:
           data:
             - - "single"
               - "Single"
+            - - "dup"
+              - "DUP"
             - - "raid0"
               - "RAID0"
             - - "raid1"
@@ -48,10 +50,12 @@ data:
             - constraint:
                 operator: if
                 arg0:
-                  operator: eq
+                  operator: in
                   arg0:
                     prop: profile
-                  arg1: single
+                  arg1:
+                    - single
+                    - dup
                 arg1:
                   operator: '>='
                   arg0:

--- a/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/btrfs.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/btrfs.inc
@@ -404,20 +404,170 @@ class Btrfs extends Filesystem {
 
 	/**
 	 * Check if the specified path is a subvolume.
-	 * @param string $filename The path to check.
+	 * @param string $path The path to check.
 	 * @return Returns TRUE if the specified path is a subvolume,
 	 *   otherwise FALSE.
 	 */
-	public static function isSubvolume($filename) {
+	public static function isSubvolume($path) {
 		$cmdArgs = [];
 		$cmdArgs[] = "subvolume";
 		$cmdArgs[] = "show";
-		$cmdArgs[] = escapeshellarg($filename);
+		$cmdArgs[] = escapeshellarg($path);
 		$cmd = new \OMV\System\Process("btrfs", $cmdArgs);
 		$cmd->setQuiet(TRUE);
 		$cmd->execute($output, $exitStatus);
 		if ($exitStatus !== 0)
 			return FALSE;
 		return TRUE;
+	}
+
+	/**
+	 * Get information about the specified subvolume.
+	 * @param string $path The path of the subvolume.
+	 * @return Returns an array containing the subvolume information,
+	 *   otherwise FALSE.
+	 */
+	public static function getSubvolumeInfo($path) {
+		$cmdArgs = [];
+		$cmdArgs[] = "subvolume";
+		$cmdArgs[] = "show";
+		$cmdArgs[] = escapeshellarg($path);
+		$cmd = new \OMV\System\Process("btrfs", $cmdArgs);
+		$cmd->setQuiet(TRUE);
+		$cmd->execute($output, $exitStatus);
+		if ($exitStatus !== 0)
+			return FALSE;
+		$result = [];
+		// Parse the output:
+		//
+		// test01
+		//     Name:            test01
+		//     UUID:            9b0fa98a-c1aa-934a-83c7-e48ec4d806db
+		//     Parent UUID:     -
+		//     Received UUID:   -
+		//     Creation time:   2023-02-01 16:12:53 +0300
+		//     Subvolume ID:    259
+		//     Generation:      32
+		//     Gen at creation: 12
+		//     Parent ID:       5
+		//     Top level ID:    5
+		//     Flags:           -
+		//     Snapshot(s):
+		//                      .snapshots/test01-foo-bar
+		foreach ($output as $outputk => $outputv) {
+			$regex = "/^\s+([\w ]+):\s+(.+)$/";
+			if (1 !== preg_match($regex, $outputv, $matches)) {
+				continue;
+			}
+			$key = strtolower(str_replace(" ", "_", $matches[1]));
+			$result[$key] = $matches[2];
+		}
+		return $result;
+	}
+
+	/**
+	 * Create a subvolume.
+	 * @param string $path The path of the subvolume.
+	 */
+	public static function createSubvolume($path) {
+		$cmdArgs = [];
+		$cmdArgs[] = "subvolume";
+		$cmdArgs[] = "create";
+		$cmdArgs[] = escapeshellarg($path);
+		$cmd = new \OMV\System\Process("btrfs", $cmdArgs);
+		$cmd->execute();
+	}
+
+	/**
+	 * Delete a subvolume.
+	 * @param string $path The path of the subvolume.
+	 */
+	public static function deleteSubvolume($path) {
+		$cmdArgs = [];
+		$cmdArgs[] = "subvolume";
+		$cmdArgs[] = "delete";
+		$cmdArgs[] = "--verbose";
+		$cmdArgs[] = escapeshellarg($path);
+		$cmd = new \OMV\System\Process("btrfs", $cmdArgs);
+		$cmd->execute();
+	}
+
+	/**
+	 * Get a list of snapshots for the specified subvolume.
+	 * @param string $path The path of the subvolume.
+	 * @return Returns a list of snapshots.
+	 */
+	public static function listSnapshots($path) {
+		$cmdArgs = [];
+		$cmdArgs[] = "subvolume";
+		$cmdArgs[] = "list";
+		$cmdArgs[] = "-s";
+		$cmdArgs[] = "-q";
+		$cmdArgs[] = "-u";
+		$cmdArgs[] = escapeshellarg($path);
+		$cmd = new \OMV\System\Process("btrfs", $cmdArgs);
+		$cmd->execute($output);
+		$result = [];
+		// Parse the output:
+		//
+		// ID 262 gen 32 cgen 32 top level 5 otime 2023-02-02 15:01:14 parent_uuid 9b0fa98a-c1aa-934a-83c7-e48ec4d806db uuid d1cad0c2-10f7-8441-a978-c5e1c6ecf40b path .snapshots/test01-foo-bar
+		foreach ($output as $outputk => $outputv) {
+			$regex = "/^ID (\d+) gen (\d+) cgen (\d+) top level (\d+) otime (.+) parent_uuid (.+) uuid (.+) path (.+)$/";
+			if (1 !== preg_match($regex, $outputv, $matches)) {
+				continue;
+			}
+			$result[] = [
+				"id" => $matches[1],
+				"gen" => $matches[2],
+				"cgen" => $matches[3],
+				"top_level" => $matches[4],
+				"otime" => $matches[5],
+				"parent_uuid" => $matches[6],
+				"uuid" => $matches[7],
+				"path" => $matches[8],
+				"name" => basename($matches[8])
+			];
+		}
+		return $result;
+	}
+
+	/**
+	 * Create a snapshot of the specified subvolume.
+	 * @param string $path The path of the subvolume.
+	 * @param string $target The path where the snapshot is stored.
+	 * @param bool $readOnly Make the new snapshot readonly.
+	 *   Defaults to FALSE.
+	 * @return void
+	 */
+	public static function createSnapshot($path, $target, $readOnly = FALSE) {
+		$cmdArgs = [];
+		$cmdArgs[] = "subvolume";
+		$cmdArgs[] = "snapshot";
+		if (TRUE === $readOnly) {
+			$cmdArgs[] = "-r";
+		}
+		$cmdArgs[] = escapeshellarg($path);
+		$cmdArgs[] = escapeshellarg($target);
+		$cmd = new \OMV\System\Process("btrfs", $cmdArgs);
+		$cmd->execute();
+	}
+
+	/**
+	 * Delete a snapshot of a specified subvolume.
+	 * @param string $path The path of the subvolume.
+	 * @param string|int $id The ID of the subvolume. Defaults to NULL.
+	 * @return void
+	 */
+	public static function deleteSnapshot($path, $id = NULL) {
+		$cmdArgs = [];
+		$cmdArgs[] = "subvolume";
+		$cmdArgs[] = "delete";
+		if (!is_null($id)) {
+			$cmdArgs[] = "--subvolid";
+			$cmdArgs[] = $id;
+		}
+		$cmdArgs[] = escapeshellarg($path);
+		$cmd = new \OMV\System\Process("btrfs", $cmdArgs);
+		$cmd->execute();
 	}
 }

--- a/deb/openmediavault/workbench/src/app/pages/storage/shared-folders/shared-folder-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/storage/shared-folders/shared-folder-datatable-page.component.ts
@@ -138,6 +138,20 @@ export class SharedFolderDatatablePageComponent {
         }
       },
       {
+        type: 'iconButton',
+        icon: 'mdi:camera',
+        tooltip: gettext('Snapshots'),
+        enabledConstraints: {
+          minSelected: 1,
+          maxSelected: 1,
+          constraint: [{ operator: 'truthy', arg0: { prop: 'snapshots' } }]
+        },
+        execute: {
+          type: 'url',
+          url: '/storage/shared-folders/snapshots/{{ _selected[0].uuid }}'
+        }
+      },
+      {
         template: 'delete',
         enabledConstraints: {
           constraint: [

--- a/deb/openmediavault/workbench/src/app/pages/storage/shared-folders/shared-folder-snapshots-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/storage/shared-folders/shared-folder-snapshots-datatable-page.component.ts
@@ -1,0 +1,198 @@
+/**
+ * This file is part of OpenMediaVault.
+ *
+ * @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+ * @author    Volker Theile <volker.theile@openmediavault.org>
+ * @copyright Copyright (c) 2009-2023 Volker Theile
+ *
+ * OpenMediaVault is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * OpenMediaVault is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+import { Component } from '@angular/core';
+import { marker as gettext } from '@ngneat/transloco-keys-manager/marker';
+
+import { DatatablePageConfig } from '~/app/core/components/intuition/models/datatable-page-config.type';
+
+@Component({
+  template: '<omv-intuition-datatable-page [config]="this.config"></omv-intuition-datatable-page>'
+})
+export class SharedFolderSnapshotsDatatablePageComponent {
+  public config: DatatablePageConfig = {
+    stateId: '7fcc8590-a2e3-11ed-ac0f-238d9ec75eda',
+    autoReload: false,
+    limit: 0,
+    hasFooter: false,
+    hasSearchField: false,
+    selectionType: 'single',
+    columns: [
+      {
+        name: gettext('ID'),
+        prop: 'id',
+        flexGrow: 1,
+        sortable: true,
+        hidden: true
+      },
+      {
+        name: gettext('Name'),
+        prop: 'name',
+        flexGrow: 2,
+        sortable: true
+      },
+      {
+        name: gettext('Creation Time'),
+        prop: 'otimets',
+        flexGrow: 1,
+        sortable: true,
+        cellTemplateName: 'localeDateTime'
+      },
+      {
+        name: gettext('UUID'),
+        prop: 'uuid',
+        flexGrow: 1,
+        sortable: true,
+        hidden: true,
+        cellTemplateName: 'copyToClipboard'
+      },
+      {
+        name: gettext('Parent UUID'),
+        prop: 'parent_uuid',
+        flexGrow: 1,
+        sortable: true,
+        hidden: true,
+        cellTemplateName: 'copyToClipboard'
+      },
+      {
+        name: gettext('Relative Path'),
+        prop: 'path',
+        flexGrow: 1,
+        sortable: true,
+        hidden: true,
+        cellTemplateName: 'copyToClipboard'
+      },
+      {
+        name: gettext('Absolute Path'),
+        prop: 'abspath',
+        flexGrow: 1,
+        sortable: true,
+        hidden: true,
+        cellTemplateName: 'copyToClipboard'
+      },
+      {
+        name: gettext('Referenced'),
+        prop: '_used',
+        flexGrow: 1,
+        sortable: true,
+        cellTemplateName: 'checkIcon'
+      }
+    ],
+    sorters: [
+      {
+        dir: 'asc',
+        prop: 'name'
+      }
+    ],
+    store: {
+      proxy: {
+        service: 'ShareMgmt',
+        get: {
+          method: 'enumerateSnapshots',
+          params: {
+            uuid: '{{ _routeParams.uuid }}'
+          }
+        }
+      }
+    },
+    actions: [
+      {
+        template: 'create',
+        execute: {
+          type: 'request',
+          request: {
+            service: 'ShareMgmt',
+            method: 'createSnapshot',
+            params: {
+              uuid: '{{ _routeParams.uuid }}'
+            }
+          }
+        }
+      },
+      {
+        type: 'iconButton',
+        icon: 'share',
+        tooltip: gettext('Share'),
+        enabledConstraints: {
+          minSelected: 1,
+          maxSelected: 1,
+          constraint: [{ operator: 'falsy', arg0: { prop: '_used' } }]
+        },
+        execute: {
+          type: 'request',
+          request: {
+            service: 'ShareMgmt',
+            method: 'fromSnapshot',
+            params: {
+              uuid: '{{ _routeParams.uuid }}',
+              id: '{{ id }}'
+            },
+            successNotification: gettext(
+              'The shared folder {{ _selected[0].name }} was successfully created.'
+            )
+          }
+        }
+      },
+      // {
+      //   type: 'iconButton',
+      //   icon: 'restore',
+      //   tooltip: gettext('Restore'),
+      //   enabledConstraints: {
+      //     minSelected: 1,
+      //     maxSelected: 1
+      //   },
+      //   execute: {
+      //     type: 'request',
+      //     request: {
+      //       service: 'ShareMgmt',
+      //       method: 'restoreSnapshot',
+      //       params: {
+      //         uuid: '{{ _routeParams.uuid }}',
+      //         id: '{{ id }}'
+      //       }
+      //     }
+      //   }
+      // },
+      {
+        template: 'delete',
+        enabledConstraints: {
+          constraint: [
+            // Disable button if the snapshot is in use.
+            { operator: 'falsy', arg0: { prop: '_used' } }
+          ]
+        },
+        execute: {
+          type: 'request',
+          request: {
+            service: 'ShareMgmt',
+            method: 'deleteSnapshot',
+            params: {
+              uuid: '{{ _routeParams.uuid }}',
+              id: '{{ id }}'
+            }
+          }
+        }
+      }
+    ],
+    buttons: [
+      {
+        template: 'back',
+        url: '/storage/shared-folders'
+      }
+    ]
+  };
+}

--- a/deb/openmediavault/workbench/src/app/pages/storage/storage-routing.module.ts
+++ b/deb/openmediavault/workbench/src/app/pages/storage/storage-routing.module.ts
@@ -22,6 +22,7 @@ import { SharedFolderAclFormPageComponent } from '~/app/pages/storage/shared-fol
 import { SharedFolderDatatablePageComponent } from '~/app/pages/storage/shared-folders/shared-folder-datatable-page.component';
 import { SharedFolderFormPageComponent } from '~/app/pages/storage/shared-folders/shared-folder-form-page.component';
 import { SharedFolderPrivilegesDatatablePageComponent } from '~/app/pages/storage/shared-folders/shared-folder-privileges-datatable-page.component';
+import { SharedFolderSnapshotsDatatablePageComponent } from '~/app/pages/storage/shared-folders/shared-folder-snapshots-datatable-page.component';
 import { SmartDeviceDatatablePageComponent } from '~/app/pages/storage/smart/smart-device-datatable-page.component';
 import { SmartDeviceDetailsTabsPageComponent } from '~/app/pages/storage/smart/smart-device-details-tabs-page.component';
 import { SmartDeviceFormPageComponent } from '~/app/pages/storage/smart/smart-device-form-page.component';
@@ -182,6 +183,13 @@ const routes: Routes = [
         data: {
           title: gettext('ACL'),
           notificationTitle: gettext('Updated access control list of shared folder.')
+        }
+      },
+      {
+        path: 'snapshots/:uuid',
+        component: SharedFolderSnapshotsDatatablePageComponent,
+        data: {
+          title: gettext('Snapshots')
         }
       }
     ]

--- a/deb/openmediavault/workbench/src/app/pages/storage/storage.module.ts
+++ b/deb/openmediavault/workbench/src/app/pages/storage/storage.module.ts
@@ -21,6 +21,7 @@ import { SharedFolderAclFormPageComponent } from '~/app/pages/storage/shared-fol
 import { SharedFolderDatatablePageComponent } from '~/app/pages/storage/shared-folders/shared-folder-datatable-page.component';
 import { SharedFolderFormPageComponent } from '~/app/pages/storage/shared-folders/shared-folder-form-page.component';
 import { SharedFolderPrivilegesDatatablePageComponent } from '~/app/pages/storage/shared-folders/shared-folder-privileges-datatable-page.component';
+import { SharedFolderSnapshotsDatatablePageComponent } from '~/app/pages/storage/shared-folders/shared-folder-snapshots-datatable-page.component';
 import { SmartDeviceDatatablePageComponent } from '~/app/pages/storage/smart/smart-device-datatable-page.component';
 import { SmartDeviceDetailsTabsPageComponent } from '~/app/pages/storage/smart/smart-device-details-tabs-page.component';
 import { SmartDeviceFormPageComponent } from '~/app/pages/storage/smart/smart-device-form-page.component';
@@ -50,6 +51,7 @@ import { SharedModule } from '~/app/shared/shared.module';
     MdRecoverFormPageComponent,
     SharedFolderFormPageComponent,
     SharedFolderPrivilegesDatatablePageComponent,
+    SharedFolderSnapshotsDatatablePageComponent,
     FilesystemEditFormPageComponent,
     FilesystemMountFormPageComponent,
     FilesystemQuotaDatatablePageComponent,

--- a/deb/openmediavault/workbench/src/app/shared/enum/icon.enum.ts
+++ b/deb/openmediavault/workbench/src/app/shared/enum/icon.enum.ts
@@ -97,5 +97,6 @@ export enum Icon {
   collapse = 'mdi:arrow-collapse',
   folder = 'mdi:folder',
   console = 'mdi:console',
-  close = 'mdi:window-close'
+  close = 'mdi:window-close',
+  restore = 'mdi:restore'
 }


### PR DESCRIPTION
Snapshots can be created per shared folder. The snapshot management UI allows to create and delete those snapshots. A restore feature has not been implemented by intention because those shared folders need to be unreferenced from every service beforehand. Instead shared folders should be created from these snapshots, which is a less error-prone approach.

- Subvolumes will be used for shared folders on BTRFS volumes.
- Add snapshot management for shared folders.
- A restore/rollback of snapshots has NOT been implemented by intention because it is difficult to do that when running services access the shared folder. Forcing the users to remove all shares beforehand (as suggested in the docs of a commencial NAS) does not make sense. Instead the user can easily create a shared folder pointing to the snapshot.
- Snapshots are NOT stored below the shared folder, instead they are stored in the root of the BTRFS filesystem in the `.snapshots` subvolume. This is done to do not pollute the shared folder which might cause side-effect, e.g. when syncing data with tools that do not know that `.snapshots` should be ignored.
- Snapshots are named like the shared folder and a timestamp in ISO 8601 format.

```
|- /srv/xxxx (Mount point BTRFS filesystem)
  |- .snapshots
  |- Shared folder 1
  |- Shared folder 2
```

![Peek 2023-02-02 18-03](https://user-images.githubusercontent.com/1897962/216392673-4987ffc7-f837-4bc1-a9b7-3ac831b345c1.gif)

![Peek 2023-02-06 18-19](https://user-images.githubusercontent.com/1897962/217040188-03b5de8b-25ea-446b-8dcb-32ba211d8dcd.gif)

Fixes: https://github.com/openmediavault/openmediavault/issues/312
Fixes: https://github.com/openmediavault/openmediavault/issues/1241

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
