### PR TITLE
Issue #1490: Support SMB shadow copies for shared folders that are located on a BTRFS file system.

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -13,6 +13,8 @@ openmediavault (6.3.0-2) stable; urgency=low
     be created from these snapshots, which is a less error-prone
     approach. The snapshots are stored in the `.snapshots` folder
     in the root subvolume of the BTRFS file system.
+  * Issue #1490: Support SMB shadow copies for shared folders that
+    are located on a BTRFS file system.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Tue, 31 Jan 2023 12:31:57 +0100
 

--- a/deb/openmediavault/debian/openmediavault.postinst
+++ b/deb/openmediavault/debian/openmediavault.postinst
@@ -437,6 +437,9 @@ case "$1" in
 		  # the unit file must be unmasked.
 			systemctl unmask proftpd.service || :
 		fi
+		if dpkg --compare-versions "$2" lt-nl "6.3.0"; then
+			omv_module_set_dirty samba
+		fi
 
 		########################################################################
 		# Trigger the restart of the omv-engined daemon to load and use the

--- a/deb/openmediavault/srv/salt/omv/deploy/samba/files/shares.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/samba/files/shares.j2
@@ -27,13 +27,16 @@
 {%- set fruit_veto_appledouble = salt['pillar.get']('default:OMV_SAMBA_SHARE_FRUIT_VETOAPPLEDOUBLE', 'no') -%}
 {%- set fruit_wipe_intentionally_left_blank_rfork = salt['pillar.get']('default:OMV_SAMBA_SHARE_FRUIT_WIPEINTENTIONALLYLEFTBLANKRFORK', 'yes') -%}
 {%- set fruit_delete_empty_adfiles = salt['pillar.get']('default:OMV_SAMBA_SHARE_FRUIT_DELETEEMPTYADFILES', 'yes') -%}
+{%- set shadow_sort = salt['pillar.get']('default:OMV_SAMBA_SHARE_SHADOW_SORT', 'desc') -%}
 #======================= Share Definitions =======================
 {%- for share in config.shares.share | selectattr('enable') %}
-[{{ salt['omv_conf.get_sharedfolder_name'](share.sharedfolderref) }}]
+{%- set sf_name = salt['omv_conf.get_sharedfolder_name'](share.sharedfolderref) %}
+{%- set sf_path = salt['omv_conf.get_sharedfolder_path'](share.sharedfolderref) %}
+[{{ sf_name }}]
 {%- if share.comment | length > 0 %}
 comment = {{ share.comment }}
 {%- endif %}
-path = {{ salt['omv_conf.get_sharedfolder_path'](share.sharedfolderref) }}
+path = {{ sf_path }}
 guest ok = {{ (share.guest != 'no') | yesno }}
 guest only = {{ (share.guest == 'only') | yesno }}
 read only = {{ share.readonly | to_bool | yesno }}
@@ -80,6 +83,13 @@ recycle:maxsize = {{ share.recyclemaxsize }}
 {%- endif %}
 {%- if share.sharedfolderref | omv_conf_get_by_identifier('conf.system.sharedfolder') | attr('mntentref') | omv_conf_get_by_identifier('conf.system.filesystem.mountpoint') | attr('type') == 'btrfs' %}
 {%- set _ = vfs_objects.append('btrfs') %}
+{%- set _ = vfs_objects.append('shadow_copy2') %}
+shadow:mountpoint = {{ salt['omv_conf.get_sharedfolder_mount_path'](share.sharedfolderref) }}
+shadow:snapdir = .snapshots
+shadow:basedir = {{ sf_path }}
+shadow:sort = {{ shadow_sort }}
+shadow:format = {{ sf_name }}_%FT%T
+shadow:localtime = yes
 {%- endif %}
 vfs objects = {{ vfs_objects | unique | join(' ') }}
 printable = {{ printable }}

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/sharemgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/sharemgmt.inc
@@ -1252,12 +1252,14 @@ class ShareMgmt extends \OMV\Rpc\ServiceAbstract {
 				$sfObject->get("name"));
 		}
 		// Build the target of the snapshot. This includes the name of
-		// the shared folder + the current time in ISO 8601 format.
+		// the shared folder + the current time in ISO 8601 format
+		// (without time zone designator).
 		// Make sure the `.snapshots` directory/subvolume exists.
 		$snapshotsDir = build_path(DIRECTORY_SEPARATOR,
 			$meObject->get("dir"), ".snapshots");
 		$snapshotPath = build_path(DIRECTORY_SEPARATOR, $snapshotsDir,
-			sprintf("%s_%s", $sfObject->get("name"), date('c')));
+			sprintf("%s_%s", $sfObject->get("name"),
+			date('Y-m-d\TH:i:s')));
 		if (FALSE === is_dir($snapshotsDir)) {
 			$fs->createSubvolume($snapshotsDir);
 		}


### PR DESCRIPTION
Note, the snapshot file name need to be changed to ISO 8601 without time zone designator because strptime (in vfs_shadow_copy2) can not parse the date correct otherwise.

Fixes: https://github.com/openmediavault/openmediavault/issues/1490

Signed-off-by: Volker Theile <votdev@gmx.de>


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
