### PR TITLE
Issue #1500: Use ISO 8601 basic format in the snapshot naming schema.

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -2,6 +2,11 @@ openmediavault (6.3.2-1) stable; urgency=low
 
   * Issue #1490: Support SMB shadow copies for home directories
     when the shared folder is located on a BTRFS file system.
+  * Issue #1500: Use ISO 8601 basic format in the snapshot
+    naming schema because Windows does not support `:` in
+    file names. Note that due to this change, earlier snapshots
+    with the ISO 8601 extended format are no longer listed under
+    Windows in `Previous Versions`.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Mon, 20 Feb 2023 01:39:54 +0100
 

--- a/deb/openmediavault/srv/salt/omv/deploy/samba/files/homes.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/samba/files/homes.j2
@@ -52,7 +52,7 @@ shadow:mountpoint = {{ sf_mount_path }}
 shadow:snapdir = {{ sf_mount_path | path_join('.snapshots') | path_prettify }}
 shadow:basedir = {{ sf_path }}
 shadow:sort = {{ shadow_sort }}
-shadow:format = homes_%FT%T
+shadow:format = homes_%Y%m%dT%H%M%S
 shadow:localtime = yes
 {%- endif %}
 vfs objects = {{ vfs_objects | unique | join(' ') }}

--- a/deb/openmediavault/srv/salt/omv/deploy/samba/files/shares.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/samba/files/shares.j2
@@ -89,7 +89,7 @@ shadow:mountpoint = {{ sf_mount_path }}
 shadow:snapdir = {{ sf_mount_path | path_join('.snapshots') | path_prettify }}
 shadow:basedir = {{ sf_path }}
 shadow:sort = {{ shadow_sort }}
-shadow:format = {{ sf_name }}_%FT%T
+shadow:format = {{ sf_name }}_%Y%m%dT%H%M%S
 shadow:localtime = yes
 {%- endif %}
 vfs objects = {{ vfs_objects | unique | join(' ') }}

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/sharemgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/sharemgmt.inc
@@ -1254,11 +1254,11 @@ class ShareMgmt extends \OMV\Rpc\ServiceAbstract {
 				$sfObject->get("name"));
 		}
 		// Build the target of the snapshot. This includes the name of
-		// the shared folder + the current time in ISO 8601 format
+		// the shared folder + the current time in ISO 8601 basic format
 		// (without time zone designator).
 		// Make sure the `.snapshots` directory/subvolume exists.
 		$snapshotName = sprintf("%s_%s", $sfObject->get("name"),
-			date('Y-m-d\TH:i:s'));
+			date('Ymd\THis'));
 		$snapshotsDir = build_path(DIRECTORY_SEPARATOR,
 			$meObject->get("dir"), ".snapshots");
 		$snapshotPath = build_path(DIRECTORY_SEPARATOR, $snapshotsDir,


### PR DESCRIPTION
Switch from ISO 8601 extended to basic format because SMB/Windows does not support `:` in file names. Note that due to this change, earlier snapshots with the ISO 8601 extended format are no longer listed under Windows in `Previous Versions`.

The naming schema is hardcoded by intention because PHP and date (CLI) do not use the same pattern which would result in using two environment variables and completely denies the use of a UI setting to allow users to specify their own naming schema. IMO, OMV does not need to support everything. Following KISS is sometimes the better choice.

Fixes: https://github.com/openmediavault/openmediavault/issues/1500


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
