### PR TITLE
Add the ability to specify the metric (relative priority) …

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -5,6 +5,9 @@ openmediavault (6.3.3-1) stable; urgency=low
     via scheduled tasks, e.g. `images@daily_20230228T095758`.
     Please delete your existing scheduled tasks and recreate
     them to take advantage of the new naming scheme.
+  * Add the ability to specify the metric (relative priority)
+    of the default route set via the `Gateway` option in the
+    network interface page.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Tue, 28 Feb 2023 00:08:49 +0100
 

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/bond.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/bond.j2
@@ -28,11 +28,22 @@ network:
       - {{ interface.address6 }}/{{ interface.netmask6 }}
 {%- endif %}
 {%- endif %}
+{%- if (interface.method == "static" and interface.gateway | is_ipv4) or (interface.method6 == "static" and interface.gateway6 | is_ipv6) %}
+      routes:
 {%- if interface.method == "static" and interface.gateway | is_ipv4 %}
-      gateway4: {{ interface.gateway }}
+      - to: 0.0.0.0/0
+        via: {{ interface.gateway }}
+{%- if interface.routemetric > 0 %}
+        metric: {{ interface.routemetric }}
+{%- endif %}
 {%- endif %}
 {%- if interface.method6 == "static" and interface.gateway6 | is_ipv6 %}
-      gateway6: {{ interface.gateway6 }}
+      - to: ::/0
+        via: {{ interface.gateway6 }}
+{%- if interface.routemetric6 != 1 %}
+        metric: {{ interface.routemetric6 }}
+{%- endif %}
+{%- endif %}
 {%- endif %}
 {%- if interface.method6 in ["auto", "dhcp"] %}
       accept-ra: true

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/bridge.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/bridge.j2
@@ -28,11 +28,22 @@ network:
       - {{ interface.address6 }}/{{ interface.netmask6 }}
 {%- endif %}
 {%- endif %}
+{%- if (interface.method == "static" and interface.gateway | is_ipv4) or (interface.method6 == "static" and interface.gateway6 | is_ipv6) %}
+      routes:
 {%- if interface.method == "static" and interface.gateway | is_ipv4 %}
-      gateway4: {{ interface.gateway }}
+      - to: 0.0.0.0/0
+        via: {{ interface.gateway }}
+{%- if interface.routemetric > 0 %}
+        metric: {{ interface.routemetric }}
+{%- endif %}
 {%- endif %}
 {%- if interface.method6 == "static" and interface.gateway6 | is_ipv6 %}
-      gateway6: {{ interface.gateway6 }}
+      - to: ::/0
+        via: {{ interface.gateway6 }}
+{%- if interface.routemetric6 != 1 %}
+        metric: {{ interface.routemetric6 }}
+{%- endif %}
+{%- endif %}
 {%- endif %}
 {%- if interface.method6 in ["auto", "dhcp"] %}
       accept-ra: true

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/ethernet.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/ethernet.j2
@@ -14,11 +14,22 @@ network:
       - {{ interface.address6 }}/{{ interface.netmask6 }}
 {%- endif %}
 {%- endif %}
+{%- if (interface.method == "static" and interface.gateway | is_ipv4) or (interface.method6 == "static" and interface.gateway6 | is_ipv6) %}
+      routes:
 {%- if interface.method == "static" and interface.gateway | is_ipv4 %}
-      gateway4: {{ interface.gateway }}
+      - to: 0.0.0.0/0
+        via: {{ interface.gateway }}
+{%- if interface.routemetric > 0 %}
+        metric: {{ interface.routemetric }}
+{%- endif %}
 {%- endif %}
 {%- if interface.method6 == "static" and interface.gateway6 | is_ipv6 %}
-      gateway6: {{ interface.gateway6 }}
+      - to: ::/0
+        via: {{ interface.gateway6 }}
+{%- if interface.routemetric6 != 1 %}
+        metric: {{ interface.routemetric6 }}
+{%- endif %}
+{%- endif %}
 {%- endif %}
 {%- if interface.method6 in ["auto", "dhcp"] %}
       accept-ra: true

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/vlan.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/vlan.j2
@@ -11,11 +11,22 @@ network:
       - {{ interface.address6 }}/{{ interface.netmask6 }}
 {%- endif %}
 {%- endif %}
+{%- if (interface.method == "static" and interface.gateway | is_ipv4) or (interface.method6 == "static" and interface.gateway6 | is_ipv6) %}
+      routes:
 {%- if interface.method == "static" and interface.gateway | is_ipv4 %}
-      gateway4: {{ interface.gateway }}
+      - to: 0.0.0.0/0
+        via: {{ interface.gateway }}
+{%- if interface.routemetric > 0 %}
+        metric: {{ interface.routemetric }}
+{%- endif %}
 {%- endif %}
 {%- if interface.method6 == "static" and interface.gateway6 | is_ipv6 %}
-      gateway6: {{ interface.gateway6 }}
+      - to: ::/0
+        via: {{ interface.gateway6 }}
+{%- if interface.routemetric6 != 1 %}
+        metric: {{ interface.routemetric6 }}
+{%- endif %}
+{%- endif %}
 {%- endif %}
 {%- if interface.method6 in ["auto", "dhcp"] %}
       accept-ra: true

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/wifi.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/wifi.j2
@@ -11,11 +11,22 @@ network:
       - {{ interface.address6 }}/{{ interface.netmask6 }}
 {%- endif %}
 {%- endif %}
+{%- if (interface.method == "static" and interface.gateway | is_ipv4) or (interface.method6 == "static" and interface.gateway6 | is_ipv6) %}
+      routes:
 {%- if interface.method == "static" and interface.gateway | is_ipv4 %}
-      gateway4: {{ interface.gateway }}
+      - to: 0.0.0.0/0
+        via: {{ interface.gateway }}
+{%- if interface.routemetric > 0 %}
+        metric: {{ interface.routemetric }}
+{%- endif %}
 {%- endif %}
 {%- if interface.method6 == "static" and interface.gateway6 | is_ipv6 %}
-      gateway6: {{ interface.gateway6 }}
+      - to: ::/0
+        via: {{ interface.gateway6 }}
+{%- if interface.routemetric6 != 1 %}
+        metric: {{ interface.routemetric6 }}
+{%- endif %}
+{%- endif %}
 {%- endif %}
 {%- if interface.method6 in ["auto", "dhcp"] %}
       accept-ra: true

--- a/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_6.3.3.sh
+++ b/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_6.3.3.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+set -e
+
+. /usr/share/openmediavault/scripts/helper-functions
+
+omv_config_add_key "/config/system/network/interfaces/interface" "routemetric" "0"
+omv_config_add_key "/config/system/network/interfaces/interface" "routemetric6" "1"
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/confdb/populate.d/40interfaces.sh
+++ b/deb/openmediavault/usr/share/openmediavault/confdb/populate.d/40interfaces.sh
@@ -66,12 +66,12 @@ grep -iP "^\s*iface\s+(eth[0-9]+|en[a-z0-9]+)\s+(inet|inet6)\s+(static|dhcp)" ${
             fi
             jq --null-input --compact-output "{uuid: \"${OMV_CONFIGOBJECT_NEW_UUID}\", \
                 devicename: \"${devname}\", type: \"ethernet\", method6: \"manual\", \
-                address6: \"\", netmask6: 64, gateway6: \"\", \
+                address6: \"\", netmask6: 64, gateway6: \"\", routemetric6: 1, \
                 dnsnameservers: \"${dnsnameservers}\", dnssearch: \"\", \
                 wol: false, mtu: 0, \
                 comment: \"\", method: \"${method}\", \
                 address: \"${address}\", netmask: \"${netmask}\", \
-                gateway: \"${gateway}\"}" |
+                gateway: \"${gateway}\", routemetric: 0}" |
                 omv-confdbadm update "conf.system.network.interface" -
         fi
     done

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.system.network.interface.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.system.network.interface.json
@@ -35,6 +35,12 @@
 		"gateway": {
 			"type": "string"
 		},
+		"routemetric": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 65535,
+			"default": 0
+		},
 		"method6": {
 			"type": "string",
 			"enum": [ "auto", "dhcp", "static", "manual" ],
@@ -51,6 +57,12 @@
 		},
 		"gateway6": {
 			"type": "string"
+		},
+		"routemetric6": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 65535,
+			"default": 1
 		},
 		"dnsnameservers": {
 			"type": "string",

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.network.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.network.json
@@ -30,6 +30,12 @@
 			   "type": "string",
 			   "required": true
 			},
+			"routemetric": {
+			   "type": "integer",
+			   "minimum": 0,
+			   "maximum": 65535,
+			   "required": true
+			},
 			"method6": {
 			   "type": "string",
 			   "enum": [ "auto", "static", "manual", "dhcp" ],
@@ -47,6 +53,12 @@
 			},
 			"gateway6": {
 			   "type": "string",
+			   "required": true
+			},
+			"routemetric6": {
+			   "type": "integer",
+			   "minimum": 0,
+			   "maximum": 65535,
 			   "required": true
 			},
 			"dnsnameservers": {
@@ -107,6 +119,12 @@
 			   "type": "string",
 			   "required": true
 			},
+			"routemetric": {
+			   "type": "integer",
+			   "minimum": 0,
+			   "maximum": 65535,
+			   "required": true
+			},
 			"method6": {
 			   "type": "string",
 			   "enum": [ "auto", "static", "manual", "dhcp" ],
@@ -124,6 +142,12 @@
 			},
 			"gateway6": {
 			   "type": "string",
+			   "required": true
+			},
+			"routemetric6": {
+			   "type": "integer",
+			   "minimum": 0,
+			   "maximum": 65535,
 			   "required": true
 			},
 			"dnsnameservers": {
@@ -216,6 +240,12 @@
 			   "type": "string",
 			   "required": true
 			},
+			"routemetric": {
+			   "type": "integer",
+			   "minimum": 0,
+			   "maximum": 65535,
+			   "required": true
+			},
 			"method6": {
 			   "type": "string",
 			   "enum": [ "auto", "static", "manual", "dhcp" ],
@@ -233,6 +263,12 @@
 			},
 			"gateway6": {
 			   "type": "string",
+			   "required": true
+			},
+			"routemetric6": {
+			   "type": "integer",
+			   "minimum": 0,
+			   "maximum": 65535,
 			   "required": true
 			},
 			"dnsnameservers": {
@@ -303,6 +339,12 @@
 			   "type": "string",
 			   "required": true
 			},
+			"routemetric": {
+			   "type": "integer",
+			   "minimum": 0,
+			   "maximum": 65535,
+			   "required": true
+			},
 			"method6": {
 			   "type": "string",
 			   "enum": [ "auto", "static", "manual", "dhcp" ],
@@ -320,6 +362,12 @@
 			},
 			"gateway6": {
 			   "type": "string",
+			   "required": true
+			},
+			"routemetric6": {
+			   "type": "integer",
+			   "minimum": 0,
+			   "maximum": 65535,
 			   "required": true
 			},
 			"dnsnameservers": {
@@ -393,6 +441,12 @@
 				"type": "string",
 				"required": true
 			},
+			"routemetric": {
+			   "type": "integer",
+			   "minimum": 0,
+			   "maximum": 65535,
+			   "required": true
+			},
 			"method6": {
 				"type": "string",
 				"enum": ["auto", "static", "manual", "dhcp"],
@@ -411,6 +465,12 @@
 			"gateway6": {
 				"type": "string",
 				"required": true
+			},
+			"routemetric6": {
+			   "type": "integer",
+			   "minimum": 0,
+			   "maximum": 65535,
+			   "required": true
 			},
 			"dnsnameservers": {
 				"type": "string",

--- a/deb/openmediavault/usr/share/openmediavault/firstaid/modules.d/10configure_network.py
+++ b/deb/openmediavault/usr/share/openmediavault/firstaid/modules.d/10configure_network.py
@@ -19,7 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
 import ipaddress
-import re
 import sys
 
 import dialog
@@ -43,11 +42,13 @@ class Module(openmediavault.firstaid.IModule):
         address = ""
         netmask = ""
         gateway = ""
+        routemetric = 0
         method = "manual"
         address6 = ""
         method6 = "manual"
         netmask6 = 64
         gateway6 = ""
+        routemetric6 = 1
         wol = False
         dns_nameservers = ""
         wpa_ssid = None
@@ -385,10 +386,12 @@ class Module(openmediavault.firstaid.IModule):
                 "address": address,
                 "netmask": netmask,
                 "gateway": gateway,
+                "routemetric": routemetric,
                 "method6": method6,
                 "address6": address6,
                 "netmask6": netmask6,
                 "gateway6": gateway6,
+                "routemetric6": routemetric6,
                 "dnsnameservers": dns_nameservers,
                 "dnssearch": "",
                 "mtu": 0,

--- a/deb/openmediavault/usr/share/openmediavault/templates/config.xml
+++ b/deb/openmediavault/usr/share/openmediavault/templates/config.xml
@@ -143,10 +143,12 @@
 					<address>xxx.xxx.xxx.xxx</address>
 					<netmask>xxx.xxx.xxx.xxx</netmask>
 					<gateway>xxx.xxx.xxx.xxx</gateway>
+					<routemetric>0-65535</routemetric>
 					<method6>auto|dhcp|static|manual</method6>
 					<address6>xxxx:xxxx:...:xxxx</address6>
 					<netmask6>0-128</netmask6>
 					<gateway6>xxxx:xxxx:...:xxxx</gateway6>
+					<routemetric6>0-65535</routemetric6>
 					<dnsnameservers>xxx yyy zzz</dnsnameservers>
 					<dnssearch></dnssearch>
 					<mtu>0...n</mtu>

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-bond-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-bond-form-page.component.ts
@@ -340,17 +340,40 @@ export class InterfaceBondFormPageComponent extends BaseFormPageComponent {
         ]
       },
       {
-        type: 'textInput',
-        name: 'gateway',
-        label: gettext('Gateway'),
-        value: '',
-        validators: {
-          patternType: 'ipv4'
-        },
-        modifiers: [
+        type: 'container',
+        fields: [
           {
-            type: 'disabled',
-            constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
+            type: 'textInput',
+            name: 'gateway',
+            label: gettext('Gateway'),
+            value: '',
+            validators: {
+              patternType: 'ipv4'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
+              }
+            ],
+            flex: 75
+          },
+          {
+            type: 'numberInput',
+            name: 'routemetric',
+            label: gettext('Metric'),
+            value: 0,
+            validators: {
+              min: 0,
+              max: 65535,
+              patternType: 'integer'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
+              }
+            ]
           }
         ]
       },
@@ -410,17 +433,40 @@ export class InterfaceBondFormPageComponent extends BaseFormPageComponent {
         ]
       },
       {
-        type: 'textInput',
-        name: 'gateway6',
-        label: gettext('Gateway'),
-        value: '',
-        validators: {
-          patternType: 'ipv6'
-        },
-        modifiers: [
+        type: 'container',
+        fields: [
           {
-            type: 'disabled',
-            constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
+            type: 'textInput',
+            name: 'gateway6',
+            label: gettext('Gateway'),
+            value: '',
+            validators: {
+              patternType: 'ipv6'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
+              }
+            ],
+            flex: 75
+          },
+          {
+            type: 'numberInput',
+            name: 'routemetric6',
+            label: gettext('Metric'),
+            value: 1,
+            validators: {
+              min: 0,
+              max: 65535,
+              patternType: 'integer'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
+              }
+            ]
           }
         ]
       },

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-bridge-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-bridge-form-page.component.ts
@@ -157,17 +157,40 @@ export class InterfaceBridgeFormPageComponent extends BaseFormPageComponent {
         ]
       },
       {
-        type: 'textInput',
-        name: 'gateway',
-        label: gettext('Gateway'),
-        value: '',
-        validators: {
-          patternType: 'ipv4'
-        },
-        modifiers: [
+        type: 'container',
+        fields: [
           {
-            type: 'disabled',
-            constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
+            type: 'textInput',
+            name: 'gateway',
+            label: gettext('Gateway'),
+            value: '',
+            validators: {
+              patternType: 'ipv4'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
+              }
+            ],
+            flex: 75
+          },
+          {
+            type: 'numberInput',
+            name: 'routemetric',
+            label: gettext('Metric'),
+            value: 0,
+            validators: {
+              min: 0,
+              max: 65535,
+              patternType: 'integer'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
+              }
+            ]
           }
         ]
       },
@@ -227,17 +250,40 @@ export class InterfaceBridgeFormPageComponent extends BaseFormPageComponent {
         ]
       },
       {
-        type: 'textInput',
-        name: 'gateway6',
-        label: gettext('Gateway'),
-        value: '',
-        validators: {
-          patternType: 'ipv6'
-        },
-        modifiers: [
+        type: 'container',
+        fields: [
           {
-            type: 'disabled',
-            constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
+            type: 'textInput',
+            name: 'gateway6',
+            label: gettext('Gateway'),
+            value: '',
+            validators: {
+              patternType: 'ipv6'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
+              }
+            ],
+            flex: 75
+          },
+          {
+            type: 'numberInput',
+            name: 'routemetric6',
+            label: gettext('Metric'),
+            value: 1,
+            validators: {
+              min: 0,
+              max: 65535,
+              patternType: 'integer'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
+              }
+            ]
           }
         ]
       },

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-ethernet-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-ethernet-form-page.component.ts
@@ -146,17 +146,40 @@ export class InterfaceEthernetFormPageComponent extends BaseFormPageComponent {
         ]
       },
       {
-        type: 'textInput',
-        name: 'gateway',
-        label: gettext('Gateway'),
-        value: '',
-        validators: {
-          patternType: 'ipv4'
-        },
-        modifiers: [
+        type: 'container',
+        fields: [
           {
-            type: 'disabled',
-            constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
+            type: 'textInput',
+            name: 'gateway',
+            label: gettext('Gateway'),
+            value: '',
+            validators: {
+              patternType: 'ipv4'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
+              }
+            ],
+            flex: 75
+          },
+          {
+            type: 'numberInput',
+            name: 'routemetric',
+            label: gettext('Metric'),
+            value: 0,
+            validators: {
+              min: 0,
+              max: 65535,
+              patternType: 'integer'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
+              }
+            ]
           }
         ]
       },
@@ -216,17 +239,40 @@ export class InterfaceEthernetFormPageComponent extends BaseFormPageComponent {
         ]
       },
       {
-        type: 'textInput',
-        name: 'gateway6',
-        label: gettext('Gateway'),
-        value: '',
-        validators: {
-          patternType: 'ipv6'
-        },
-        modifiers: [
+        type: 'container',
+        fields: [
           {
-            type: 'disabled',
-            constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
+            type: 'textInput',
+            name: 'gateway6',
+            label: gettext('Gateway'),
+            value: '',
+            validators: {
+              patternType: 'ipv6'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
+              }
+            ],
+            flex: 75
+          },
+          {
+            type: 'numberInput',
+            name: 'routemetric6',
+            label: gettext('Metric'),
+            value: 1,
+            validators: {
+              min: 0,
+              max: 65535,
+              patternType: 'integer'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
+              }
+            ]
           }
         ]
       },

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-vlan-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-vlan-form-page.component.ts
@@ -168,17 +168,40 @@ export class InterfaceVlanFormPageComponent extends BaseFormPageComponent {
         ]
       },
       {
-        type: 'textInput',
-        name: 'gateway',
-        label: gettext('Gateway'),
-        value: '',
-        validators: {
-          patternType: 'ipv4'
-        },
-        modifiers: [
+        type: 'container',
+        fields: [
           {
-            type: 'disabled',
-            constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
+            type: 'textInput',
+            name: 'gateway',
+            label: gettext('Gateway'),
+            value: '',
+            validators: {
+              patternType: 'ipv4'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
+              }
+            ],
+            flex: 75
+          },
+          {
+            type: 'numberInput',
+            name: 'routemetric',
+            label: gettext('Metric'),
+            value: 0,
+            validators: {
+              min: 0,
+              max: 65535,
+              patternType: 'integer'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
+              }
+            ]
           }
         ]
       },
@@ -238,17 +261,40 @@ export class InterfaceVlanFormPageComponent extends BaseFormPageComponent {
         ]
       },
       {
-        type: 'textInput',
-        name: 'gateway6',
-        label: gettext('Gateway'),
-        value: '',
-        validators: {
-          patternType: 'ipv6'
-        },
-        modifiers: [
+        type: 'container',
+        fields: [
           {
-            type: 'disabled',
-            constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
+            type: 'textInput',
+            name: 'gateway6',
+            label: gettext('Gateway'),
+            value: '',
+            validators: {
+              patternType: 'ipv6'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
+              }
+            ],
+            flex: 75
+          },
+          {
+            type: 'numberInput',
+            name: 'routemetric6',
+            label: gettext('Metric'),
+            value: 1,
+            validators: {
+              min: 0,
+              max: 65535,
+              patternType: 'integer'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
+              }
+            ]
           }
         ]
       },

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-wifi-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-wifi-form-page.component.ts
@@ -172,17 +172,40 @@ export class InterfaceWifiFormPageComponent extends BaseFormPageComponent {
         ]
       },
       {
-        type: 'textInput',
-        name: 'gateway',
-        label: gettext('Gateway'),
-        value: '',
-        validators: {
-          patternType: 'ipv4'
-        },
-        modifiers: [
+        type: 'container',
+        fields: [
           {
-            type: 'disabled',
-            constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
+            type: 'textInput',
+            name: 'gateway',
+            label: gettext('Gateway'),
+            value: '',
+            validators: {
+              patternType: 'ipv6'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
+              }
+            ],
+            flex: 75
+          },
+          {
+            type: 'numberInput',
+            name: 'routemetric',
+            label: gettext('Metric'),
+            value: 0,
+            validators: {
+              min: 0,
+              max: 65535,
+              patternType: 'integer'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
+              }
+            ]
           }
         ]
       },
@@ -242,17 +265,40 @@ export class InterfaceWifiFormPageComponent extends BaseFormPageComponent {
         ]
       },
       {
-        type: 'textInput',
-        name: 'gateway6',
-        label: gettext('Gateway'),
-        value: '',
-        validators: {
-          patternType: 'ipv6'
-        },
-        modifiers: [
+        type: 'container',
+        fields: [
           {
-            type: 'disabled',
-            constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
+            type: 'textInput',
+            name: 'gateway6',
+            label: gettext('Gateway'),
+            value: '',
+            validators: {
+              patternType: 'ipv4'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
+              }
+            ],
+            flex: 75
+          },
+          {
+            type: 'numberInput',
+            name: 'routemetric6',
+            label: gettext('Metric'),
+            value: 1,
+            validators: {
+              min: 0,
+              max: 65535,
+              patternType: 'integer'
+            },
+            modifiers: [
+              {
+                type: 'disabled',
+                constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
+              }
+            ]
           }
         ]
       },


### PR DESCRIPTION
… of the default route set via the `Gateway` option in the network interface page.

The options gateway4, gateway6 will become deprecated in next Netplan version. By setting the default route the new way we will also get the opportunity to add support for custom `metric` settings.

- https://manpages.debian.org/net-tools/route.8.en.html
- https://netplan.readthedocs.io/en/stable/netplan-yaml/#properties-for-all-device-types
- https://netplan.readthedocs.io/en/stable/netplan-yaml/#default-routes

<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
