### PR TITLE
add base path option to wetty

### DIFF
--- a/deb/openmediavault-wetty/srv/salt/omv/deploy/wetty/files/container-wetty.service.j2
+++ b/deb/openmediavault-wetty/srv/salt/omv/deploy/wetty/files/container-wetty.service.j2
@@ -1,6 +1,7 @@
 {%- set image = salt['pillar.get']('default:OMV_WETTY_APP_CONTAINER_IMAGE', 'docker.io/wettyoss/wetty:latest') -%}
 {%- set uname = salt['pillar.get']('default:OMV_WETTY_APP_CONTAINER_UNAME', 'nobody') -%}
 {%- set gname = salt['pillar.get']('default:OMV_WETTY_APP_CONTAINER_GNAME', 'nogroup') -%}
+{%- set url_base = salt['pillar.get']('default:OMV_WETTY_URL_BASE', '') -%}
 {%- set ssl_enabled = wetty_config.sslcertificateref | length > 0 -%}
 {%- if ssl_enabled -%}
 {%- set ssl_cert_dir = salt['pillar.get']('default:OMV_SSL_CERTIFICATE_DIR', '/etc/ssl') -%}
@@ -22,7 +23,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/container-wetty.pid %t/container-wetty.ctr-id
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/container-wetty.pid --cidfile %t/container-wetty.ctr-id --cgroups=no-conmon -d --replace --pull=never --name=wetty --net=host {% if not ssl_enabled %}-u {{ uid }}:{{ gid }}{% endif %} {% if ssl_enabled %}-v {{ ssl_cert_file }}:/cert.crt:ro -v {{ ssl_key_file }}:/cert.key:ro{% endif %} {{ image }} --force-ssh --ssh-port {{ ssh_config.port }} --ssh-host {{ dns_config.hostname }} --base "" --port {{ wetty_config.port }} {% if ssl_enabled %}--ssl-cert /cert.crt --ssl-key /cert.key{% endif %}
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/container-wetty.pid --cidfile %t/container-wetty.ctr-id --cgroups=no-conmon -d --replace --pull=never --name=wetty --net=host {% if not ssl_enabled %}-u {{ uid }}:{{ gid }}{% endif %} {% if ssl_enabled %}-v {{ ssl_cert_file }}:/cert.crt:ro -v {{ ssl_key_file }}:/cert.key:ro{% endif %} {{ image }} --force-ssh --ssh-port {{ ssh_config.port }} --ssh-host {{ dns_config.hostname }} --base {{ url_base }} --port {{ wetty_config.port }} {% if ssl_enabled %}--ssl-cert /cert.crt --ssl-key /cert.key{% endif %}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/container-wetty.ctr-id
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/container-wetty.ctr-id
 PIDFile=%t/container-wetty.pid

--- a/deb/openmediavault-wetty/srv/salt/omv/deploy/wetty/files/container-wetty.service.j2
+++ b/deb/openmediavault-wetty/srv/salt/omv/deploy/wetty/files/container-wetty.service.j2
@@ -1,7 +1,7 @@
 {%- set image = salt['pillar.get']('default:OMV_WETTY_APP_CONTAINER_IMAGE', 'docker.io/wettyoss/wetty:latest') -%}
 {%- set uname = salt['pillar.get']('default:OMV_WETTY_APP_CONTAINER_UNAME', 'nobody') -%}
 {%- set gname = salt['pillar.get']('default:OMV_WETTY_APP_CONTAINER_GNAME', 'nogroup') -%}
-{%- set url_base = salt['pillar.get']('default:OMV_WETTY_URL_BASE', '') -%}
+{%- set base = salt['pillar.get']('default:OMV_WETTY_APP_CONTAINER_BASE', '') -%}
 {%- set ssl_enabled = wetty_config.sslcertificateref | length > 0 -%}
 {%- if ssl_enabled -%}
 {%- set ssl_cert_dir = salt['pillar.get']('default:OMV_SSL_CERTIFICATE_DIR', '/etc/ssl') -%}
@@ -23,7 +23,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/container-wetty.pid %t/container-wetty.ctr-id
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/container-wetty.pid --cidfile %t/container-wetty.ctr-id --cgroups=no-conmon -d --replace --pull=never --name=wetty --net=host {% if not ssl_enabled %}-u {{ uid }}:{{ gid }}{% endif %} {% if ssl_enabled %}-v {{ ssl_cert_file }}:/cert.crt:ro -v {{ ssl_key_file }}:/cert.key:ro{% endif %} {{ image }} --force-ssh --ssh-port {{ ssh_config.port }} --ssh-host {{ dns_config.hostname }} --base {{ url_base }} --port {{ wetty_config.port }} {% if ssl_enabled %}--ssl-cert /cert.crt --ssl-key /cert.key{% endif %}
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/container-wetty.pid --cidfile %t/container-wetty.ctr-id --cgroups=no-conmon -d --replace --pull=never --name=wetty --net=host {% if not ssl_enabled %}-u {{ uid }}:{{ gid }}{% endif %} {% if ssl_enabled %}-v {{ ssl_cert_file }}:/cert.crt:ro -v {{ ssl_key_file }}:/cert.key:ro{% endif %} {{ image }} --force-ssh --ssh-port {{ ssh_config.port }} --ssh-host {{ dns_config.hostname }} --base "{{ base }}" --port {{ wetty_config.port }} {% if ssl_enabled %}--ssl-cert /cert.crt --ssl-key /cert.key{% endif %}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/container-wetty.ctr-id
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/container-wetty.ctr-id
 PIDFile=%t/container-wetty.pid


### PR DESCRIPTION
Fixes: #1410

Built and tested.
When using a reverse-proxy setup the "Open UI" button might not work, depending on hostname and port of the proxy. To address that, one would need an extra option for that just for this one button.

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
