### PR TITLE
Add `disk/by-uuid` UDEV rule

### DIFF
--- a/deb/openmediavault/etc/udev/rules.d/61-openmediavault-dev-disk-by-id.rules
+++ b/deb/openmediavault/etc/udev/rules.d/61-openmediavault-dev-disk-by-id.rules
@@ -547,9 +547,23 @@ ENV{ID_VENDOR_ID}=="1c04", \
   SYMLINK="disk/by-path/$env{ID_PATH}", \
   SYMLINK+="disk/by-id/$env{ID_BUS}-$env{ID_SERIAL}"
 
+# by-uuid links (filesystem metadata)
+# Skip bcache backing devices, handled in `/lib/udev/rules.d/69-bcache.rules`.
+ENV{ID_FS_TYPE}=="bcache", GOTO="omv_skip_by_uuid"
+# Skip devices that already have a `disk/by-uuid` link.
+SYMLINK=="*disk/by-uuid/*", GOTO="omv_skip_by_uuid"
+ENV{ID_FS_USAGE}=="filesystem|other|crypto", ENV{ID_FS_UUID_ENC}=="?*", SYMLINK+="disk/by-uuid/$env{ID_FS_UUID_ENC}"
+LABEL="omv_skip_by_uuid"
+
 # by-id (World Wide Name)
 SYMLINK=="*disk/by-id/wwn-*", GOTO="omv_skip_by_id_wwn"
 ENV{ID_WWN_WITH_EXTENSION}=="?*", SYMLINK+="disk/by-id/wwn-$env{ID_WWN_WITH_EXTENSION}"
 LABEL="omv_skip_by_id_wwn"
+
+# by-partuuid links (partition metadata)
+# Skip devices that already have a `disk/by-partuuid` link.
+SYMLINK=="*disk/by-partuuid/*", GOTO="omv_skip_by_partuuid"
+ENV{ID_PART_ENTRY_UUID}=="?*", SYMLINK+="disk/by-partuuid/$env{ID_PART_ENTRY_UUID}"
+LABEL="omv_skip_by_partuuid"
 
 LABEL="omv_dev_disk_by_id_end"


### PR DESCRIPTION
The UDEV rules to workaround the duplicate serial number bug in various chipsets/disk-cases override already generated symlinks. This PR will re-add these missing `disk/by-uuid` symlinks again.

References:
- /lib/udev/rules.d/60-persistent-storage.rules
- https://forum.openmediavault.org/index.php?thread/47544-tr004-exfat-drives-with-mbr-no-longer-in-dev-disks-by-uuid/

<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
