### PR TITLE
[DNM] Adding support for using partitions

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/diskmgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/diskmgmt.inc
@@ -78,6 +78,8 @@ class DiskMgmt extends \OMV\Rpc\ServiceAbstract {
 			// without an inserted media.
 			if (FALSE === $sd->IsMediaAvailable())
 				continue;
+			if (TRUE === $sd->IsPartition())
+				continue;
 			$objects[] = [
 				"devicename" => $sd->getDeviceName(),
 				"canonicaldevicefile" => $sd->getCanonicalDeviceFile(),

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/filesystemmgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/filesystemmgmt.inc
@@ -541,20 +541,6 @@ class OMVRpcServiceFileSystemMgmt extends \OMV\Rpc\ServiceAbstract {
 		// Get a list of all potential usable devices.
 		if (FALSE === ($devs = \OMV\System\Storage\StorageDevice::enumerateUnused()))
 			throw new \OMV\Exception("Failed to get list of unused devices.");
-		// Get a list of all detected file systems.
-		$filesystems = \OMV\System\Filesystem\Filesystem::getFilesystems();
-		// Get the list of device files that are occupied by a file system.
-		$usedDevs = [];
-		foreach ($filesystems as $filesystemk => $filesystemv) {
-			$usedDevs[] = $filesystemv->getParentDeviceFile();
-			// Check if the file system uses multiple devices, e.g.
-			// a BTRFS RAID, and add them.
-			if ($filesystemv->hasMultipleDevices()) {
-				$usedDevs = array_merge($filesystemv->getDeviceFiles(),
-					$usedDevs);
-			}
-		}
-		// Prepare the result list.
 		$result = [];
 		foreach ($devs as $devk => $devv) {
 			// Get the storage device object for the specified device file.
@@ -575,8 +561,8 @@ class OMVRpcServiceFileSystemMgmt extends \OMV\Rpc\ServiceAbstract {
 			  ]))
 				continue;
 */
-			// Does this device already contain a file system?
-			if (in_array($sd->getCanonicalDeviceFile(), $usedDevs))
+			if (FALSE !== \OMV\System\Filesystem\Filesystem::hasFileSystem(
+				$sd->getDeviceFile()))
 				continue;
 			// The device is a potential candidate to create a file system
 			// on it.

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/smart.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/smart.inc
@@ -86,6 +86,9 @@ class Smart extends \OMV\Rpc\ServiceAbstract {
 				if (FALSE === $sd->hasSmartSupport()) {
 					return FALSE;
 				}
+				if (TRUE === $sd->IsPartition()) {
+					return FALSE;
+				}
 				// Get the S.M.A.R.T. information about the given device.
 				$si = $sd->getSmartInformation();
 				// Try to get the device temperature via S.M.A.R.T.

--- a/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/filesystem.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/filesystem.inc
@@ -783,12 +783,12 @@ class Filesystem extends \OMV\System\BlockDevice
 	 */
 	public static function hasFileSystem($deviceFile) {
 		$cmdArgs = [];
-		$cmdArgs[] = "-u filesystem";
+		$cmdArgs[] = "-no FSTYPE";
 		$cmdArgs[] = escapeshellarg($deviceFile);
-		$cmd = new \OMV\System\Process("blkid", $cmdArgs);
+		$cmd = new \OMV\System\Process("lsblk", $cmdArgs);
 		$cmd->setQuiet(TRUE);
 		$cmd->execute($output, $exitStatus);
-		if ($exitStatus !== 0)
+		if (sizeof($output) == 1 && $output[0] == "")
 			return FALSE;
 		return TRUE;
 	}

--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/backend/backendabstract.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/backend/backendabstract.inc
@@ -130,7 +130,7 @@ abstract class BackendAbstract {
 	 */
 	final protected function enumerateProcFs($regex) {
 		$result = [];
-		$regex = sprintf('/^\s+(\d+)\s+(\d+)\s+(\d+)\s+(%s)$/', $regex);
+		$regex = sprintf('/^\s+(\d+)\s+(\d+)\s+(\d+)\s+(%s[0-9]*)$/', $regex);
 		foreach(file("/proc/partitions") as $outputk => $outputv) {
 			if (1 !== preg_match($regex, $outputv, $matches))
 				continue;

--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/backend/backendabstract.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/backend/backendabstract.inc
@@ -130,7 +130,7 @@ abstract class BackendAbstract {
 	 */
 	final protected function enumerateProcFs($regex) {
 		$result = [];
-		$regex = sprintf('/^\s+(\d+)\s+(\d+)\s+(\d+)\s+(%s[0-9]*)$/', $regex);
+		$regex = sprintf('/^\s+(\d+)\s+(\d+)\s+(\d+)\s+(%s(p?[0-9]+)?)$/', $regex);
 		foreach(file("/proc/partitions") as $outputk => $outputv) {
 			if (1 !== preg_match($regex, $outputv, $matches))
 				continue;

--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevice.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevice.inc
@@ -268,6 +268,22 @@ class StorageDevice extends \OMV\System\BlockDevice
 	}
 
 	/**
+	 * Check if the given device is a partition.
+	 * @return boolean Returns TRUE if the OS reports it as a partition,
+	 *   otherwise FALSE.
+	 */
+	function IsPartition() {
+		$cmdArgs = [];
+		$cmdArgs[] = "-dno TYPE";
+		$cmdArgs[] = escapeshellarg($this->getDeviceFile());
+		$cmd = new \OMV\System\Process("lsblk", $cmdArgs);
+		$cmd->setQuiet(TRUE);
+		$cmd->execute($output, $exitStatus);
+		return ($output[0] == "part");
+	}
+
+
+	/**
 	 * Enumerate devices matching the given storage device type.
 	 * @param integer type Defines the storage device type, e.g. hard disk,
 	 *   hard or Software RAID. Defaults to OMV_STORAGE_DEVICE_TYPE_ALL.


### PR DESCRIPTION
# Adding support for using partitions on the UI


When trying to mannualy implement something similar to that Synology calls [SHR](https://kb.synology.com/en-br/DSM/tutorial/What_is_Synology_Hybrid_RAID_SHR), one hits the wall as OMV's UI does not allow to select partitions for creating arrays or even file systems. 

This PR introduces the ability to select partitions, provided that they do not already have file systems on it. If the community finds this addition useful, I'm more than happy to make :

1. Any necessary or suggested adjustments to comply with the existing class model of the application (maybe create an Partition class inheriting from BlockDevice ?). I've given some thought on it but could not find a way to implement that would not imply in extensive refactor of the application. 
2. The extra UI's for actually running CRUD operations on  partitions 