### PR TITLE
Prevent custom network interface search domain settings from being overwritten …

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,7 @@
 openmediavault (6.3.12-1) stable; urgency=low
 
-  *
+  * Prevent custom network interface search domain settings from
+    being overwritten by settings provided via DHCP.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Mon, 15 May 2023 20:44:19 +0200
 

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/bond.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/bond.j2
@@ -58,14 +58,24 @@ network:
       addresses: []
 {%- endif %}
       dhcp4: {{ "true" if interface.method == "dhcp" else "false" }}
-{%- if not interface.dnsnameservers == "" and interface.method == "dhcp" %}
+{%- if interface.method == "dhcp" and (interface.dnsnameservers != "" or interface.dnssearch != "") %}
       dhcp4-overrides:
+{%- if interface.dnsnameservers != "" %}
         use-dns: no
 {%- endif %}
+{%- if interface.dnssearch != 0 %}
+        use-domains: no
+{%- endif %}
+{%- endif %}
       dhcp6: {{ "true" if interface.method6 == "dhcp" else "false" }}
-{%- if not interface.dnsnameservers == "" and interface.method6 == "dhcp" %}
+{%- if interface.method6 == "dhcp" and (interface.dnsnameservers != "" or interface.dnssearch != "") %}
       dhcp6-overrides:
+{%- if interface.dnsnameservers != "" %}
         use-dns: no
+{%- endif %}
+{%- if interface.dnssearch != "" %}
+        use-domains: no
+{%- endif %}
 {%- endif %}
 {%- if interface.method6 == "manual" %}
       link-local: []

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/bridge.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/bridge.j2
@@ -58,14 +58,24 @@ network:
       addresses: []
 {%- endif %}
       dhcp4: {{ "true" if interface.method == "dhcp" else "false" }}
-{%- if not interface.dnsnameservers == "" and interface.method == "dhcp" %}
+{%- if interface.method == "dhcp" and (interface.dnsnameservers != "" or interface.dnssearch != "") %}
       dhcp4-overrides:
+{%- if interface.dnsnameservers != "" %}
         use-dns: no
 {%- endif %}
+{%- if interface.dnssearch != 0 %}
+        use-domains: no
+{%- endif %}
+{%- endif %}
       dhcp6: {{ "true" if interface.method6 == "dhcp" else "false" }}
-{%- if not interface.dnsnameservers == "" and interface.method6 == "dhcp" %}
+{%- if interface.method6 == "dhcp" and (interface.dnsnameservers != "" or interface.dnssearch != "") %}
       dhcp6-overrides:
+{%- if interface.dnsnameservers != "" %}
         use-dns: no
+{%- endif %}
+{%- if interface.dnssearch != "" %}
+        use-domains: no
+{%- endif %}
 {%- endif %}
 {%- if interface.method6 == "manual" %}
       link-local: []

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/ethernet.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/ethernet.j2
@@ -44,14 +44,24 @@ network:
       addresses: []
 {%- endif %}
       dhcp4: {{ "true" if interface.method == "dhcp" else "false" }}
-{%- if not interface.dnsnameservers == "" and interface.method == "dhcp" %}
+{%- if interface.method == "dhcp" and (interface.dnsnameservers != "" or interface.dnssearch != "") %}
       dhcp4-overrides:
+{%- if interface.dnsnameservers != "" %}
         use-dns: no
 {%- endif %}
+{%- if interface.dnssearch != 0 %}
+        use-domains: no
+{%- endif %}
+{%- endif %}
       dhcp6: {{ "true" if interface.method6 == "dhcp" else "false" }}
-{%- if not interface.dnsnameservers == "" and interface.method6 == "dhcp" %}
+{%- if interface.method6 == "dhcp" and (interface.dnsnameservers != "" or interface.dnssearch != "") %}
       dhcp6-overrides:
+{%- if interface.dnsnameservers != "" %}
         use-dns: no
+{%- endif %}
+{%- if interface.dnssearch != "" %}
+        use-domains: no
+{%- endif %}
 {%- endif %}
 {%- if interface.method6 == "manual" %}
       link-local: []

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/vlan.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/vlan.j2
@@ -41,14 +41,24 @@ network:
       addresses: []
 {%- endif %}
       dhcp4: {{ "true" if interface.method == "dhcp" else "false" }}
-{%- if not interface.dnsnameservers == "" and interface.method == "dhcp" %}
+{%- if interface.method == "dhcp" and (interface.dnsnameservers != "" or interface.dnssearch != "") %}
       dhcp4-overrides:
+{%- if interface.dnsnameservers != "" %}
         use-dns: no
 {%- endif %}
+{%- if interface.dnssearch != 0 %}
+        use-domains: no
+{%- endif %}
+{%- endif %}
       dhcp6: {{ "true" if interface.method6 == "dhcp" else "false" }}
-{%- if not interface.dnsnameservers == "" and interface.method6 == "dhcp" %}
+{%- if interface.method6 == "dhcp" and (interface.dnsnameservers != "" or interface.dnssearch != "") %}
       dhcp6-overrides:
+{%- if interface.dnsnameservers != "" %}
         use-dns: no
+{%- endif %}
+{%- if interface.dnssearch != "" %}
+        use-domains: no
+{%- endif %}
 {%- endif %}
 {%- if interface.method6 == "manual" %}
       link-local: []

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/wifi.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/files/wifi.j2
@@ -41,14 +41,24 @@ network:
       addresses: []
 {%- endif %}
       dhcp4: {{ "true" if interface.method == "dhcp" else "false" }}
-{%- if not interface.dnsnameservers == "" and interface.method == "dhcp" %}
+{%- if interface.method == "dhcp" and (interface.dnsnameservers != "" or interface.dnssearch != "") %}
       dhcp4-overrides:
+{%- if interface.dnsnameservers != "" %}
         use-dns: no
 {%- endif %}
+{%- if interface.dnssearch != 0 %}
+        use-domains: no
+{%- endif %}
+{%- endif %}
       dhcp6: {{ "true" if interface.method6 == "dhcp" else "false" }}
-{%- if not interface.dnsnameservers == "" and interface.method6 == "dhcp" %}
+{%- if interface.method6 == "dhcp" and (interface.dnsnameservers != "" or interface.dnssearch != "") %}
       dhcp6-overrides:
+{%- if interface.dnsnameservers != "" %}
         use-dns: no
+{%- endif %}
+{%- if interface.dnssearch != "" %}
+        use-domains: no
+{%- endif %}
 {%- endif %}
 {%- if interface.method6 == "manual" %}
       link-local: []


### PR DESCRIPTION
… by settings provided via DHCP

Note: The `systemd-networkd` submodule will not be marked as dirty to force a redeployment of the network configuration. This has to be done manually via `omv-salt deploy run systemd-networkd` if needed. Otherwise the new Netplan configuration will be deployed as usual (incl. the new chhanges introduced by this PR) whenever the network configuration is changed.

Relates: https://github.com/openmediavault/openmediavault/issues/1551


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
