### PR TITLE
Issue #420: Fix SMB issue with Btrfs subvolumes

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,7 @@
 openmediavault (6.4.4-1) stable; urgency=low
 
-  *
+  * Issue #420: Fix SMB issue with Btrfs subvolumes. The incorrect
+    displayed share size in Windows should be fixed as well.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Wed, 07 Jun 2023 00:14:51 +0200
 

--- a/deb/openmediavault/debian/openmediavault.postinst
+++ b/deb/openmediavault/debian/openmediavault.postinst
@@ -465,6 +465,9 @@ case "$1" in
 		if dpkg --compare-versions "$2" lt-nl "6.4.2"; then
 			omv_module_set_dirty apt
 		fi
+		if dpkg --compare-versions "$2" lt-nl "6.4.4"; then
+			omv_module_set_dirty samba
+		fi
 
 		########################################################################
 		# Trigger the restart of the omv-engined daemon to load and use the

--- a/deb/openmediavault/srv/salt/omv/deploy/samba/files/homes.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/samba/files/homes.j2
@@ -18,6 +18,8 @@
 {%- set recycle_exclude = salt['pillar.get']('default:OMV_SAMBA_HOMES_RECYCLE_EXCLUDE', '') -%}
 {%- set recycle_exclude_dir = salt['pillar.get']('default:OMV_SAMBA_HOMES_RECYCLE_EXCLUDEDIR', '.recycle') -%}
 {%- set shadow_sort = salt['pillar.get']('default:OMV_SAMBA_SHARE_SHADOW_SORT', 'desc') -%}
+{%- set dfree_command = salt['pillar.get']('default:OMV_SAMBA_HOMES_DFREECOMMAND', '/usr/sbin/omv-btrfs-dfree') -%}
+{%- set dfree_cache_time = salt['pillar.get']('default:OMV_SAMBA_HOMES_DFREECACHETIME', '60') -%}
 #======================= Home Directories =======================
 [homes]
 comment = {{ comment }}
@@ -56,5 +58,7 @@ shadow:format = _%Y%m%dT%H%M%S
 shadow:delimiter = _
 shadow:snapprefix = ^homes\(@hourly\)\{0,1\}\(@daily\)\{0,1\}\(@weekly\)\{0,1\}\(@monthly\)\{0,1\}\(@yearly\)\{0,1\}$
 shadow:localtime = {{ (salt['timezone.get_offset']() != '+0000') | yesno }}
+dfree command = {{ dfree_command }}
+dfree cache time = {{ dfree_cache_time }}
 {%- endif %}
 vfs objects = {{ vfs_objects | unique | join(' ') }}

--- a/deb/openmediavault/srv/salt/omv/deploy/samba/files/shares.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/samba/files/shares.j2
@@ -28,6 +28,8 @@
 {%- set fruit_wipe_intentionally_left_blank_rfork = salt['pillar.get']('default:OMV_SAMBA_SHARE_FRUIT_WIPEINTENTIONALLYLEFTBLANKRFORK', 'yes') -%}
 {%- set fruit_delete_empty_adfiles = salt['pillar.get']('default:OMV_SAMBA_SHARE_FRUIT_DELETEEMPTYADFILES', 'yes') -%}
 {%- set shadow_sort = salt['pillar.get']('default:OMV_SAMBA_SHARE_SHADOW_SORT', 'desc') -%}
+{%- set dfree_command = salt['pillar.get']('default:OMV_SAMBA_SHARE_DFREECOMMAND', '/usr/sbin/omv-btrfs-dfree') -%}
+{%- set dfree_cache_time = salt['pillar.get']('default:OMV_SAMBA_SHARE_DFREECACHETIME', '60') -%}
 #======================= Share Definitions =======================
 {%- for share in config.shares.share | selectattr('enable') %}
 {%- set sf_name = salt['omv_conf.get_sharedfolder_name'](share.sharedfolderref) %}
@@ -96,6 +98,8 @@ shadow:format = _%Y%m%dT%H%M%S
 shadow:delimiter = _
 shadow:snapprefix = ^{{ sf_name }}\(@hourly\)\{0,1\}\(@daily\)\{0,1\}\(@weekly\)\{0,1\}\(@monthly\)\{0,1\}\(@yearly\)\{0,1\}$
 shadow:localtime = {{ (salt['timezone.get_offset']() != '+0000') | yesno }}
+dfree command = {{ dfree_command }}
+dfree cache time = {{ dfree_cache_time }}
 {%- endif %}
 vfs objects = {{ vfs_objects | unique | join(' ') }}
 printable = {{ printable }}

--- a/deb/openmediavault/usr/sbin/omv-btrfs-dfree
+++ b/deb/openmediavault/usr/sbin/omv-btrfs-dfree
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+# Documentation:
+# https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#DFREECOMMAND
+
+import os
+import re
+import sys
+
+import openmediavault.procutils
+
+
+def main():
+    path = os.path.realpath(sys.argv[1] if len(sys.argv) > 0 else '.')
+    output = openmediavault.procutils.check_output(
+        ['btrfs', 'filesystem', 'usage', '--raw', path]
+    ).decode()
+    matches = re.match(r'.+Device size:\s+(\d+).+Free \(estimated\):\s+(\d+).+',
+                       output, re.DOTALL)
+    if matches is not None:
+        total = int(matches.group(1)) // 1024
+        available = int(matches.group(2)) // 1024
+    else:
+        output = openmediavault.procutils.check_output(
+            ['df', '--portability', '--print-type', '--block-size=1K', path]
+        ).decode()
+        _, _, total, _, available, *_ = output.split('\n')[1].split()
+    sys.stdout.write(f'{total} {available} 1024\n')
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Error message: `sys_path_to_bdev() failed for path [.]!`

The incorrect displayed share size in Windows should be fixed as well.

Fixes: https://github.com/openmediavault/openmediavault/issues/420


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
