### PR TITLE
Getting rid of @angular/flex-layout NPM package

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,7 @@
-openmediavault (6.6.1-1) stable; urgency=low
+openmediavault (6.7.0-1) stable; urgency=low
 
   * Various improvements.
+  * Issue #1576: Getting rid of `@angular/flex-layout`.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Sat, 19 Aug 2023 14:32:14 +0200
 

--- a/deb/openmediavault/workbench/package-lock.json
+++ b/deb/openmediavault/workbench/package-lock.json
@@ -13,7 +13,6 @@
         "@angular/common": "^14.3.0",
         "@angular/compiler": "^14.3.0",
         "@angular/core": "^14.3.0",
-        "@angular/flex-layout": "^14.0.0-beta.41",
         "@angular/forms": "^14.3.0",
         "@angular/material": "^14.2.7",
         "@angular/platform-browser": "^14.3.0",
@@ -711,22 +710,6 @@
       "peerDependencies": {
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.11.4 || ~0.12.0"
-      }
-    },
-    "node_modules/@angular/flex-layout": {
-      "version": "14.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/@angular/flex-layout/-/flex-layout-14.0.0-beta.41.tgz",
-      "integrity": "sha512-x1YcxqkdFlcbVXEy9ebCgW/F+7n/MXkEkwEcVEIPf5v5qn7HZsjQxgIj35Lf0amvMyF7h35prpoxO1uX5+ntFg==",
-      "deprecated": "This package has been deprecated. Please see https://blog.angular.io/modern-css-in-angular-layouts-4a259dca9127",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/cdk": "^14.0.0",
-        "@angular/common": "^14.0.0",
-        "@angular/core": "^14.0.0",
-        "@angular/platform-browser": "^14.0.0",
-        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/forms": {
@@ -26163,14 +26146,6 @@
       "version": "14.3.0",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.3.0.tgz",
       "integrity": "sha512-wYiwItc0Uyn4FWZ/OAx/Ubp2/WrD3EgUJ476y1XI7yATGPF8n9Ld5iCXT08HOvc4eBcYlDfh90kTXR6/MfhzdQ==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@angular/flex-layout": {
-      "version": "14.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/@angular/flex-layout/-/flex-layout-14.0.0-beta.41.tgz",
-      "integrity": "sha512-x1YcxqkdFlcbVXEy9ebCgW/F+7n/MXkEkwEcVEIPf5v5qn7HZsjQxgIj35Lf0amvMyF7h35prpoxO1uX5+ntFg==",
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/deb/openmediavault/workbench/package.json
+++ b/deb/openmediavault/workbench/package.json
@@ -31,7 +31,6 @@
     "@angular/common": "^14.3.0",
     "@angular/compiler": "^14.3.0",
     "@angular/core": "^14.3.0",
-    "@angular/flex-layout": "^14.0.0-beta.41",
     "@angular/forms": "^14.3.0",
     "@angular/material": "^14.2.7",
     "@angular/platform-browser": "^14.3.0",

--- a/deb/openmediavault/workbench/src/app/core/components/apply-config-panel/apply-config-panel.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/apply-config-panel/apply-config-panel.component.html
@@ -3,10 +3,7 @@
                  icon="information"
                  title="{{ 'Pending configuration changes' | transloco }}"
                  [buttons]="buttons">
-  <div class="omv-cursor-pointer"
-       fxFlex
-       fxLayout="column"
-       fxLayoutAlign="center start"
+  <div class="omv-cursor-pointer omv-display-flex omv-flex-column omv-align-items-start omv-align-content-start omv-justify-content-center"
        (click)="expanded = !expanded">
     {{ 'You must apply these changes in order for them to take effect.' | transloco }}
     <div class="details"

--- a/deb/openmediavault/workbench/src/app/core/components/breadcrumb/breadcrumb.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/breadcrumb/breadcrumb.component.html
@@ -1,5 +1,4 @@
-<nav fxLayout="row"
-     fxLayoutAlign="start center">
+<nav class="omv-display-flex omv-flex-row omv-align-items-center omv-align-content-center omv-justify-content-start">
   <a routerLink="/"
      class="mat-subheading-2"
      [ngClass]="{'active': !breadcrumbs.length}"

--- a/deb/openmediavault/workbench/src/app/core/components/components.module.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/components.module.ts
@@ -1,7 +1,6 @@
 /* eslint-disable max-len */
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { RouterModule } from '@angular/router';
 import { TranslocoModule } from '@ngneat/transloco';
 import { NgScrollbarModule } from 'ngx-scrollbar';
@@ -50,7 +49,6 @@ import { SharedModule } from '~/app/shared/shared.module';
     SharedModule,
     RouterModule,
     MaterialModule,
-    FlexLayoutModule,
     IntuitionModule,
     TranslocoModule,
     NgScrollbarModule,

--- a/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-chart/dashboard-widget-chart.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-chart/dashboard-widget-chart.component.html
@@ -1,14 +1,10 @@
 <omv-dashboard-widget [config]="config"
                       (dataChangedEvent)="dataChanged($event)">
-  <div class="widget-content"
-       fxLayout="row">
+  <div class="widget-content omv-display-flex omv-flex-row">
     <div class="chart"
-         [fxFlex]="chartWidth">
+         [ngClass]="{'omv-w-100': chartWidth === 100, 'omv-w-75': chartWidth === 75, 'omv-w-50': chartWidth === 50, 'omv-w-25': chartWidth === 25}">
       <div *ngIf="config.chart?.displayValue && data && chart && chartCtx"
-           class="gauge-label"
-           fxFlexFill
-           fxLayout="column"
-           fxLayoutAlign="end center">
+           class="gauge-label omv-display-flex omv-flex-column omv-flex-fill omv-align-content-center omv-justify-content-end omv-align-items-center">
         <span class="value">{{ labelFormatter(getMaxValue(), chartCtx) }}</span>
       </div>
       <canvas #chartCtx
@@ -24,22 +20,15 @@
   <ng-container [ngSwitch]="config.chart?.type">
     <ng-template [ngSwitchCase]="'advanced-doughnut'">
       <div *ngIf="data && chart && chartCtx"
-           class="advanced-label"
-           fxFlex="50"
-           fxLayout="column"
-           fxLayoutAlign="end start">
+           class="advanced-label omv-display-flex omv-flex-column omv-w-50 omv-align-content-start omv-justify-content-end omv-align-items-start">
         <div class="total">
           <div class="total-value omv-text-truncate">{{ labelFormatter(getTotal(), chartCtx) }}</div>
           <div class="total-label omv-text-truncate">{{ 'Total' | transloco }}</div>
         </div>
-        <div class="items"
-             gdGap="8px"
-             gdColumns="repeat(2, 1fr)">
+        <div class="items omv-grid omv-gap-2 omv-grid-cols-2">
           <div *ngFor="let item of config.chart?.dataConfig"
                [ngStyle]="{'border-left-color': item.backgroundColor}"
-               class="item"
-               fxLayout="column"
-               fxLayoutAlign="start start">
+               class="item omv-flex-column omv-align-content-start omv-justify-content-start omv-align-items-start">
             <div class="item-value omv-text-truncate">{{ labelFormatterByProp(data, item.prop, chartCtx) }}</div>
             <div class="item-percent">{{ calcPercent(item, chartCtx) }}%</div>
             <div class="item-label omv-text-truncate">{{ item.label }}</div>
@@ -50,18 +39,11 @@
 
     <ng-template [ngSwitchCase]="'advanced-gauge'">
       <div *ngIf="data && chart && chartCtx"
-           class="advanced-label"
-           fxFlex="50"
-           fxLayout="column"
-           fxLayoutAlign="end start">
-        <div class="items"
-             gdGap="8px"
-             gdColumns="repeat(3, 1fr)">
+           class="advanced-label omv-display-flex omv-flex-column omv-w-50 omv-align-content-start omv-justify-content-end omv-align-items-start">
+        <div class="items omv-grid omv-gap-2 omv-grid-cols-3">
           <div *ngFor="let item of config.chart?.dataConfig"
                [ngStyle]="{'border-left-color': item.backgroundColor}"
-               class="item"
-               fxLayout="column"
-               fxLayoutAlign="start start">
+               class="item omv-flex-column omv-align-content-start omv-justify-content-start omv-align-items-start">
             <div class="item-value omv-text-truncate">{{ labelFormatterByProp(data, item.prop, chartCtx) }}</div>
             <div class="item-label omv-text-truncate">{{ item.label }}</div>
           </div>

--- a/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-chart/dashboard-widget-chart.component.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-chart/dashboard-widget-chart.component.ts
@@ -50,7 +50,8 @@ export class DashboardWidgetChartComponent implements OnInit {
   config: DashboardWidgetConfig;
 
   public chart?: Chart;
-  public chartWidth?: number;
+  // The chart width in percent.
+  public chartWidth?: 25 | 50 | 75 | 100;
   public data: Record<string, any>;
 
   constructor() {}

--- a/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-filesystems-status/dashboard-widget-filesystems-status.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-filesystems-status/dashboard-widget-filesystems-status.component.html
@@ -2,17 +2,13 @@
                       [loadData]="loadData.bind(this)"
                       (dataChangedEvent)="dataChanged($event)">
   <div *ngIf="data"
-       class="widget-content"
-       gdGap="8px"
-       gdColumns="repeat(auto-fit, minmax(100px, 1fr))">
+       class="widget-content omv-grid omv-gap-2">
     <div *ngIf="!data.total">
       <span>{{ 'No data to display.' | transloco }}</span>
     </div>
     <div *ngFor="let item of data.data"
-         class="item"
-         [ngClass]="{'error': item.status === 3, 'warning': (item.status === 1) && !item.mounted}"
-         fxLayout="column"
-         fxLayoutAlign="start stretch">
+         class="item omv-display-flex omv-flex-column omv-align-content-stretch omv-justify-content-start omv-align-items-stretch"
+         [ngClass]="{'error': item.status === 3, 'warning': (item.status === 1) && !item.mounted}">
       <div class="item-text omv-text-truncate">
         {{ item.canonicaldevicefile }}
       </div>

--- a/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-filesystems-status/dashboard-widget-filesystems-status.component.scss
+++ b/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-filesystems-status/dashboard-widget-filesystems-status.component.scss
@@ -3,6 +3,7 @@
 
 .widget-content {
   padding: 0 dv.$omv-padding dv.$omv-padding;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
 
   .item {
     border-left: 3px solid;

--- a/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-grid/dashboard-widget-grid.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-grid/dashboard-widget-grid.component.html
@@ -2,9 +2,7 @@
                       [loadData]="loadData.bind(this)"
                       (dataChangedEvent)="dataChanged($event)">
   <div *ngIf="data"
-       class="widget-content"
-       gdGap="3px"
-       gdColumns="repeat(auto-fit, minmax({{ config.grid?.item.minWidth | defaultTo:'100px' }}, 1fr))">
+       class="widget-content omv-grid omv-gap-1">
     <div *ngFor="let item of data.data"
          class="item"
          [ngClass]="config.grid?.item.class | template:item"

--- a/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-grid/dashboard-widget-grid.component.scss
+++ b/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-grid/dashboard-widget-grid.component.scss
@@ -2,6 +2,7 @@
 
 .widget-content {
   padding: 0 dv.$omv-padding dv.$omv-padding;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
 
   .item {
     cursor: default;

--- a/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-rrd/dashboard-widget-rrd.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-rrd/dashboard-widget-rrd.component.html
@@ -1,8 +1,7 @@
 <omv-dashboard-widget [config]="config"
                       [loadData]="loadData.bind(this)"
                       (dataChangedEvent)="dataChanged($event)">
-  <div class="widget-content"
-       fxLayoutAlign="center">
+  <div class="widget-content omv-display-flex omv-align-content-stretch omv-align-content-center omv-align-items-stretch">
     <img src="rrd.php?name={{ config.rrd?.name }}&time={{ time }}"
          loading="lazy"
          loadingState

--- a/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-system-information/dashboard-widget-system-information.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-system-information/dashboard-widget-system-information.component.html
@@ -2,9 +2,7 @@
                       [loadData]="loadData.bind(this)"
                       (dataChangedEvent)="dataChanged($event)">
   <div *ngIf="data"
-       class="widget-content"
-       gdGap="8px"
-       gdColumns="repeat(2, 1fr)">
+       class="widget-content omv-grid omv-gap-2 omv-grid-cols-2">
     <div class="omv-grid-cell">
       <div class="omv-grid-cell-title omv-font-weight-bold">{{ 'Hostname' | transloco }}</div>
       <div>{{ data?.hostname }}</div>

--- a/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-value/dashboard-widget-value.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard-widget-value/dashboard-widget-value.component.html
@@ -1,17 +1,14 @@
 <omv-dashboard-widget [config]="config"
                       (dataChangedEvent)="dataChanged($event)">
   <div *ngIf="data"
-       class="widget-content"
-       fxLayout="row"
-       fxLayoutAlign="start center"
+       class="widget-content omv-display-flex omv-flex-row omv-justify-content-start omv-align-items-center"
        [ngClass]="{'omv-cursor-pointer': config.value?.url}"
        [routerLink]="config.value?.url | template:data">
     <mat-icon *ngIf="config.value?.icon"
               mat-card-avatar
               svgIcon="{{ config.value?.icon | mapIconEnum }}">
     </mat-icon>
-    <div fxLayout="column"
-         fxLayoutAlign="center stretch"
+    <div class="omv-flex-column omv-align-content-stretch omv-justify-content-center omv-align-items-stretch"
          [ngClass]="{'omv-ml-h': config.value?.icon}">
       <div class="omv-font-weight-bold">
         {{ config.value?.title | template:data | transloco }}

--- a/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard.module.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/dashboard/dashboard.module.ts
@@ -18,7 +18,6 @@
 /* eslint-disable max-len */
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { RouterModule } from '@angular/router';
 import { TranslocoModule } from '@ngneat/transloco';
 
@@ -56,13 +55,6 @@ import { SharedModule } from '~/app/shared/shared.module';
     DashboardWidgetTextComponent,
     DashboardWidgetValueComponent
   ],
-  imports: [
-    CommonModule,
-    FlexLayoutModule,
-    MaterialModule,
-    RouterModule,
-    SharedModule,
-    TranslocoModule
-  ]
+  imports: [CommonModule, MaterialModule, RouterModule, SharedModule, TranslocoModule]
 })
 export class DashboardModule {}

--- a/deb/openmediavault/workbench/src/app/core/components/guru-meditation/guru-meditation.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/guru-meditation/guru-meditation.component.html
@@ -1,5 +1,4 @@
-<div class="message"
-     fxFlex>
+<div class="message">
   <span>
     {{ 'Software Failure.&nbsp;&nbsp;&nbsp;Press left mouse button to continue.' | transloco }}
   </span>

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/datatable-page/datatable-page.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/datatable-page/datatable-page.component.html
@@ -28,16 +28,15 @@
                    [remoteSearching]="config.remoteSearching"
                    [sorters]="config.sorters"
                    [sortType]="config.sortType">
-      <omv-datatable-actions fxFlex
-                             [actions]="config.actions"
+      <omv-datatable-actions [actions]="config.actions"
                              [selection]="selection"
                              [table]="table">
       </omv-datatable-actions>
     </omv-datatable>
   </mat-card-content>
   <mat-card-actions *ngIf="config.buttons.length"
-                    fxLayout="row"
-                    [fxLayoutAlign]="config.buttonAlign">
+                    class="omv-display-flex omv-flex-row"
+                    [ngClass]="{'omv-justify-content-start': config.buttonAlign === 'start', 'omv-justify-content-center': config.buttonAlign === 'center', 'omv-justify-content-end': config.buttonAlign === 'end'}">
     <ng-container *ngFor="let button of config.buttons">
       <omv-submit-button *ngIf="button.template === 'submit'"
                          [disabled]="button.disabled"

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form-page/form-page.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form-page/form-page.component.html
@@ -17,8 +17,8 @@
     </omv-intuition-form>
   </mat-card-content>
   <mat-card-actions *ngIf="config.buttons.length"
-                    fxLayout="row"
-                    [fxLayoutAlign]="config.buttonAlign">
+                    class="omv-display-flex omv-flex-row"
+                    [ngClass]="{'omv-justify-content-start': config.buttonAlign === 'start', 'omv-justify-content-center': config.buttonAlign === 'center', 'omv-justify-content-end': config.buttonAlign === 'end'}">
     <ng-container *ngFor="let button of config.buttons">
       <omv-submit-button *ngIf="button.template === 'submit'"
                          [form]="config.id"

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-binary-unit-input/form-binary-unit-input.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-binary-unit-input/form-binary-unit-input.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex
+<mat-form-field class="omv-flex-1"
                 [formGroup]="formGroup">
   <div *ngIf="config.icon"
        matPrefix>

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-button/form-button.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-button/form-button.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex
+<mat-form-field class="omv-flex-1"
                 [formGroup]="formGroup">
   <mat-label>{{ config.label | transloco }}</mat-label>
   <mat-form-button [formControlName]="config.name"

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-checkbox/form-checkbox.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-checkbox/form-checkbox.component.html
@@ -1,6 +1,4 @@
-<div class="omv-form-checkbox-wrapper mat-form-field"
-     fxFlex
-     fxLayout="column"
+<div class="omv-form-checkbox-wrapper mat-form-field omv-display-flex omv-flex-1 omv-flex-column"
      [formGroup]="formGroup">
   <mat-checkbox [formControlName]="config.name"
                 [checked]="config.value"

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-code-editor/form-code-editor.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-code-editor/form-code-editor.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex
+<mat-form-field class="omv-flex-1"
                 [formGroup]="formGroup">
   <mat-label>{{ config.label | transloco }}</mat-label>
   <mat-form-code-editor [formControlName]="config.name"

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-datatable/form-datatable.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-datatable/form-datatable.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex
+<mat-form-field class="omv-flex-1"
                 [formGroup]="formGroup">
   <mat-label>{{ config.label | transloco }}</mat-label>
   <mat-form-datatable [formControlName]="config.name"

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-datepicker/form-datepicker.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-datepicker/form-datepicker.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex
+<mat-form-field class="omv-flex-1"
                 [formGroup]="formGroup">
   <mat-label>{{ config.label }}</mat-label>
   <input matInput

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-divider/form-divider.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-divider/form-divider.component.html
@@ -1,4 +1,4 @@
-<div class="omv-form-divider">
+<div class="omv-form-divider omv-flex-1">
   <mat-divider></mat-divider>
   <div *ngIf="config.title"
        class="title">

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-file-input/form-file-input.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-file-input/form-file-input.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex
+<mat-form-field class="omv-flex-1"
                 [formGroup]="formGroup">
   <div *ngIf="config.icon"
        matPrefix>

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-folderbrowser/form-folderbrowser.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-folderbrowser/form-folderbrowser.component.html
@@ -1,5 +1,5 @@
 <mat-form-field *ngIf="config.dirVisible"
-                fxFlex="25"
+                class="omv-flex-initial omv-w-25"
                 [formGroup]="formGroup">
   <mat-label>{{ 'Base path' | transloco }}</mat-label>
   <input *ngIf="config.dirVisible"
@@ -14,7 +14,7 @@
 <mat-form-field #origin="cdkOverlayOrigin"
                 #trigger
                 cdkOverlayOrigin
-                fxFlex
+                class="omv-flex-1"
                 [formGroup]="formGroup">
   <div *ngIf="config.icon"
        matPrefix>
@@ -71,11 +71,8 @@
              (backdropClick)="close()"
              (detach)="close()">
   <div class="mat-select-panel-wrap">
-    <div class="mat-select-panel mat-primary"
-         fxLayout="column">
-      <mat-toolbar class="omv-selection-header"
-                   fxLayout="row"
-                   fxLayoutAlign="end center">
+    <div class="mat-select-panel mat-primary">
+      <mat-toolbar class="omv-selection-header omv-display-flex omv-flex-row omv-justify-content-end">
         <mat-form-field>
           <button mat-icon-button
                   matPrefix>
@@ -113,16 +110,14 @@
           </mat-list-option>
         </mat-selection-list>
       </div>
-      <div class="omv-selection-actions"
-           fxLayout="row"
-           fxLayoutAlign="start center">
+      <div class="omv-selection-actions omv-display-flex omv-flex-row omv-justify-content-start omv-align-items-center">
         <mat-icon class="omv-text-muted omv-mr-q"
                   svgIcon="mdi:folder-open">
         </mat-icon>
         <div class="omv-text-muted">
           {{ currentPath }}
         </div>
-        <div fxFlex></div>
+        <div class="omv-flex-1"></div>
         <button mat-flat-button
                 (click)="close()">
           {{ 'Cancel' | transloco }}

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-icon-button/form-icon-button.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-icon-button/form-icon-button.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex
+<mat-form-field class="omv-flex-1"
                 [formGroup]="formGroup">
   <mat-label>{{ config.label | transloco }}</mat-label>
   <mat-form-button [formControlName]="config.name"

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-number-input/form-number-input.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-number-input/form-number-input.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex
+<mat-form-field class="omv-flex-1"
                 [formGroup]="formGroup">
   <div *ngIf="config.icon"
        matPrefix>

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-password-input/form-password-input.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-password-input/form-password-input.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex
+<mat-form-field class="omv-flex-1"
                 [formGroup]="formGroup">
   <div *ngIf="config.icon"
        matPrefix>

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-select/form-select.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-select/form-select.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex
+<mat-form-field class="omv-flex-1"
                 [formGroup]="formGroup">
   <mat-label>{{ config.label | transloco }}</mat-label>
   <mat-select [formControlName]="config.name"

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-sharedfolder-select/form-sharedfolder-select.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-sharedfolder-select/form-sharedfolder-select.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex
+<mat-form-field class="omv-flex-1"
                 [formGroup]="formGroup">
   <mat-label>{{ config.label }}</mat-label>
   <mat-select [formControlName]="config.name"

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-slider/form-slider.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-slider/form-slider.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex
+<mat-form-field class="omv-flex-1"
                 [formGroup]="formGroup">
   <div *ngIf="config.icon"
        matPrefix>

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-sshcert-select/form-sshcert-select.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-sshcert-select/form-sshcert-select.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex
+<mat-form-field class="omv-flex-1"
                 [formGroup]="formGroup">
   <mat-label>{{ config.label }}</mat-label>
   <mat-select [formControlName]="config.name"

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-sslcert-select/form-sslcert-select.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-sslcert-select/form-sslcert-select.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex
+<mat-form-field class="omv-flex-1"
                 [formGroup]="formGroup">
   <mat-label>{{ config.label }}</mat-label>
   <mat-select [formControlName]="config.name"

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-tag-input/form-tag-input.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-tag-input/form-tag-input.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex
+<mat-form-field class="omv-flex-1"
                 [formGroup]="formGroup">
   <div *ngIf="config.icon"
        matPrefix>

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-text-input/form-text-input.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-text-input/form-text-input.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex
+<mat-form-field class="omv-flex-1"
                 [formGroup]="formGroup">
   <div *ngIf="config.icon"
        matPrefix>

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-textarea/form-textarea.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-textarea/form-textarea.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex
+<mat-form-field class="omv-flex-1"
                 [formGroup]="formGroup">
   <div *ngIf="config.icon"
        matPrefix>

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/form.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/form.component.html
@@ -11,125 +11,142 @@
              let-field>
   <ng-container [ngSwitch]="field.type">
     <ng-template [ngSwitchCase]="'button'">
-      <omv-form-button [config]="field"
+      <omv-form-button class="omv-display-flex"
+                       [config]="field"
                        [formGroup]="formGroup">
       </omv-form-button>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'iconButton'">
-      <omv-form-icon-button [config]="field"
+      <omv-form-icon-button class="omv-display-flex"
+                            [config]="field"
                             [formGroup]="formGroup">
       </omv-form-icon-button>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'textInput'">
-      <omv-form-text-input [config]="field"
+      <omv-form-text-input class="omv-display-flex"
+                           [config]="field"
                            [formGroup]="formGroup">
       </omv-form-text-input>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'tagInput'">
-      <omv-form-tag-input [config]="field"
+      <omv-form-tag-input class="omv-display-flex"
+                          [config]="field"
                           [formGroup]="formGroup">
       </omv-form-tag-input>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'numberInput'">
-      <omv-form-number-input [config]="field"
+      <omv-form-number-input class="omv-display-flex"
+                             [config]="field"
                              [formGroup]="formGroup">
       </omv-form-number-input>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'binaryUnitInput'">
-      <omv-form-binary-unit-input [config]="field"
+      <omv-form-binary-unit-input class="omv-display-flex"
+                                  [config]="field"
                                   [formGroup]="formGroup">
       </omv-form-binary-unit-input>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'folderBrowser'">
-      <omv-form-folderbrowser [config]="field"
+      <omv-form-folderbrowser class="omv-display-flex"
+                              [config]="field"
                               [formGroup]="formGroup">
       </omv-form-folderbrowser>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'checkbox'">
-      <omv-form-checkbox [config]="field"
+      <omv-form-checkbox class="omv-display-flex"
+                         [config]="field"
                          [formGroup]="formGroup">
       </omv-form-checkbox>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'passwordInput'">
-      <omv-form-password-input [config]="field"
+      <omv-form-password-input class="omv-display-flex"
+                               [config]="field"
                                [formGroup]="formGroup">
       </omv-form-password-input>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'textarea'">
-      <omv-form-textarea [config]="field"
+      <omv-form-textarea class="omv-display-flex"
+                         [config]="field"
                          [formGroup]="formGroup">
       </omv-form-textarea>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'select'">
-      <omv-form-select [config]="field"
+      <omv-form-select class="omv-display-flex"
+                       [config]="field"
                        [formGroup]="formGroup">
       </omv-form-select>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'sharedFolderSelect'">
-      <omv-form-sharedfolder-select [config]="field"
+      <omv-form-sharedfolder-select class="omv-display-flex"
+                                    [config]="field"
                                     [formGroup]="formGroup">
       </omv-form-sharedfolder-select>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'sshCertSelect'">
-      <omv-form-sshcert-select [config]="field"
+      <omv-form-sshcert-select class="omv-display-flex"
+                               [config]="field"
                                [formGroup]="formGroup">
       </omv-form-sshcert-select>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'sslCertSelect'">
-      <omv-form-sslcert-select [config]="field"
+      <omv-form-sslcert-select class="omv-display-flex"
+                               [config]="field"
                                [formGroup]="formGroup">
       </omv-form-sslcert-select>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'divider'">
-      <omv-form-divider [config]="field"
+      <omv-form-divider class="omv-display-flex"
+                        [config]="field"
                         [formGroup]="formGroup">
       </omv-form-divider>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'paragraph'">
-      <omv-form-paragraph [config]="field"
+      <omv-form-paragraph class="omv-display-flex"
+                          [config]="field"
                           [formGroup]="formGroup">
       </omv-form-paragraph>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'datePicker'">
-      <omv-form-datepicker [config]="field"
+      <omv-form-datepicker class="omv-display-flex"
+                           [config]="field"
                            [formGroup]="formGroup">
       </omv-form-datepicker>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'datatable'">
-      <omv-form-datatable [config]="field"
+      <omv-form-datatable class="omv-display-flex"
+                          [config]="field"
                           [formGroup]="formGroup">
       </omv-form-datatable>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'slider'">
-      <omv-form-slider [config]="field"
+      <omv-form-slider class="omv-display-flex"
+                       [config]="field"
                        [formGroup]="formGroup">
       </omv-form-slider>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'container'">
-      <div class="omv-form-container"
-           fxLayout="row">
+      <div class="omv-form-container omv-display-flex omv-flex-row">
         <div *ngFor="let innerField of field.fields"
-             class="omv-form-container-item"
-             [fxFlex]="innerField.flex ? innerField.flex : ''">
+             class="omv-form-container-item omv-w-{{ innerField.flex ?? 100 }}">
           <ng-container [ngTemplateOutlet]="renderFormField"
                         [ngTemplateOutletContext]="{ $implicit: innerField }">
           </ng-container>
@@ -138,19 +155,22 @@
     </ng-template>
 
     <ng-template [ngSwitchCase]="'fileInput'">
-      <omv-form-file-input [config]="field"
+      <omv-form-file-input class="omv-display-flex"
+                           [config]="field"
                            [formGroup]="formGroup">
       </omv-form-file-input>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'hint'">
-      <omv-form-hint [config]="field"
+      <omv-form-hint class="omv-display-flex"
+                     [config]="field"
                      [formGroup]="formGroup">
       </omv-form-hint>
     </ng-template>
 
     <ng-template [ngSwitchCase]="'codeEditor'">
-      <omv-form-code-editor [config]="field"
+      <omv-form-code-editor class="omv-display-flex"
+                            [config]="field"
                             [formGroup]="formGroup">
       </omv-form-code-editor>
     </ng-template>

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/intuition.module.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/intuition.module.ts
@@ -1,7 +1,6 @@
 /* eslint-disable max-len */
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { TranslocoModule } from '@ngneat/transloco';
@@ -93,7 +92,6 @@ import { SharedModule } from '~/app/shared/shared.module';
     CommonModule,
     SharedModule,
     MaterialModule,
-    FlexLayoutModule,
     FormsModule,
     ReactiveFormsModule,
     TranslocoModule,

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/material/mat-form-datatable/mat-form-datatable.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/material/mat-form-datatable/mat-form-datatable.component.html
@@ -14,8 +14,7 @@
                [sorters]="sorters"
                [sortType]="sortType"
                (cellDataChangedEvent)="onCellDataChanged($event)">
-  <omv-datatable-actions fxFlex
-                         [actions]="actions"
+  <omv-datatable-actions [actions]="actions"
                          [selection]="selection"
                          [table]="table">
   </omv-datatable-actions>

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/models/form-field-config.type.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/models/form-field-config.type.ts
@@ -172,7 +172,7 @@ export type FormFieldConfig = {
   fields?: Array<FormFieldConfig>;
   // Fields in a container will respect the 'flex' configuration.
   // Specifies the size of the field in percent.
-  flex?: number;
+  flex?: 10 | 20 | 25 | 33 | 45 | 50 | 66 | 75 | 80 | 90 | 100;
 
   // --- button | hint ---
   text?: string;

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/rrd-page/rrd-page.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/rrd-page/rrd-page.component.html
@@ -52,18 +52,14 @@
 <ng-template #renderRrdGraph
              let-name>
   <mat-card>
-    <mat-toolbar fxLayout="row"
-                 class="omv-sticky">
-      <span fxFlex></span>
+    <mat-toolbar class="omv-display-flex omv-flex-row omv-justify-content-end omv-sticky">
       <button mat-icon-button
               matTooltip="{{ 'Reload' | transloco }}"
               (click)="onGenerate()">
-        <mat-icon svgIcon="{{ icon.reload }}">
-        </mat-icon>
+        <mat-icon svgIcon="{{ icon.reload }}"></mat-icon>
       </button>
     </mat-toolbar>
-    <mat-card-content fxLayout="column"
-                      fxLayoutAlign="start center">
+    <mat-card-content class="omv-display-flex omv-flex-column omv-justify-content-start omv-align-items-center">
       <div>
         <img src="rrd.php?name={{ name }}-hour.png&time={{ time }}"
              loading="lazy"

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/selection-list-page/selection-list-page.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/selection-list-page/selection-list-page.component.html
@@ -10,8 +10,7 @@
 </omv-alert-panel>
 <mat-card [ngClass]="{'omv-display-none': loading || error}">
   <mat-toolbar *ngIf="config.multiple && config.hasSelectAllButton"
-               class="omv-sticky"
-               fxLayout="row">
+               class="omv-sticky">
     <button mat-icon-button
             matTooltip="{{ 'Select all' | transloco }}"
             (click)="onSelectAll()">
@@ -42,8 +41,8 @@
     </mat-selection-list>
   </mat-card-content>
   <mat-card-actions *ngIf="config.buttons.length"
-                    fxLayout="row"
-                    [fxLayoutAlign]="config.buttonAlign">
+                    class="omv-display-flex omv-flex-row"
+                    [ngClass]="{'omv-justify-content-start': config.buttonAlign === 'start', 'omv-justify-content-center': config.buttonAlign === 'center', 'omv-justify-content-end': config.buttonAlign === 'end'}">
     <ng-container *ngFor="let button of config.buttons">
       <omv-submit-button *ngIf="button.template === 'submit'"
                          [disabled]="!dirty"

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/text-page/text-page.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/text-page/text-page.component.html
@@ -10,15 +10,14 @@
 </omv-alert-panel>
 <mat-card [ngClass]="{'omv-display-none': loading || error}">
   <mat-toolbar *ngIf="config.hasCopyToClipboardButton || (config.hasReloadButton && !config.autoReload)"
-               class="omv-sticky"
-               fxLayout="row">
+               class="omv-display-flex omv-flex-row omv-sticky">
     <button *ngIf="config.hasCopyToClipboardButton"
             mat-icon-button
             matTooltip="{{ 'Copy to clipboard' | transloco }}"
             (click)="onCopyToClipboard()">
       <mat-icon svgIcon="{{ icon.copy }}"></mat-icon>
     </button>
-    <div fxFlex></div>
+    <div class="omv-flex-1"></div>
     <button *ngIf="config.hasReloadButton && !config.autoReload"
             mat-icon-button
             matTooltip="{{ 'Reload' | transloco }}"
@@ -38,8 +37,8 @@
     <div class="omv-text-wrap omv-text-monospace">{{ text }}</div>
   </mat-card-content>
   <mat-card-actions *ngIf="config.buttons.length"
-                    fxLayout="row"
-                    [fxLayoutAlign]="config.buttonAlign">
+                    class="omv-display-flex omv-flex-row"
+                    [ngClass]="{'omv-justify-content-start': config.buttonAlign === 'start', 'omv-justify-content-center': config.buttonAlign === 'center', 'omv-justify-content-end': config.buttonAlign === 'end'}">
     <button *ngFor="let button of config.buttons"
             mat-flat-button
             [class]="button.class"

--- a/deb/openmediavault/workbench/src/app/core/components/layouts/workbench-layout/workbench-layout.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/layouts/workbench-layout/workbench-layout.component.html
@@ -1,5 +1,5 @@
 <mat-sidenav-container *ngIf="!loading"
-                       fxFlexFill
+                       class="omv-flex-fill"
                        autosize>
   <mat-sidenav #navigationSidenav
                id="omv-workbench-navigation"
@@ -8,7 +8,7 @@
                [opened]="sideNavOpened">
     <omv-navigation-bar></omv-navigation-bar>
   </mat-sidenav>
-  <mat-sidenav-content fxLayout="column">
+  <mat-sidenav-content class="omv-display-flex omv-flex-column">
     <omv-top-bar (navigationToggleChange)="onToggleNavigation()"
                  (notificationToggleChange)="onToggleNotification()">
     </omv-top-bar>

--- a/deb/openmediavault/workbench/src/app/core/components/layouts/workbench-layout/workbench-layout.component.spec.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/layouts/workbench-layout/workbench-layout.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { ɵMockMatchMediaProvider } from '@angular/flex-layout';
 import { ToastrModule } from 'ngx-toastr';
 
 import { ComponentsModule } from '~/app/core/components/components.module';
@@ -12,7 +11,6 @@ describe('WorkbenchLayoutComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      providers: [ɵMockMatchMediaProvider],
       imports: [ComponentsModule, TestingModule, ToastrModule.forRoot()]
     }).compileComponents();
   }));

--- a/deb/openmediavault/workbench/src/app/core/components/layouts/workbench-layout/workbench-layout.component.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/layouts/workbench-layout/workbench-layout.component.ts
@@ -15,8 +15,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { MediaObserver } from '@angular/flex-layout';
 import { MatDrawerMode, MatSidenav } from '@angular/material/sidenav';
 import { Event, NavigationEnd, Router } from '@angular/router';
 import { marker as gettext } from '@ngneat/transloco-keys-manager/marker';
@@ -65,7 +65,7 @@ export class WorkbenchLayoutComponent implements OnInit {
     private authSessionService: AuthSessionService,
     private blockUiService: BlockUiService,
     private dashboardWidgetConfigService: DashboardWidgetConfigService,
-    private media: MediaObserver,
+    private breakpointObserver: BreakpointObserver,
     private navigationConfig: NavigationConfigService,
     private notificationService: NotificationService,
     private prefersColorSchemeService: PrefersColorSchemeService,
@@ -89,7 +89,7 @@ export class WorkbenchLayoutComponent implements OnInit {
         })
     );
     this.subscriptions.add(
-      media.asObservable().subscribe(() => {
+      breakpointObserver.observe([Breakpoints.XSmall, Breakpoints.Small]).subscribe(() => {
         this.updateState();
       })
     );
@@ -108,7 +108,9 @@ export class WorkbenchLayoutComponent implements OnInit {
   }
 
   private updateState() {
-    this.isSmallScreen = this.media.isActive('xs') || this.media.isActive('sm');
+    this.isSmallScreen =
+      this.breakpointObserver.isMatched(Breakpoints.XSmall) ||
+      this.breakpointObserver.isMatched(Breakpoints.Small);
     setTimeout(() => {
       this.sideNavOpened = !this.isSmallScreen;
       this.sideNavMode = this.isSmallScreen ? 'over' : 'side';

--- a/deb/openmediavault/workbench/src/app/core/components/navigation-bar/navigation-bar-list-item/navigation-bar-list-item.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/navigation-bar/navigation-bar-list-item/navigation-bar-list-item.component.html
@@ -7,8 +7,8 @@
     {{ item.text | transloco }}
   </div>
   <div *ngIf="item.children?.length > 0"
-       fxFlex>
-    <div fxFlex></div>
+       class="omv-display-flex omv-flex-row omv-flex-1">
+    <div class="omv-flex-1"></div>
     <mat-icon svgIcon="{{ item.expanded ? icon.chevronDown : icon.chevronRight }}"></mat-icon>
   </div>
 </mat-list-item>

--- a/deb/openmediavault/workbench/src/app/core/components/navigation-bar/navigation-bar.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/navigation-bar/navigation-bar.component.html
@@ -1,10 +1,8 @@
-<div class="omv-navigation-bar"
-     fxLayout="column">
+<div class="omv-navigation-bar omv-display-flex omv-flex-column">
   <mat-toolbar class="header">
     <div class="logo"></div>
   </mat-toolbar>
-  <div class="content"
-       fxFlex>
+  <div class="content omv-flex-1">
     <ng-scrollbar appearance="standard"
                   visibility="hover">
       <mat-nav-list role="list">

--- a/deb/openmediavault/workbench/src/app/core/components/top-bar/top-bar.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/top-bar/top-bar.component.html
@@ -5,7 +5,7 @@
           (click)="onToggleNavigation($event)">
     <mat-icon svgIcon="{{ icon.menu }}"></mat-icon>
   </button>
-  <span fxFlex></span>
+  <span class="omv-flex-1"></span>
   <span class="hostname">{{ hostname }}</span>
   <mat-divider *ngIf="hostname"
                vertical="true">

--- a/deb/openmediavault/workbench/src/app/core/pages/about-page/about-page.component.html
+++ b/deb/openmediavault/workbench/src/app/core/pages/about-page/about-page.component.html
@@ -1,14 +1,13 @@
-<div class="omv-about-page omv-cursor-amiga13-select omv-cursor-amiga13-link">
-  <mat-card>
-    <div class="titlebar omv-flex omv-flex-row">
+<div class="omv-about-page">
+  <mat-card class="omv-cursor-amiga13-select omv-cursor-amiga13-link">
+    <div class="titlebar omv-display-flex omv-flex-row">
       <div class="title">{{ 'About' | transloco }}</div>
       <div class="mid omv-flex-grow"></div>
       <div class="mid-end"></div>
       <div class="position"></div>
     </div>
     <mat-card-content>
-      <div class="logo omv-text-monospace"
-           fxLayout="column">
+      <div class="logo omv-text-monospace omv-display-flex omv-flex-column">
         <pre class="ascii-art">
                                                .__.__                         .__   __
   ____ ______   ____   ____   _____   ____   __| _|_______ ___  ______   __ __|  |_/  |_
@@ -17,9 +16,8 @@
  \____/|   __/ \___  |___|  |__|_|  /\___  \____ ||__(____  /\_/ (____  |____/|____|__|
        |__|        \/     \/      \/     \/     \/        \/          \/
         </pre>
-        <div class="side-scroller">
-          <div class="text"
-               fxFlex>
+        <div class="side-scroller omv-display-flex omv-flex-row">
+          <div class="text omv-flex-1">
             gREETINGS gO tO [Edith] ♦ [Räuberweg] ♦ [B69] ♦ [Chris] ♦ [lENNY dEE] ♦ [iCARUS] ♦ [lUCAS] ♦ [sHALLOW] ♦ [lUCKY] ♦ [gREMLIN] ♦ [bLACKY] ♦ [-jOE cOOL!] ♦ [tHALER] ♦ [nEUROdANCER] ♦ [iNTERCODE] ♦ [sUNSET] ♦ [E.F.A.] ♦ [sISKO] ♦ [bBC] ♦ [bILBO bAGGINS] ♦ ] jOKER [ ♦ [wENDIGO] ♦ [bRAINDEAD] ♦ [ryecoaaron] ♦ [Adoby] ♦ [Agricola] ♦ [crashtest] ♦ [geaves] ♦ [KM0201] ♦ [macom] ♦ [davidh2k] ♦ [donh] ♦ [jhmiller] ♦ [SerErris] ♦ [Solo0815] ♦ [Spy Alelo] ♦ [subzero79] ♦ [tekkb] ♦ [WastlJ] ... sORRY tO aLL i hAVE fORGOTTEN ...
           </div>
         </div>

--- a/deb/openmediavault/workbench/src/app/core/pages/login-page/login-page.component.html
+++ b/deb/openmediavault/workbench/src/app/core/pages/login-page/login-page.component.html
@@ -5,7 +5,7 @@
                   secondaryColor="#f8d400">
   </omv-green-rain>
   <div class="toolbar">
-    <mat-toolbar class="omv-flex omv-justify-end">
+    <mat-toolbar class="omv-display-flex omv-justify-content-end">
       <button mat-icon-button
               matTooltip="{{ 'Language' | transloco }}"
               [matMenuTriggerFor]="localeMenu">
@@ -19,7 +19,7 @@
     <div class="logo"></div>
   </div>
   <div class="content">
-    <omv-intuition-form-page class="omv-flex omv-justify-center omv-items-center"
+    <omv-intuition-form-page class="omv-display-flex omv-justify-content-center omv-align-items-center"
                              [config]="this.config">
     </omv-intuition-form-page>
   </div>

--- a/deb/openmediavault/workbench/src/app/core/pages/navigation-page/navigation-page.component.html
+++ b/deb/openmediavault/workbench/src/app/core/pages/navigation-page/navigation-page.component.html
@@ -1,10 +1,7 @@
-<div class="omv-navigation-page"
-     gdGap="12px"
-     gdColumns="repeat(auto-fit, minmax(150px, 1fr))">
+<div class="omv-navigation-page omv-grid omv-gap-3">
   <mat-card *ngFor="let item of menuItems"
+            class="omv-box-border omv-display-flex omv-flex-column omv-align-content-center omv-justify-content-center omv-align-items-center"
             mat-ripple
-            fxLayout="column"
-            fxLayoutAlign="center center"
             tabindex="0"
             (keyup.space)="onClick(item)"
             (keyup.enter)="onClick(item)"

--- a/deb/openmediavault/workbench/src/app/core/pages/navigation-page/navigation-page.component.scss
+++ b/deb/openmediavault/workbench/src/app/core/pages/navigation-page/navigation-page.component.scss
@@ -2,6 +2,7 @@
 
 .omv-navigation-page {
   margin: dv.$omv-margin;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
 
   .mat-card {
     cursor: pointer;

--- a/deb/openmediavault/workbench/src/app/core/pages/pages.module.ts
+++ b/deb/openmediavault/workbench/src/app/core/pages/pages.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { RouterModule } from '@angular/router';
 import { TranslocoModule } from '@ngneat/transloco';
 
@@ -42,7 +41,6 @@ import { SharedModule } from '~/app/shared/shared.module';
     CommonModule,
     SharedModule,
     ComponentsModule,
-    FlexLayoutModule,
     MaterialModule,
     RouterModule,
     TranslocoModule,

--- a/deb/openmediavault/workbench/src/app/pages/dashboard/dashboard.module.ts
+++ b/deb/openmediavault/workbench/src/app/pages/dashboard/dashboard.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { TranslocoModule } from '@ngneat/transloco';
 
 import { CoreModule } from '~/app/core/core.module';
@@ -17,8 +16,7 @@ import { SharedModule } from '~/app/shared/shared.module';
     DashboardRoutingModule,
     MaterialModule,
     SharedModule,
-    TranslocoModule,
-    FlexLayoutModule
+    TranslocoModule
   ]
 })
 export class DashboardModule {}

--- a/deb/openmediavault/workbench/src/app/pages/network/network.module.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/network.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { TranslocoModule } from '@ngneat/transloco';
 
 import { CoreModule } from '~/app/core/core.module';
@@ -40,7 +39,6 @@ import { SharedModule } from '~/app/shared/shared.module';
   imports: [
     CommonModule,
     CoreModule,
-    FlexLayoutModule,
     MaterialModule,
     SharedModule,
     NetworkRoutingModule,

--- a/deb/openmediavault/workbench/src/app/pages/system/plugins/plugins-datatable-page.component.html
+++ b/deb/openmediavault/workbench/src/app/pages/system/plugins/plugins-datatable-page.component.html
@@ -3,8 +3,7 @@
 <ng-template #pluginInfoTpl
              let-row="row">
   <div class="omv-datatable-cell-package-info">
-    <div fxLayout="row"
-         class="omv-datatable-cell-header">
+    <div class="omv-datatable-cell-header">
       <div class="omv-datatable-cell-header-text">
         <div class="omv-font-weight-title omv-font-size-title">{{ row.name }} {{ row.version }}</div>
         <div class="omv-font-size-subheading-2">{{ row.summary }}</div>

--- a/deb/openmediavault/workbench/src/app/pages/system/system.module.ts
+++ b/deb/openmediavault/workbench/src/app/pages/system/system.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { TranslocoModule } from '@ngneat/transloco';
 
 import { CoreModule } from '~/app/core/core.module';
@@ -56,7 +55,6 @@ import { SharedModule } from '~/app/shared/shared.module';
   imports: [
     CommonModule,
     CoreModule,
-    FlexLayoutModule,
     MaterialModule,
     SharedModule,
     SystemRoutingModule,

--- a/deb/openmediavault/workbench/src/app/pages/system/updates/update-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/system/updates/update-datatable-page.component.ts
@@ -33,7 +33,7 @@ export class UpdateDatatablePageComponent {
         cellTemplateName: 'template',
         cellTemplateConfig:
           '<div>' +
-          '  <div fxLayout="row">' +
+          '  <div class="omv-display-flex omv-flex-row">' +
           '    <div class="omv-font-weight-title omv-font-size-title">{{ name }} {{ version }}</div>' +
           '    <div class="omv-font-size-subheading-2">{{ summary }}</div>' +
           '  </div>' +

--- a/deb/openmediavault/workbench/src/app/shared/components/alert-panel/alert-panel.component.html
+++ b/deb/openmediavault/workbench/src/app/shared/components/alert-panel/alert-panel.component.html
@@ -1,13 +1,10 @@
 <mat-card class="alert-{{ type }}"
           [ngClass]="{'omv-m': hasMargin, 'omv-display-none': dismissed}">
-  <div fxLayout="row">
+  <div class="omv-display-flex omv-flex-row">
     <mat-icon *ngIf="icon"
               class="alert-icon omv-icon-lg"
               svgIcon="{{ icon }}"></mat-icon>
-    <div class="content-wrapper"
-         fxFlex
-         fxLayout="column"
-         fxLayoutAlign="center">
+    <div class="content-wrapper omv-flex-column omv-flex-1 omv-justify-content-center omv-align-items-start">
       <mat-card-title *ngIf="hasTitle && title">
         {{ title | transloco }}
       </mat-card-title>
@@ -16,9 +13,7 @@
       </mat-card-content>
     </div>
     <mat-card-actions *ngIf="buttons.length"
-                      fxLayout="row"
-                      fxLayoutAlign="end start"
-                      fxLayout.lt-sm="column-reverse">
+                      class="omv-display-flex omv-flex-row omv-flex-column-reverse-lt-sm omv-justify-content-end omv-align-items-start">
       <div *ngFor="let button of buttons"
            class="alert-action-button omv-ml-q"
            [class]="button.class"

--- a/deb/openmediavault/workbench/src/app/shared/components/components.module.ts
+++ b/deb/openmediavault/workbench/src/app/shared/components/components.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
 import { TranslocoModule } from '@ngneat/transloco';
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
@@ -44,7 +43,6 @@ import { PipesModule } from '~/app/shared/pipes/pipes.module';
     NgxDatatableModule,
     TranslocoModule,
     FormsModule,
-    FlexLayoutModule,
     DirectivesModule
   ]
 })

--- a/deb/openmediavault/workbench/src/app/shared/components/datatable/datatable.component.html
+++ b/deb/openmediavault/workbench/src/app/shared/components/datatable/datatable.component.html
@@ -1,9 +1,9 @@
 <mat-toolbar *ngIf="hasActionBar"
-             [ngClass]="{'omv-sticky': hasStickyActionBar}"
-             fxLayout="row">
+             class="omv-display-flex"
+             [ngClass]="{'omv-sticky': hasStickyActionBar}">
   <!-- Custom action buttons -->
   <ng-content select="omv-datatable-actions"></ng-content>
-  <span fxFlex></span>
+  <span class="omv-flex-1"></span>
   <!-- Default action buttons -->
   <button *ngIf="stateId"
           mat-icon-button
@@ -182,10 +182,10 @@
              let-value="value"
              let-column="column"
              let-row="row">
-  <mat-button-toggle-group fxLayout="row"
+  <mat-button-toggle-group class="omv-display-flex omv-flex-row"
                            value="{{ value }}">
     <mat-button-toggle *ngFor="let button of column.cellTemplateConfig.buttons"
-                       fxFlex
+                       class="omv-flex-1"
                        [value]="button.value"
                        (change)="onButtonToggleChange($event, row, column)">
       <span>{{ button.text }}</span>

--- a/deb/openmediavault/workbench/src/app/shared/components/modal-dialog/modal-dialog.component.html
+++ b/deb/openmediavault/workbench/src/app/shared/components/modal-dialog/modal-dialog.component.html
@@ -1,8 +1,6 @@
 <div *ngIf="config.title"
-     class="omv-flex omv-items-center"
-     mat-dialog-title
-     fxLayout="row"
-     fxLayoutGap="10px">
+     class="omv-display-flex omv-flex-row omv-align-items-center omv-gap-4"
+     mat-dialog-title>
   <mat-icon *ngIf="config.icon"
             class="omv-icon-lg"
             svgIcon="{{ config.icon }}">
@@ -17,7 +15,7 @@
     <mat-checkbox (change)="onConfirmCheckboxChange()">
       {{ 'Confirm' | transloco }}
     </mat-checkbox>
-    <span fxFlex></span>
+    <span class="omv-flex-1"></span>
   </ng-container>
   <button *ngFor="let button of config.buttons"
           mat-flat-button

--- a/deb/openmediavault/workbench/src/app/shared/components/task-dialog/task-dialog.component.html
+++ b/deb/openmediavault/workbench/src/app/shared/components/task-dialog/task-dialog.component.html
@@ -1,5 +1,5 @@
 <h1 *ngIf="config.title"
-    class="omv-flex omv-items-center"
+    class="omv-display-flex omv-align-items-center"
     mat-dialog-title>
   <mat-icon *ngIf="config.icon"
             class="omv-pr-h"

--- a/deb/openmediavault/workbench/src/styles.scss
+++ b/deb/openmediavault/workbench/src/styles.scss
@@ -72,13 +72,13 @@ $omv-dark-theme: mat.define-dark-theme(
 ////////////////////////////////////////////////////////////////////////////////
 // Orientation
 .omv-vertical-align {
-  @extend .omv-flex;
-  @extend .omv-items-center;
+  @extend .omv-display-flex;
+  @extend .omv-align-items-center;
 }
 
 .omv-horizontal-align {
-  @extend .omv-flex;
-  @extend .omv-justify-center;
+  @extend .omv-display-flex;
+  @extend .omv-justify-content-center;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -89,6 +89,46 @@ $omv-dark-theme: mat.define-dark-theme(
 
 .omv-h-auto {
   height: auto;
+}
+
+.omv-w-10 {
+  width: 10% !important;
+}
+
+.omv-w-20 {
+  width: 20% !important;
+}
+
+.omv-w-25 {
+  width: 25% !important;
+}
+
+.omv-w-33 {
+  width: 33.3333% !important;
+}
+
+.omv-w-45 {
+  width: 45% !important;
+}
+
+.omv-w-50 {
+  width: 50% !important;
+}
+
+.omv-w-66 {
+  width: 66.6667% !important;
+}
+
+.omv-w-75 {
+  width: 75% !important;
+}
+
+.omv-w-80 {
+  width: 80% !important;
+}
+
+.omv-w-90 {
+  width: 90% !important;
 }
 
 .omv-w-100 {
@@ -362,7 +402,14 @@ $omv-dark-theme: mat.define-dark-theme(
 
 ////////////////////////////////////////////////////////////////////////////////
 // Flex
-.omv-flex {
+//
+// The following implementation is based on Angular flex-layout to make
+// the transition as easy as possible.
+//
+// References:
+// - https://github.com/angular/flex-layout/wiki/Declarative-API-Overview
+// - https://github.com/angular/flex-layout/wiki/Responsive-API
+.omv-display-flex {
   display: flex !important;
 }
 
@@ -370,8 +417,52 @@ $omv-dark-theme: mat.define-dark-theme(
   flex-direction: row;
 }
 
+.omv-flex-row-reverse {
+  flex-direction: row-reverse;
+}
+
 .omv-flex-column {
   flex-direction: column;
+}
+
+.omv-flex-column-reverse {
+  flex-direction: column-reverse;
+}
+
+.omv-flex-column-reverse-lt-sm {
+  @media only screen and (width <= 599px) {
+    flex-direction: column-reverse;
+  }
+}
+
+// Prevent a flex item from growing or shrinking.
+.omv-flex-none {
+  flex: none;
+}
+
+// Allow a flex item to grow and shrink as needed, ignoring its initial
+// size.
+.omv-flex-1 {
+  flex: 1 1 0%;
+}
+
+// Allow a flex item to shrink but not grow, taking into account its
+// initial size.
+.omv-flex-initial {
+  flex: 0 1 auto;
+}
+
+// Allow a flex item to grow and shrink, taking its initial size into
+// account.
+.omv-flex-auto {
+  flex: 1 1 auto;
+}
+
+.omv-flex-fill {
+  height: 100%;
+  min-height: 100%;
+  min-width: 100%;
+  width: 100%;
 }
 
 .omv-flex-grow {
@@ -382,28 +473,128 @@ $omv-dark-theme: mat.define-dark-theme(
   flex-grow: 0;
 }
 
-.omv-justify-start {
+.omv-flex-wrap {
+  flex-wrap: wrap;
+}
+
+.omv-flex-nowrap {
+  flex-wrap: nowrap;
+}
+
+.omv-flex-wrap-reverse {
+  flex-wrap: wrap-reverse;
+}
+
+.omv-justify-content-start {
   justify-content: flex-start;
 }
 
-.omv-justify-end {
-  justify-content: flex-end;
-}
-
-.omv-justify-center {
+.omv-justify-content-center {
   justify-content: center;
 }
 
-.omv-items-start {
+.omv-justify-content-end {
+  justify-content: flex-end;
+}
+
+.omv-align-content-start {
+  align-content: flex-start;
+}
+
+.omv-align-content-center {
+  align-content: center;
+}
+
+.omv-align-content-end {
+  align-content: flex-end;
+}
+
+.omv-align-content-stretch {
+  align-content: stretch;
+}
+
+.omv-align-items-start {
   align-items: flex-start;
 }
 
-.omv-items-end {
+.omv-align-items-center {
+  align-items: center;
+}
+
+.omv-align-items-end {
   align-items: flex-end;
 }
 
-.omv-items-center {
-  align-items: center;
+.omv-align-items-stretch {
+  align-items: stretch;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Grid
+.omv-grid {
+  display: grid;
+}
+
+.omv-grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+.omv-grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.omv-grid-cols-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.omv-grid-cols-none {
+  grid-template-columns: none;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Gap
+.omv-gap-0 {
+  gap: 0;
+}
+
+/* stylelint-disable selector-class-pattern */
+.omv-gap-0\.5 {
+  gap: 0.125rem;
+}
+
+.omv-gap-1 {
+  gap: 0.25rem;
+}
+
+.omv-gap-1\.5 {
+  gap: 0.375rem;
+}
+
+.omv-gap-2 {
+  gap: 0.5rem;
+}
+
+.omv-gap-2\.5 {
+  gap: 0.625rem;
+}
+/* stylelint-enable selector-class-pattern */
+
+.omv-gap-3 {
+  gap: 0.75rem;
+}
+
+.omv-gap-4 {
+  gap: 1rem;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Box sizing
+.omv-box-border {
+  box-sizing: border-box;
+}
+
+.omv-box-content {
+  box-sizing: content-box;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is necessary to be able to upgrade to a newer Angular version because the flex-layout has been deprecated and is not supported anymore.

Fixes: https://github.com/openmediavault/openmediavault/issues/1576

References:
- https://github.com/angular/flex-layout/wiki/Declarative-API-Overview
- https://css-tricks.com/snippets/css/a-guide-to-flexbox/#flexbox-background


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [x] Includes tests for new functionality or reproducer for bug
