### PR TITLE
Add alternative MAC address support for wired, wireless and VLAN network interfaces

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,3 +1,10 @@
+openmediavault (6.5.0-1) stable; urgency=low
+
+  * Issue #1564: Add alternative MAC address support for wired,
+    wireless and VLAN network interfaces.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Thu, 13 Jul 2023 13:14:36 +0200
+
 openmediavault (6.4.9-1) stable; urgency=low
 
   * Improve `omv-btrfs-dfree` command which is used by Samba on

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/50netplan.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/50netplan.sls
@@ -19,6 +19,7 @@
 
 # Documentation/Howto:
 # https://superuser.com/questions/1490670/does-systemd-networkd-systemd-resolved-add-search-domains-specified-in-dhcp
+# https://netplan.readthedocs.io/en/stable/netplan-yaml
 
 include:
   - .netplan

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/ethernet.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/ethernet.j2
@@ -5,8 +5,8 @@ network:
     {{ interface.devicename }}:
       match:
         macaddress: {{ mac_address }}
-{%- if not interface.forcedmac == "" %}
-      macaddress: {{ interface.forcedmac }}
+{%- if interface.altmacaddress | length > 0 %}
+      macaddress: {{ interface.altmacaddress }}
 {%- endif %}
 {%- if interface.method == "static" or interface.method6 == "static" %}
       addresses:

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/ethernet.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/ethernet.j2
@@ -5,6 +5,9 @@ network:
     {{ interface.devicename }}:
       match:
         macaddress: {{ mac_address }}
+{%- if not interface.forcedmac == "" %}
+      macaddress: {{ interface.forcedmac }}
+{%- endif %}
 {%- if interface.method == "static" or interface.method6 == "static" %}
       addresses:
 {%- if interface.method == "static" %}

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/vlan.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/vlan.j2
@@ -2,6 +2,9 @@
 network:
   vlans:
     {{ interface.devicename }}:
+{%- if not interface.forcedmac == "" %}
+      macaddress: {{ interface.forcedmac }}
+{%- endif %}
 {%- if interface.method == "static" or interface.method6 == "static" %}
       addresses:
 {%- if interface.method == "static" %}

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/vlan.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/vlan.j2
@@ -2,8 +2,8 @@
 network:
   vlans:
     {{ interface.devicename }}:
-{%- if not interface.forcedmac == "" %}
-      macaddress: {{ interface.forcedmac }}
+{%- if interface.altmacaddress | length > 0 %}
+      macaddress: {{ interface.altmacaddress }}
 {%- endif %}
 {%- if interface.method == "static" or interface.method6 == "static" %}
       addresses:

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/wifi.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/wifi.j2
@@ -2,6 +2,9 @@
 network:
   wifis:
     {{ interface.devicename }}:
+{%- if not interface.forcedmac == "" %}
+      macaddress: {{ interface.forcedmac }}
+{%- endif %}
 {%- if interface.method == "static" or interface.method6 == "static" %}
       addresses:
 {%- if interface.method == "static" %}

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/wifi.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/wifi.j2
@@ -2,8 +2,8 @@
 network:
   wifis:
     {{ interface.devicename }}:
-{%- if not interface.forcedmac == "" %}
-      macaddress: {{ interface.forcedmac }}
+{%- if interface.altmacaddress | length > 0 %}
+      macaddress: {{ interface.altmacaddress }}
 {%- endif %}
 {%- if interface.method == "static" or interface.method6 == "static" %}
       addresses:

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.system.network.interface.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.system.network.interface.json
@@ -85,6 +85,11 @@
 		"comment": {
 			"type": "string"
 		},
+		"altmacaddress": {
+			"type": "string",
+			"pattern": "^([a-fA-F0-9]{2}(:[a-fA-F0-9]{2}){5})?$",
+			"default": ""
+		},
 		"slaves": {
 			"type": "string",
 			"oneOf": [{

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.network.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.network.json
@@ -84,6 +84,11 @@
 			"comment": {
 			   "type": "string",
 			   "required": true
+			},
+			"altmacaddress": {
+			   "type": "string",
+			   "pattern": "^([a-fA-F0-9]{2}(:[a-fA-F0-9]{2}){5})?$",
+			   "required": true
 			}
 		}
 	}
@@ -295,16 +300,21 @@
 			   "type": "string",
 			   "required": true
 		   },
+		   "altmacaddress": {
+			   "type": "string",
+			   "pattern": "^([a-fA-F0-9]{2}(:[a-fA-F0-9]{2}){5})?$",
+			   "required": true
+		   },
 		   "vlanid": {
-				"type": "integer",
-				"minimum": 1,
-				"maximum": 4095,
+			   "type": "integer",
+			   "minimum": 1,
+			   "maximum": 4095,
 			   "required": true
-			},
-			"vlanrawdevice": {
-				"type": "string",
+		   },
+		   "vlanrawdevice": {
+			   "type": "string",
 			   "required": true
-			}
+		   }
 		}
 	}
 },{
@@ -394,18 +404,23 @@
 			   "type": "string",
 			   "required": true
 		   },
+		   "altmacaddress": {
+			   "type": "string",
+			   "pattern": "^([a-fA-F0-9]{2}(:[a-fA-F0-9]{2}){5})?$",
+			   "required": true
+		   },
 		   "wpassid": {
-				"type": "string",
-				"required": true
-			},
-			"wpapsk": {
-				"type": "string",
-				"required": true
-			},
-			"hidden": {
+			   "type": "string",
+			   "required": true
+		   },
+		   "wpapsk": {
+			   "type": "string",
+			   "required": true
+		   },
+		   "hidden": {
 			   "type": "boolean",
 			   "required": true
-			}
+		   }
 		}
 	}
 },{

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/network.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/network.inc
@@ -567,8 +567,7 @@ class Network extends \OMV\Rpc\ServiceAbstract {
 		$this->validateMethodParams($params, "rpc.network.setethernetiface");
 		// Set the configuration object.
 		return $this->setInterfaceConfig($params, [
-			"type" => "ethernet",
-			"forcedmac" => preg_replace("/[ -.]/", ":", $params['forcedmac'])
+			"type" => "ethernet"
 		]);
 	}
 
@@ -835,8 +834,7 @@ class Network extends \OMV\Rpc\ServiceAbstract {
 		return $this->setInterfaceConfig($params, [
 			"type" => "vlan",
 			"vlanid" => $params['vlanid'],
-			"vlanrawdevice" => $params['vlanrawdevice'],
-			"forcedmac" => preg_replace("/[ -.]/", ":", $params['forcedmac'])
+			"vlanrawdevice" => $params['vlanrawdevice']
 		]);
 	}
 
@@ -913,8 +911,7 @@ class Network extends \OMV\Rpc\ServiceAbstract {
 			"type" => "wifi",
 			"wpassid" => $params['wpassid'],
 			"wpapsk" => $params['wpapsk'],
-			"hidden" => $params['hidden'],
-			"forcedmac" => preg_replace("/[ -.]/", ":", $params['forcedmac'])
+			"hidden" => $params['hidden']
 		]);
     }
 

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/network.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/network.inc
@@ -567,7 +567,8 @@ class Network extends \OMV\Rpc\ServiceAbstract {
 		$this->validateMethodParams($params, "rpc.network.setethernetiface");
 		// Set the configuration object.
 		return $this->setInterfaceConfig($params, [
-			"type" => "ethernet"
+			"type" => "ethernet",
+			"forcedmac" => preg_replace("/[ -.]/", ":", $params['forcedmac'])
 		]);
 	}
 
@@ -834,7 +835,8 @@ class Network extends \OMV\Rpc\ServiceAbstract {
 		return $this->setInterfaceConfig($params, [
 			"type" => "vlan",
 			"vlanid" => $params['vlanid'],
-			"vlanrawdevice" => $params['vlanrawdevice']
+			"vlanrawdevice" => $params['vlanrawdevice'],
+			"forcedmac" => preg_replace("/[ -.]/", ":", $params['forcedmac'])
 		]);
 	}
 
@@ -911,7 +913,8 @@ class Network extends \OMV\Rpc\ServiceAbstract {
 			"type" => "wifi",
 			"wpassid" => $params['wpassid'],
 			"wpapsk" => $params['wpapsk'],
-			"hidden" => $params['hidden']
+			"hidden" => $params['hidden'],
+			"forcedmac" => preg_replace("/[ -.]/", ":", $params['forcedmac'])
 		]);
     }
 

--- a/deb/openmediavault/usr/share/openmediavault/firstaid/modules.d/10configure_network.py
+++ b/deb/openmediavault/usr/share/openmediavault/firstaid/modules.d/10configure_network.py
@@ -397,6 +397,7 @@ class Module(openmediavault.firstaid.IModule):
                 "mtu": 0,
                 "wol": wol,
                 "comment": "",
+                "altmacaddress": "",
             }
         )
         # Do we process a wireless network interface?

--- a/deb/openmediavault/usr/share/openmediavault/locale/ar_SA/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/ar_SA/openmediavault.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: omv nas <myomv100@gmail.com>, 2020-2023\n"
 "Language-Team: Arabic (Saudi Arabia) (http://app.transifex.com/openmediavault/openmediavault/language/ar_SA/)\n"
@@ -1289,6 +1289,9 @@ msgstr "الأعلام"
 msgid "Force SSL/TLS"
 msgstr "فرض SSL / TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "فرض اتصال آمن فقط."
 
@@ -1815,6 +1818,9 @@ msgstr "لوكسمبورغ"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "عنوان MAC"
 
 msgid "MII monitoring frequency"
 msgstr "تردد مراقبة MII"
@@ -3421,6 +3427,9 @@ msgstr "يجب أن يكون هذا الحقل وفق التنسيق <hh:mm:ss>.
 
 msgid "This field should be a IP network address in CIDR notation."
 msgstr "يجب أن يحتوي هذا الحقل على عنوان شبكة IP في صيغة CIDR"
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
+msgstr ""
 
 msgid "This field should be a domain name or an IP address."
 msgstr "يجب أن يحتوي هذا الحقل على اسم نطاق أو عنوان IP"

--- a/deb/openmediavault/usr/share/openmediavault/locale/bg_BG/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/bg_BG/openmediavault.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Plamen Vasilev <p.vasileff@gmail.com>, 2017\n"
 "Language-Team: Bulgarian (Bulgaria) (http://app.transifex.com/openmediavault/openmediavault/language/bg_BG/)\n"
@@ -1288,6 +1288,9 @@ msgstr ""
 msgid "Force SSL/TLS"
 msgstr ""
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr ""
 
@@ -1813,6 +1816,9 @@ msgid "Luxembourg"
 msgstr ""
 
 msgid "MAC"
+msgstr ""
+
+msgid "MAC address"
 msgstr ""
 
 msgid "MII monitoring frequency"
@@ -3419,6 +3425,9 @@ msgid "This field must have the format <hh:mm:ss>."
 msgstr ""
 
 msgid "This field should be a IP network address in CIDR notation."
+msgstr ""
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
 msgstr ""
 
 msgid "This field should be a domain name or an IP address."

--- a/deb/openmediavault/usr/share/openmediavault/locale/ca_ES/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/ca_ES/openmediavault.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Quim Farriol <qfarriol@valette.cat>, 2020-2022\n"
 "Language-Team: Catalan (Spain) (http://app.transifex.com/openmediavault/openmediavault/language/ca_ES/)\n"
@@ -1290,6 +1290,9 @@ msgstr "Banderes"
 msgid "Force SSL/TLS"
 msgstr "Forçar SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "Forçar connexió segura"
 
@@ -1816,6 +1819,9 @@ msgstr "Luxemburg"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "Adreça MAC"
 
 msgid "MII monitoring frequency"
 msgstr "Freqüència de monitoratge (ethernet)"
@@ -3422,6 +3428,9 @@ msgstr "Aquest camp ha de tenir el format<hh:mm:ss>. "
 
 msgid "This field should be a IP network address in CIDR notation."
 msgstr "Aquest camp hauria de ser una adreça de xarxa IP a la notació CIDR. "
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
+msgstr ""
 
 msgid "This field should be a domain name or an IP address."
 msgstr "Aquest camp hauria de ser un nom de domini o una adreça IP. "

--- a/deb/openmediavault/usr/share/openmediavault/locale/cs_CZ/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/cs_CZ/openmediavault.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>, 2014-2021\n"
 "Language-Team: Czech (Czech Republic) (http://app.transifex.com/openmediavault/openmediavault/language/cs_CZ/)\n"
@@ -1289,6 +1289,9 @@ msgstr "Příznaky"
 msgid "Force SSL/TLS"
 msgstr "Vynucovat SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "Požadovat výhradně zabezpečené spojení."
 
@@ -1815,6 +1818,9 @@ msgstr "Lucembursko"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "MAC adresa"
 
 msgid "MII monitoring frequency"
 msgstr "Četnost hlídání rozhraní MII"
@@ -3421,6 +3427,9 @@ msgstr "Je třeba, aby kolonka byla ve formátu <hh:mm:ss>."
 
 msgid "This field should be a IP network address in CIDR notation."
 msgstr "Kolonka by měla obsahovat IP adresu sítě v CIDR zápisu."
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
+msgstr ""
 
 msgid "This field should be a domain name or an IP address."
 msgstr "Tato kolonka by měla obsahovat doménový název nebo IP adresu."

--- a/deb/openmediavault/usr/share/openmediavault/locale/da_DA/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/da_DA/openmediavault.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Stefan Thrane Overby <stoverby@gmail.com>, 2012-2018,2020-2022\n"
 "Language-Team: Danish (http://app.transifex.com/openmediavault/openmediavault/language/da/)\n"
@@ -1288,6 +1288,9 @@ msgstr "Flag"
 msgid "Force SSL/TLS"
 msgstr "Tving SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "Tving kun sikker forbindelse"
 
@@ -1814,6 +1817,9 @@ msgstr "Luxembourg"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "MAC adresse"
 
 msgid "MII monitoring frequency"
 msgstr "MII overvågnings frekvens"
@@ -3419,6 +3425,9 @@ msgid "This field must have the format <hh:mm:ss>."
 msgstr ""
 
 msgid "This field should be a IP network address in CIDR notation."
+msgstr ""
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
 msgstr ""
 
 msgid "This field should be a domain name or an IP address."

--- a/deb/openmediavault/usr/share/openmediavault/locale/de_DE/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/de_DE/openmediavault.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Volker Theile <votdev@gmx.de>, 2021-2023\n"
 "Language-Team: German (http://app.transifex.com/openmediavault/openmediavault/language/de/)\n"
@@ -1300,6 +1300,9 @@ msgstr "Flags"
 msgid "Force SSL/TLS"
 msgstr "Erzwinge SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr "Erzwinge eine bestimmte MAC-Adresse auf dieser Schnittstelle."
+
 msgid "Force secure connection only."
 msgstr "Sichere Verbindung erzwingen."
 
@@ -1826,6 +1829,9 @@ msgstr "Luxemburg"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "MAC-Adresse"
 
 msgid "MII monitoring frequency"
 msgstr "MII Überwachungs-häufigkeit"
@@ -3432,6 +3438,9 @@ msgstr "Dieses Feld muss das Format <hh:mm:ss> haben."
 
 msgid "This field should be a IP network address in CIDR notation."
 msgstr "Dieses Feld sollte eine IP-Netzwerkadresse in CIDR-Notation sein."
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
+msgstr "Dieses Feld sollte eine MAC-Adresse sein, z.B. 00:80:41:ae:fd:7e."
 
 msgid "This field should be a domain name or an IP address."
 msgstr "Dieses Feld erwartet einen Domainnamen oder eine IP Adresse."

--- a/deb/openmediavault/usr/share/openmediavault/locale/el_GR/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/el_GR/openmediavault.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Kostas Moho, 2012-2023\n"
 "Language-Team: Greek (Greece) (http://app.transifex.com/openmediavault/openmediavault/language/el_GR/)\n"
@@ -1288,6 +1288,9 @@ msgstr "Σημάνσεις"
 msgid "Force SSL/TLS"
 msgstr "Επιβολή SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "Να απαιτείται μόνο ασφαλής σύνδεση."
 
@@ -1814,6 +1817,9 @@ msgstr "Luxembourg"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "Διεύθυνση MAC"
 
 msgid "MII monitoring frequency"
 msgstr "Συχνότητα παρακολούθησης ΜΙΙ"
@@ -3420,6 +3426,9 @@ msgstr "Αυτό το πεδίο πρέπει να έχει μορφή <hh:mm:ss
 
 msgid "This field should be a IP network address in CIDR notation."
 msgstr "Αυτό το πεδίο δέχεται διεύθυνση ΙΡ σε μορφή CIDR."
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
+msgstr ""
 
 msgid "This field should be a domain name or an IP address."
 msgstr "Αυτό το πεδίο δέχεται όνομα τομέα ή διεύθυνση ΙΡ."

--- a/deb/openmediavault/usr/share/openmediavault/locale/es_ES/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/es_ES/openmediavault.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Raul Fernandez Garcia <raulfg3@gmail.com>, 2012-2023\n"
 "Language-Team: Spanish (Spain) (http://app.transifex.com/openmediavault/openmediavault/language/es_ES/)\n"
@@ -1291,6 +1291,9 @@ msgstr "Banderas"
 msgid "Force SSL/TLS"
 msgstr "Forzar SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "Forzar conexión segura"
 
@@ -1817,6 +1820,9 @@ msgstr "Luxemburgo"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "Dirección MAC"
 
 msgid "MII monitoring frequency"
 msgstr "Frecuencia de monitorización (ethernet)"
@@ -3423,6 +3429,9 @@ msgstr "Este campo debe tener el formato: <hh:mm:ss>."
 
 msgid "This field should be a IP network address in CIDR notation."
 msgstr "Este campo debe ser una dirección de red IP en notación CIDR."
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
+msgstr ""
 
 msgid "This field should be a domain name or an IP address."
 msgstr "Este campo debe ser un nombre de dominio o una dirección IP."

--- a/deb/openmediavault/usr/share/openmediavault/locale/fr_FR/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/fr_FR/openmediavault.po
@@ -22,7 +22,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: M@T D., 2022-2023\n"
 "Language-Team: French (France) (http://app.transifex.com/openmediavault/openmediavault/language/fr_FR/)\n"
@@ -1302,6 +1302,9 @@ msgstr "Drapeaux"
 msgid "Force SSL/TLS"
 msgstr "Forcer SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "Forcer les connections sécurisées."
 
@@ -1828,6 +1831,9 @@ msgstr "Luxembourg"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "Adresse MAC"
 
 msgid "MII monitoring frequency"
 msgstr "Fréquence MII"
@@ -3434,6 +3440,9 @@ msgstr "Ce champ doit avoir le format <hh:mm:ss>."
 
 msgid "This field should be a IP network address in CIDR notation."
 msgstr "Ce champ doit contenir une adresse IP en notation CIDR."
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
+msgstr ""
 
 msgid "This field should be a domain name or an IP address."
 msgstr "Ce champ doit contenir un nom de domaine ou une adresse IP."

--- a/deb/openmediavault/usr/share/openmediavault/locale/gl_ES/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/gl_ES/openmediavault.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Miguel Anxo Bouzada <mbouzada@gmail.com>, 2013,2015\n"
 "Language-Team: Galician (Spain) (http://app.transifex.com/openmediavault/openmediavault/language/gl_ES/)\n"
@@ -1291,6 +1291,9 @@ msgstr "Marcas"
 msgid "Force SSL/TLS"
 msgstr "Forzar SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "Forzar a só conexións seguras."
 
@@ -1817,6 +1820,9 @@ msgstr "Luxemburgo"
 
 msgid "MAC"
 msgstr ""
+
+msgid "MAC address"
+msgstr "Enderezo MAC"
 
 msgid "MII monitoring frequency"
 msgstr "Supervisión da frecuencia MII"
@@ -3422,6 +3428,9 @@ msgid "This field must have the format <hh:mm:ss>."
 msgstr ""
 
 msgid "This field should be a IP network address in CIDR notation."
+msgstr ""
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
 msgstr ""
 
 msgid "This field should be a domain name or an IP address."

--- a/deb/openmediavault/usr/share/openmediavault/locale/hu_HU/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/hu_HU/openmediavault.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Gyuris Gellért <jobel@ujevangelizacio.hu>, 2021-2023\n"
 "Language-Team: Hungarian (Hungary) (http://app.transifex.com/openmediavault/openmediavault/language/hu_HU/)\n"
@@ -1294,6 +1294,9 @@ msgstr "Zászlók"
 msgid "Force SSL/TLS"
 msgstr "SSL/TLS kényszerítés"
 
+msgid "Force a specific MAC address on this interface."
+msgstr "Egy bizonyos MAC-cím kényszerítése ezen az interfészen"
+
 msgid "Force secure connection only."
 msgstr "Csak biztonságos kapcsolat kényszerítése."
 
@@ -1820,6 +1823,9 @@ msgstr "Luxemburg"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "MAC cím"
 
 msgid "MII monitoring frequency"
 msgstr "MII ellenőrzési gyakoriság"
@@ -3426,6 +3432,9 @@ msgstr "E mezőnek <hh:mm:ss>formátumúnak kell lennie."
 
 msgid "This field should be a IP network address in CIDR notation."
 msgstr "E mezőnek egy IP hálózati címnek kell lennie CIDR jelölésben."
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
+msgstr "Ez a mező egy MAC-cím kell legyen, pl. 00:80:41:ae:fd:7e."
 
 msgid "This field should be a domain name or an IP address."
 msgstr "E mezőnek egy tartománynévnek vagy egy IP címnek kell lennie."

--- a/deb/openmediavault/usr/share/openmediavault/locale/it_IT/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/it_IT/openmediavault.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Paolo Velati <paolo.velati@gmail.com>, 2013-2019,2021\n"
 "Language-Team: Italian (http://app.transifex.com/openmediavault/openmediavault/language/it/)\n"
@@ -1293,6 +1293,9 @@ msgstr "Flag"
 msgid "Force SSL/TLS"
 msgstr "Forza SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "Forza solo connessioni sicure."
 
@@ -1819,6 +1822,9 @@ msgstr "Lussemburgo"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "MAC address"
 
 msgid "MII monitoring frequency"
 msgstr "Frequenza di monitoraggio MII"
@@ -3424,6 +3430,9 @@ msgid "This field must have the format <hh:mm:ss>."
 msgstr ""
 
 msgid "This field should be a IP network address in CIDR notation."
+msgstr ""
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
 msgstr ""
 
 msgid "This field should be a domain name or an IP address."

--- a/deb/openmediavault/usr/share/openmediavault/locale/ja_JP/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/ja_JP/openmediavault.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Toshihiro Kan <kansuke4649@gmail.com>, 2014-2023\n"
 "Language-Team: Japanese (Japan) (http://app.transifex.com/openmediavault/openmediavault/language/ja_JP/)\n"
@@ -1288,6 +1288,9 @@ msgstr "フラグ"
 msgid "Force SSL/TLS"
 msgstr "Force SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "セキュアコネクションを強制します。"
 
@@ -1814,6 +1817,9 @@ msgstr "ルクセンブルク"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "MACアドレス"
 
 msgid "MII monitoring frequency"
 msgstr "MII モニタリング頻度"
@@ -3420,6 +3426,9 @@ msgstr "このフィールドは <hh:mm:ss>のフォーマットで記述する�
 
 msgid "This field should be a IP network address in CIDR notation."
 msgstr "このフィールドは、CIDR記法によるIPネットワークアドレスである必要があります。"
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
+msgstr ""
 
 msgid "This field should be a domain name or an IP address."
 msgstr "このフィールドは、ドメイン名またはIPアドレスである必要があります。"

--- a/deb/openmediavault/usr/share/openmediavault/locale/ko_KR/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/ko_KR/openmediavault.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Ji-Hyeon Gim <potatogim@potatogim.net>, 2014-2015,2018,2020\n"
 "Language-Team: Korean (Korea) (http://app.transifex.com/openmediavault/openmediavault/language/ko_KR/)\n"
@@ -1291,6 +1291,9 @@ msgstr "플래그"
 msgid "Force SSL/TLS"
 msgstr "강제 SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "보안 연결 강제"
 
@@ -1817,6 +1820,9 @@ msgstr "룩셈부르크"
 
 msgid "MAC"
 msgstr ""
+
+msgid "MAC address"
+msgstr "MAC 주소"
 
 msgid "MII monitoring frequency"
 msgstr "MII 감시 주파수"
@@ -3422,6 +3428,9 @@ msgid "This field must have the format <hh:mm:ss>."
 msgstr ""
 
 msgid "This field should be a IP network address in CIDR notation."
+msgstr ""
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
 msgstr ""
 
 msgid "This field should be a domain name or an IP address."

--- a/deb/openmediavault/usr/share/openmediavault/locale/nl_NL/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/nl_NL/openmediavault.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Tim <co_ti@hotmail.com>, 2013-2014,2016-2017,2022\n"
 "Language-Team: Dutch (Netherlands) (http://app.transifex.com/openmediavault/openmediavault/language/nl_NL/)\n"
@@ -1294,6 +1294,9 @@ msgstr "Vlaggen"
 msgid "Force SSL/TLS"
 msgstr "Forceer SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "Alleen beveiligde verbindingen toestaan."
 
@@ -1820,6 +1823,9 @@ msgstr "Luxemburg"
 
 msgid "MAC"
 msgstr ""
+
+msgid "MAC address"
+msgstr "MAC-adres"
 
 msgid "MII monitoring frequency"
 msgstr "MII monitor frequentie"
@@ -3425,6 +3431,9 @@ msgid "This field must have the format <hh:mm:ss>."
 msgstr ""
 
 msgid "This field should be a IP network address in CIDR notation."
+msgstr ""
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
 msgstr ""
 
 msgid "This field should be a domain name or an IP address."

--- a/deb/openmediavault/usr/share/openmediavault/locale/no_NO/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/no_NO/openmediavault.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: runesudden <runesudden@gmail.com>, 2013\n"
 "Language-Team: Norwegian (http://app.transifex.com/openmediavault/openmediavault/language/no/)\n"
@@ -1289,6 +1289,9 @@ msgstr ""
 msgid "Force SSL/TLS"
 msgstr "Tving SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "Tving sikre tilkoblinger."
 
@@ -1815,6 +1818,9 @@ msgstr "Luxembourg"
 
 msgid "MAC"
 msgstr ""
+
+msgid "MAC address"
+msgstr "MAC adresse"
 
 msgid "MII monitoring frequency"
 msgstr "MII overvåkningsfrekvens"
@@ -3420,6 +3426,9 @@ msgid "This field must have the format <hh:mm:ss>."
 msgstr ""
 
 msgid "This field should be a IP network address in CIDR notation."
+msgstr ""
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
 msgstr ""
 
 msgid "This field should be a domain name or an IP address."

--- a/deb/openmediavault/usr/share/openmediavault/locale/openmediavault.pot
+++ b/deb/openmediavault/usr/share/openmediavault/locale/openmediavault.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1250,6 +1250,9 @@ msgstr ""
 msgid "Force SSL/TLS"
 msgstr ""
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr ""
 
@@ -1746,6 +1749,9 @@ msgid "Luxembourg"
 msgstr ""
 
 msgid "MAC"
+msgstr ""
+
+msgid "MAC address"
 msgstr ""
 
 msgid "MII monitoring frequency"
@@ -3252,6 +3258,9 @@ msgid "This field must have the format <hh:mm:ss>."
 msgstr ""
 
 msgid "This field should be a IP network address in CIDR notation."
+msgstr ""
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
 msgstr ""
 
 msgid "This field should be a domain name or an IP address."

--- a/deb/openmediavault/usr/share/openmediavault/locale/pl_PL/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/pl_PL/openmediavault.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: jacekniedziolka71 <lucas71@interia.pl>, 2017,2022\n"
 "Language-Team: Polish (Poland) (http://app.transifex.com/openmediavault/openmediavault/language/pl_PL/)\n"
@@ -1293,6 +1293,9 @@ msgstr "Flagi"
 msgid "Force SSL/TLS"
 msgstr "Wymuś SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "Wymuś bezpieczne połączenie."
 
@@ -1819,6 +1822,9 @@ msgstr "Luxembourg"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "Adres MAC"
 
 msgid "MII monitoring frequency"
 msgstr "Monitorowanie częstotliwości MII"
@@ -3425,6 +3431,9 @@ msgstr "To pole musi mieć format <hh:mm:ss>."
 
 msgid "This field should be a IP network address in CIDR notation."
 msgstr "To pole powinno powinno zawierać adres sieciowy IP w zapisie CIDR."
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
+msgstr ""
 
 msgid "This field should be a domain name or an IP address."
 msgstr "To pole powinno być nazwą domeny lub adresem IP."

--- a/deb/openmediavault/usr/share/openmediavault/locale/pt_PT/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/pt_PT/openmediavault.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Nelson Rosado <nelsontrosado@gmail.com>, 2012-2015,2017,2019\n"
 "Language-Team: Portuguese (Portugal) (http://app.transifex.com/openmediavault/openmediavault/language/pt_PT/)\n"
@@ -1289,6 +1289,9 @@ msgstr "Flags"
 msgid "Force SSL/TLS"
 msgstr "Forçar SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "Forçar ligações seguras apenas."
 
@@ -1815,6 +1818,9 @@ msgstr "Luxemburgo"
 
 msgid "MAC"
 msgstr ""
+
+msgid "MAC address"
+msgstr "Endereço MAC"
 
 msgid "MII monitoring frequency"
 msgstr "Frequência Monitorizada MII"
@@ -3420,6 +3426,9 @@ msgid "This field must have the format <hh:mm:ss>."
 msgstr ""
 
 msgid "This field should be a IP network address in CIDR notation."
+msgstr ""
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
 msgstr ""
 
 msgid "This field should be a domain name or an IP address."

--- a/deb/openmediavault/usr/share/openmediavault/locale/ru_RU/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/ru_RU/openmediavault.po
@@ -22,7 +22,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Никита Геннадьевич <ex-er-sis@ya.ru>, 2023\n"
 "Language-Team: Russian (Russia) (http://app.transifex.com/openmediavault/openmediavault/language/ru_RU/)\n"
@@ -1302,6 +1302,9 @@ msgstr "Флаг"
 msgid "Force SSL/TLS"
 msgstr "Принудительно SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "Принудительно только защищенное соединение"
 
@@ -1828,6 +1831,9 @@ msgstr "Люксембург"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "MAC адрес"
 
 msgid "MII monitoring frequency"
 msgstr "Частота мониторинга MII"
@@ -3434,6 +3440,9 @@ msgstr "Это поле должно соответствовать формат
 
 msgid "This field should be a IP network address in CIDR notation."
 msgstr "В этом поле должен быть IP-адрес сети в нотации CIDR."
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
+msgstr ""
 
 msgid "This field should be a domain name or an IP address."
 msgstr "В этом поле должно быть доменное имя или IP-адрес."

--- a/deb/openmediavault/usr/share/openmediavault/locale/sl_SI/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/sl_SI/openmediavault.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Miha Bezjak <miha@bezjak.info>, 2017\n"
 "Language-Team: Slovenian (Slovenia) (http://app.transifex.com/openmediavault/openmediavault/language/sl_SI/)\n"
@@ -1288,6 +1288,9 @@ msgstr "Zastavice"
 msgid "Force SSL/TLS"
 msgstr "Vsili SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "Vsili le varno povezavo"
 
@@ -1814,6 +1817,9 @@ msgstr "Luksemburg"
 
 msgid "MAC"
 msgstr ""
+
+msgid "MAC address"
+msgstr "MAC naslov"
 
 msgid "MII monitoring frequency"
 msgstr "Frekvenca MII monitoringa"
@@ -3419,6 +3425,9 @@ msgid "This field must have the format <hh:mm:ss>."
 msgstr ""
 
 msgid "This field should be a IP network address in CIDR notation."
+msgstr ""
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
 msgstr ""
 
 msgid "This field should be a domain name or an IP address."

--- a/deb/openmediavault/usr/share/openmediavault/locale/sv_SV/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/sv_SV/openmediavault.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Jonatan Nyberg, 2021-2023\n"
 "Language-Team: Swedish (http://app.transifex.com/openmediavault/openmediavault/language/sv/)\n"
@@ -1291,6 +1291,9 @@ msgstr "Flaggor"
 msgid "Force SSL/TLS"
 msgstr "Tvinga SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "Tvinga endast säker anslutning."
 
@@ -1817,6 +1820,9 @@ msgstr "Luxemburg"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "MAC-adress"
 
 msgid "MII monitoring frequency"
 msgstr "MII övervakningsfrekvens"
@@ -3423,6 +3429,9 @@ msgstr "Det här fältet måste ha formatet <hh:mm:ss>."
 
 msgid "This field should be a IP network address in CIDR notation."
 msgstr "Det här fältet ska vara en IP-nätverksadress i CIDR-notering."
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
+msgstr ""
 
 msgid "This field should be a domain name or an IP address."
 msgstr "Det här fältet ska vara ett domännamn eller en IP-adress."

--- a/deb/openmediavault/usr/share/openmediavault/locale/tr_TR/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/tr_TR/openmediavault.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Serhat SUT <serhat.sut@gmail.com>, 2012-2018,2020-2022\n"
 "Language-Team: Turkish (Turkey) (http://app.transifex.com/openmediavault/openmediavault/language/tr_TR/)\n"
@@ -1288,6 +1288,9 @@ msgstr "Flamalar"
 msgid "Force SSL/TLS"
 msgstr "SSL/TLS i zorunlu kıl"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "Sadece güvenli bağlatıyı zorunlu kıl"
 
@@ -1814,6 +1817,9 @@ msgstr "Lüksemburg"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "MAC adresi"
 
 msgid "MII monitoring frequency"
 msgstr "MII izleme sıklığı"
@@ -3419,6 +3425,9 @@ msgid "This field must have the format <hh:mm:ss>."
 msgstr ""
 
 msgid "This field should be a IP network address in CIDR notation."
+msgstr ""
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
 msgstr ""
 
 msgid "This field should be a domain name or an IP address."

--- a/deb/openmediavault/usr/share/openmediavault/locale/uk_UK/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/uk_UK/openmediavault.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: zubr139, 2013-2019,2021-2022\n"
 "Language-Team: Ukrainian (http://app.transifex.com/openmediavault/openmediavault/language/uk/)\n"
@@ -1290,6 +1290,9 @@ msgstr "Прапори"
 msgid "Force SSL/TLS"
 msgstr "Примусово SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "Тільки захищене з'єднання."
 
@@ -1816,6 +1819,9 @@ msgstr "Люксембург"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "MAC адреса"
 
 msgid "MII monitoring frequency"
 msgstr "MII моніторингу частоти"
@@ -3422,6 +3428,9 @@ msgstr "Це поле має мати формат <hh:mm:ss>."
 
 msgid "This field should be a IP network address in CIDR notation."
 msgstr "Це поле повинне містити адресу мережі IP в нотації CIDR."
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
+msgstr ""
 
 msgid "This field should be a domain name or an IP address."
 msgstr "Це поле повинно бути доменне ім'я або IP-адреса."

--- a/deb/openmediavault/usr/share/openmediavault/locale/zh_CN/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/zh_CN/openmediavault.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: songming <by@songming.me>, 2013-2023\n"
 "Language-Team: Chinese (China) (http://app.transifex.com/openmediavault/openmediavault/language/zh_CN/)\n"
@@ -1294,6 +1294,9 @@ msgstr "标签"
 msgid "Force SSL/TLS"
 msgstr "强制使用 SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "强制只允许使用安全连接。"
 
@@ -1820,6 +1823,9 @@ msgstr "卢森堡"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "MAC 位址"
 
 msgid "MII monitoring frequency"
 msgstr "MII 监测频率"
@@ -3426,6 +3432,9 @@ msgstr "此字段的格式必须为 <hh:mm:ss>"
 
 msgid "This field should be a IP network address in CIDR notation."
 msgstr "此处应该是 CIDR 格式的 IP 地址。"
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
+msgstr ""
 
 msgid "This field should be a domain name or an IP address."
 msgstr "此处应该是域名或者 IP 地址"

--- a/deb/openmediavault/usr/share/openmediavault/locale/zh_TW/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/zh_TW/openmediavault.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-25 22:05+0200\n"
+"POT-Creation-Date: 2023-07-13 16:26+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: kochin <kochinc@outlook.com>, 2013-2023\n"
 "Language-Team: Chinese (Taiwan) (http://app.transifex.com/openmediavault/openmediavault/language/zh_TW/)\n"
@@ -1290,6 +1290,9 @@ msgstr "旗標"
 msgid "Force SSL/TLS"
 msgstr "強制 SSL/TLS"
 
+msgid "Force a specific MAC address on this interface."
+msgstr ""
+
 msgid "Force secure connection only."
 msgstr "強制只能進行安全連線。"
 
@@ -1816,6 +1819,9 @@ msgstr "盧森堡"
 
 msgid "MAC"
 msgstr "MAC"
+
+msgid "MAC address"
+msgstr "MAC 位址"
 
 msgid "MII monitoring frequency"
 msgstr "MII 監測頻率"
@@ -3422,6 +3428,9 @@ msgstr "此欄位的格式必須為 <hh:mm:ss>。"
 
 msgid "This field should be a IP network address in CIDR notation."
 msgstr "此欄位應該是一個以 CIDR 表示法的 IP 網路位址。"
+
+msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
+msgstr ""
 
 msgid "This field should be a domain name or an IP address."
 msgstr "此欄位應該是一個網域名稱或 IP 位址。"

--- a/deb/openmediavault/usr/share/openmediavault/templates/config.xml
+++ b/deb/openmediavault/usr/share/openmediavault/templates/config.xml
@@ -155,6 +155,8 @@
 					<wol>0|1</wol>
 					<comment>xxx</comment>
 					# Optional arguments by type:
+					# - ethernet | wifi | vlan
+					<altmacaddress>|xx:xx:xx:xx:xx:xx</altmacaddress>
 					# - bond
 					<slaves>(((eth|venet|wlan)\d+|(en|veth|wl)\S+),)*((eth|venet|wlan)\d+|(en|veth|wl)\S+)</slaves>
 					<bondprimary>(eth|wlan)\d+</bondprimary>

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/models/form-field-config.type.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/models/form-field-config.type.ts
@@ -135,6 +135,7 @@ export type FormFieldConfig = {
       | 'groupName'
       | 'shareName'
       | 'email'
+      | 'macAddress'
       | 'ip'
       | 'ipv4'
       | 'ipv6'

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-ethernet-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-ethernet-form-page.component.ts
@@ -88,6 +88,16 @@ export class InterfaceEthernetFormPageComponent extends BaseFormPageComponent {
         }
       },
       {
+        type: 'textInput',
+        name: 'forcedmac',
+        label: gettext('Forced MAC Address'),
+        hint: gettext('Force a specific MAC Address on this interface.'),
+        value: '',
+        validators: {
+          patternType: 'macAddress'
+        }
+      },
+      {
         type: 'tagInput',
         name: 'comment',
         label: gettext('Tags'),

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-ethernet-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-ethernet-form-page.component.ts
@@ -88,16 +88,6 @@ export class InterfaceEthernetFormPageComponent extends BaseFormPageComponent {
         }
       },
       {
-        type: 'textInput',
-        name: 'forcedmac',
-        label: gettext('Forced MAC Address'),
-        hint: gettext('Force a specific MAC Address on this interface.'),
-        value: '',
-        validators: {
-          patternType: 'macAddress'
-        }
-      },
-      {
         type: 'tagInput',
         name: 'comment',
         label: gettext('Tags'),
@@ -289,6 +279,16 @@ export class InterfaceEthernetFormPageComponent extends BaseFormPageComponent {
       {
         type: 'divider',
         title: gettext('Advanced settings')
+      },
+      {
+        type: 'textInput',
+        name: 'altmacaddress',
+        label: gettext('MAC address'),
+        hint: gettext('Force a specific MAC address on this interface.'),
+        value: '',
+        validators: {
+          patternType: 'macAddress'
+        }
       },
       {
         type: 'textInput',

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-vlan-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-vlan-form-page.component.ts
@@ -110,16 +110,6 @@ export class InterfaceVlanFormPageComponent extends BaseFormPageComponent {
         disabled: '{{ _routeConfig.data.editing | toboolean }}'
       },
       {
-        type: 'textInput',
-        name: 'forcedmac',
-        label: gettext('Forced MAC Address'),
-        hint: gettext('Force a specific MAC Address on this interface.'),
-        value: '',
-        validators: {
-          patternType: 'macAddress'
-        }
-      },
-      {
         type: 'tagInput',
         name: 'comment',
         label: gettext('Tags'),
@@ -311,6 +301,16 @@ export class InterfaceVlanFormPageComponent extends BaseFormPageComponent {
       {
         type: 'divider',
         title: gettext('Advanced settings')
+      },
+      {
+        type: 'textInput',
+        name: 'altmacaddress',
+        label: gettext('MAC address'),
+        hint: gettext('Force a specific MAC address on this interface.'),
+        value: '',
+        validators: {
+          patternType: 'macAddress'
+        }
       },
       {
         type: 'textInput',

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-vlan-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-vlan-form-page.component.ts
@@ -110,6 +110,16 @@ export class InterfaceVlanFormPageComponent extends BaseFormPageComponent {
         disabled: '{{ _routeConfig.data.editing | toboolean }}'
       },
       {
+        type: 'textInput',
+        name: 'forcedmac',
+        label: gettext('Forced MAC Address'),
+        hint: gettext('Force a specific MAC Address on this interface.'),
+        value: '',
+        validators: {
+          patternType: 'macAddress'
+        }
+      },
+      {
         type: 'tagInput',
         name: 'comment',
         label: gettext('Tags'),

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-wifi-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-wifi-form-page.component.ts
@@ -114,6 +114,16 @@ export class InterfaceWifiFormPageComponent extends BaseFormPageComponent {
         value: false
       },
       {
+        type: 'textInput',
+        name: 'forcedmac',
+        label: gettext('Forced MAC Address'),
+        hint: gettext('Force a specific MAC Address on this interface.'),
+        value: '',
+        validators: {
+          patternType: 'macAddress'
+        }
+      },
+      {
         type: 'tagInput',
         name: 'comment',
         label: gettext('Tags'),

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-wifi-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-wifi-form-page.component.ts
@@ -114,16 +114,6 @@ export class InterfaceWifiFormPageComponent extends BaseFormPageComponent {
         value: false
       },
       {
-        type: 'textInput',
-        name: 'forcedmac',
-        label: gettext('Forced MAC Address'),
-        hint: gettext('Force a specific MAC Address on this interface.'),
-        value: '',
-        validators: {
-          patternType: 'macAddress'
-        }
-      },
-      {
         type: 'tagInput',
         name: 'comment',
         label: gettext('Tags'),
@@ -315,6 +305,16 @@ export class InterfaceWifiFormPageComponent extends BaseFormPageComponent {
       {
         type: 'divider',
         title: gettext('Advanced settings')
+      },
+      {
+        type: 'textInput',
+        name: 'altmacaddress',
+        label: gettext('MAC address'),
+        hint: gettext('Force a specific MAC address on this interface.'),
+        value: '',
+        validators: {
+          patternType: 'macAddress'
+        }
       },
       {
         type: 'textInput',

--- a/deb/openmediavault/workbench/src/app/shared/forms/custom-validators.spec.ts
+++ b/deb/openmediavault/workbench/src/app/shared/forms/custom-validators.spec.ts
@@ -139,6 +139,34 @@ describe('CustomValidators', () => {
       });
     });
 
+    describe('macAddress', () => {
+      let validator: ValidatorFn;
+
+      beforeEach(() => {
+        validator = CustomValidators.patternType('macAddress');
+      });
+
+      it('should validate Mac Address', () => {
+        formControl.setValue('01:23:45:ab:cd:ef');
+        expect(validator(formControl)).toBeNull();
+      });
+
+      it('should not validate Mac Address (1)', () => {
+        formControl.setValue('bar');
+        expect(validator(formControl)).toEqual({ pattern: 'This field should be a MAC Address.' });
+      });
+
+      it('should not validate Mac Address (2)', () => {
+        formControl.setValue('01:23:45:abc:d:ef');
+        expect(validator(formControl)).toEqual({ pattern: 'This field should be a MAC Address.' });
+      });
+
+      it('should not validate Mac Address (3)', () => {
+        formControl.setValue('01:23:45:ab:cd');
+        expect(validator(formControl)).toEqual({ pattern: 'This field should be a MAC Address.' });
+      });
+    });
+
     describe('ip', () => {
       let validator: ValidatorFn;
 

--- a/deb/openmediavault/workbench/src/app/shared/forms/custom-validators.spec.ts
+++ b/deb/openmediavault/workbench/src/app/shared/forms/custom-validators.spec.ts
@@ -146,24 +146,37 @@ describe('CustomValidators', () => {
         validator = CustomValidators.patternType('macAddress');
       });
 
-      it('should validate Mac Address', () => {
+      it('should validate MAC address', () => {
         formControl.setValue('01:23:45:ab:cd:ef');
         expect(validator(formControl)).toBeNull();
       });
 
-      it('should not validate Mac Address (1)', () => {
+      it('should not validate MAC address [1]', () => {
         formControl.setValue('bar');
-        expect(validator(formControl)).toEqual({ pattern: 'This field should be a MAC Address.' });
+        expect(validator(formControl)).toEqual({
+          pattern: 'This field should be a MAC address, e.g. 00:80:41:ae:fd:7e.'
+        });
       });
 
-      it('should not validate Mac Address (2)', () => {
+      it('should not validate MAC address [2]', () => {
         formControl.setValue('01:23:45:abc:d:ef');
-        expect(validator(formControl)).toEqual({ pattern: 'This field should be a MAC Address.' });
+        expect(validator(formControl)).toEqual({
+          pattern: 'This field should be a MAC address, e.g. 00:80:41:ae:fd:7e.'
+        });
       });
 
-      it('should not validate Mac Address (3)', () => {
+      it('should not validate MAC address [3]', () => {
         formControl.setValue('01:23:45:ab:cd');
-        expect(validator(formControl)).toEqual({ pattern: 'This field should be a MAC Address.' });
+        expect(validator(formControl)).toEqual({
+          pattern: 'This field should be a MAC address, e.g. 00:80:41:ae:fd:7e.'
+        });
+      });
+
+      it('should not validate MAC address [4]', () => {
+        formControl.setValue('00-80-41-ae-fd-7e');
+        expect(validator(formControl)).toEqual({
+          pattern: 'This field should be a MAC address, e.g. 00:80:41:ae:fd:7e.'
+        });
       });
     });
 

--- a/deb/openmediavault/workbench/src/app/shared/forms/custom-validators.ts
+++ b/deb/openmediavault/workbench/src/app/shared/forms/custom-validators.ts
@@ -268,6 +268,14 @@ export class CustomValidators {
           (value) => validator.isEmail(value),
           gettext('This field should be an email address.')
         );
+      case 'macAddress':
+        return CustomValidators.pattern(
+          // .isMACAddress doesn't accept ":", so we can remove them for the check
+          // systemd *does* accept ":", so we don't have to edit the value in the config
+          // see https://manpages.debian.org/buster/systemd/systemd.network.5.en.html#%5BMATCH%5D_SECTION_OPTIONS
+          (value) => validator.isMACAddress(value.replace(":","-")),
+          gettext('This field should be an MAC address.')
+        );
       case 'ipv4':
         return CustomValidators.pattern(
           (value) => validator.isIP(value, 4),

--- a/deb/openmediavault/workbench/src/app/shared/forms/custom-validators.ts
+++ b/deb/openmediavault/workbench/src/app/shared/forms/custom-validators.ts
@@ -68,7 +68,8 @@ const regExp = {
     /^(128|192|224|24[08]|25[245].0.0.0)|(255.(0|128|192|224|24[08]|25[245]).0.0)|(255.255.(0|128|192|224|24[08]|25[245]).0)|(255.255.255.(0|128|192|224|24[08]|252))$/,
   // See https://www.w3schools.com/Jsref/jsref_regexp_wordchar.asp
   wordChars: /^[\w]+$/,
-  binaryUnit: /^\d+(.\d+)?\s?(b|[kmgtpezy]ib)$/i
+  binaryUnit: /^\d+(.\d+)?\s?(b|[kmgtpezy]ib)$/i,
+  macAddress: /^[a-fA-F0-9]{2}(:[a-fA-F0-9]{2}){5}$/
 };
 
 const isEmptyInputValue = (value: any): boolean => _.isNull(value) || value.length === 0;
@@ -270,11 +271,8 @@ export class CustomValidators {
         );
       case 'macAddress':
         return CustomValidators.pattern(
-          // .isMACAddress doesn't accept ":", so we can remove them for the check
-          // systemd *does* accept ":", so we don't have to edit the value in the config
-          // see https://manpages.debian.org/buster/systemd/systemd.network.5.en.html#%5BMATCH%5D_SECTION_OPTIONS
-          (value) => validator.isMACAddress(value.replace(":","-")),
-          gettext('This field should be an MAC address.')
+          regExp.macAddress,
+          gettext('This field should be a MAC address, e.g. 00:80:41:ae:fd:7e.')
         );
       case 'ipv4':
         return CustomValidators.pattern(


### PR DESCRIPTION
Support forced/custom Mac Addresses from the network interfaces tab

This PR adds support for custom/forced MAC addresses on Ethernet, VLAN, & Wifi interface types. It is implemented similar to the DNS fields, if the field is blank on the webpage, no custom value is input into the `{{ 20 | 30 | 50 }}-openmediavault-{{ interface.devicename }}.yaml` file that gets generated for the network configuration.

Fixes: #1564