### PR TITLE
Add ability to specify the supported NFS protocol versions

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,5 +1,6 @@
 openmediavault (6.5.0-1) stable; urgency=low
 
+  * Add ability to specify the supported NFS protocol versions.
   * Improve Debian security repository cleanup.
   * Issue #1564: Add alternative MAC address support for wired,
     wireless and VLAN network interfaces.

--- a/deb/openmediavault/srv/salt/omv/deploy/nfs/files/etc-default-nfs-common.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/nfs/files/etc-default-nfs-common.j2
@@ -1,0 +1,19 @@
+{%- set rpc_statd_opts = salt['pillar.get']('default:OMV_NFSD_STATDOPTS', '') -%}
+{%- set need_gssd = salt['pillar.get']('default:OMV_NFSD_NEEDGSSD', '') -%}
+{%- set nfs_versions = config.versions.split(',') -%}
+{{ pillar['headers']['multiline'] }}
+# Do you want to start the statd daemon? It is not needed for NFSv4.
+NEED_STATD="{{ (['2', '3'] | intersect(config.versions) | length > 0) | yesno }}"
+
+# Options for rpc.statd.
+#   Should rpc.statd listen on a specific port? This is especially useful
+#   when you have a port-based firewall. To use a fixed port, set this
+#   this variable to a statd argument like: "--port 4000 --outgoing-port 4001".
+#   For more information, see rpc.statd(8) or http://wiki.debian.org/SecuringNFS
+STATDOPTS="{{ rpc_statd_opts }}"
+
+# Do you want to start the idmapd daemon? It is only needed for NFSv4.
+NEED_IDMAPD="{{ (['4', '4.1', '4.2'] | intersect(config.versions) | length > 0) | yesno }}"
+
+# Do you want to start the gssd daemon? It is required for Kerberos mounts.
+NEED_GSSD={% if need_gssd | length > 0  %}"{{ need_gssd }}"{% endif %}

--- a/deb/openmediavault/srv/salt/omv/deploy/nfs/files/etc-default-nfs-kernel-server.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/nfs/files/etc-default-nfs-kernel-server.j2
@@ -4,17 +4,26 @@
 {%- set rpc_mountd_opts = salt['pillar.get']('default:OMV_NFSD_MOUNTDOPTS', '--manage-gids') -%}
 {%- set need_svcgssd = salt['pillar.get']('default:OMV_NFSD_NEEDSVCGSSD', '') -%}
 {%- set rpc_svcgssd_opts = salt['pillar.get']('default:OMV_NFSD_SVCGSSDOPTS', '') -%}
+{%- set rpc_nfsd_versions = config.versions.split(',') -%}
+{%- set no_rpc_nfsd_versions = ['2', '3', '4', '4.1', '4.2'] | difference(rpc_nfsd_versions) -%}
+{%- set rpc_mountd_versions = config.versions.split(',') | map('int') | unique -%}
+{%- set no_rpc_mountd_versions = [2, 3, 4] | difference(rpc_mountd_versions) -%}
 {{ pillar['headers']['multiline'] }}
 # Number of servers to start up
 RPCNFSDCOUNT="{{ rpc_nfsd_count }}"
+
 # Runtime priority of server (see nice(1))
 RPCNFSDPRIORITY="{{ rpc_nfsd_priority }}"
+
 # Options for rpc.nfsd.
-RPCNFSDOPTS="{{ rpc_nfsd_opts }}"
+RPCNFSDOPTS="{% for version in no_rpc_nfsd_versions %}--no-nfs-version {{ version }} {% endfor %}{% for version in rpc_nfsd_versions %}--nfs-version {{ version }} {% endfor %}{{ rpc_nfsd_opts }}"
+
 # Options for rpc.mountd.
-RPCMOUNTDOPTS="{{ rpc_mountd_opts }}"
+RPCMOUNTDOPTS="{% for version in no_rpc_mountd_versions %}--no-nfs-version {{ version }} {% endfor %}{% for version in rpc_mountd_versions %}--nfs-version {{ version }} {% endfor %}{{ rpc_mountd_opts }}"
+
 # Do you want to start the svcgssd daemon? It is only required for Kerberos
 # exports.
-NEED_SVCGSSD="{{ need_svcgssd }}"
+NEED_SVCGSSD={% if need_svcgssd | length > 0  %}"{{ need_svcgssd }}"{% endif %}
+
 # Options for rpc.svcgssd.
 RPCSVCGSSDOPTS="{{ rpc_svcgssd_opts }}"

--- a/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_6.5.0.sh
+++ b/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_6.5.0.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env dash
+#
 # This file is part of OpenMediaVault.
 #
 # @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
@@ -17,8 +19,13 @@
 # You should have received a copy of the GNU General Public License
 # along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
 
-# Make sure custom Jinja filters are registered.
-{% set _ = salt['omv_utils.register_jinja_filters']() %}
+set -e
 
-include:
-  - .{{ salt['pillar.get']('deploy_nfs', 'default') }}
+. /usr/share/openmediavault/scripts/helper-functions
+
+# Convert the enabled NFS versions into a comma separated list.
+# E.g: +2 -3 +4 -4.1 -4.2 => 2,4
+versions=$(cat /proc/fs/nfsd/versions | sed -E 's/-([[:digit:]](.[[:digit:]])?)//g' | tr -d '+' | sed -e 's/[[:space:]]*$//' | tr -s ' ' ',')
+omv_config_add_key "/config/services/nfs" "versions" "${versions}"
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.nfs.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.nfs.json
@@ -11,6 +11,10 @@
 			"type": "boolean",
 			"default": false
 		},
+		"versions": {
+			"type": "string",
+			"default": "3,4,4.1,4.2"
+		},
 		"shares": {
 			"type": "object",
 			"properties": {

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.nfs.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.nfs.json
@@ -7,6 +7,20 @@
 			"enable": {
 				"type": "boolean",
 				"required": true
+			},
+			"versions": {
+				"type": "array",
+				"items": {
+					"type": "string",
+					"enum": [
+						"2",
+						"3",
+						"4",
+						"4.1",
+						"4.2"
+					]
+				},
+				"required": true
 			}
 		}
 	}

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/nfs.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/nfs.inc
@@ -55,7 +55,9 @@ class Nfs extends \OMV\Rpc\ServiceAbstract {
 		// Get the configuration object.
 		$db = \OMV\Config\Database::getInstance();
 		$object = $db->get("conf.service.nfs");
-		return $object->getAssoc();
+		$result = $object->getAssoc();
+		$result["versions"] = explode_safe(",", $result["versions"]);
+		return $result;
 	}
 
 	/**
@@ -71,6 +73,8 @@ class Nfs extends \OMV\Rpc\ServiceAbstract {
 		]);
 		// Validate the parameters of the RPC service method.
 		$this->validateMethodParams($params, "rpc.nfs.setsettings");
+		// Modify 'versions' property.
+		$params["versions"] = implode(",", $params["versions"]);
 		// Get the existing configuration object.
 		$db = \OMV\Config\Database::getInstance();
 		$object = $db->get("conf.service.nfs");

--- a/deb/openmediavault/usr/share/openmediavault/locale/ar_SA/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/ar_SA/openmediavault.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: omv nas <myomv100@gmail.com>, 2020-2023\n"
 "Language-Team: Arabic (Saudi Arabia) (http://app.transifex.com/openmediavault/openmediavault/language/ar_SA/)\n"
@@ -3203,6 +3203,9 @@ msgstr "اختبار"
 msgid "Thailand"
 msgstr "تايلاند"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "حقل وصف NT."
 
@@ -3950,6 +3953,9 @@ msgstr "فنزويلا"
 
 msgid "Version"
 msgstr "الإصدار"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "فيتنام"

--- a/deb/openmediavault/usr/share/openmediavault/locale/bg_BG/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/bg_BG/openmediavault.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Plamen Vasilev <p.vasileff@gmail.com>, 2017\n"
 "Language-Team: Bulgarian (Bulgaria) (http://app.transifex.com/openmediavault/openmediavault/language/bg_BG/)\n"
@@ -3202,6 +3202,9 @@ msgstr ""
 msgid "Thailand"
 msgstr ""
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr ""
 
@@ -3949,6 +3952,9 @@ msgstr ""
 
 msgid "Version"
 msgstr "Версия"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr ""

--- a/deb/openmediavault/usr/share/openmediavault/locale/ca_ES/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/ca_ES/openmediavault.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Quim Farriol <qfarriol@valette.cat>, 2020-2022\n"
 "Language-Team: Catalan (Spain) (http://app.transifex.com/openmediavault/openmediavault/language/ca_ES/)\n"
@@ -3204,6 +3204,9 @@ msgstr "Prova "
 msgid "Thailand"
 msgstr "Tailàndia"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "El camp NT de descripció"
 
@@ -3951,6 +3954,9 @@ msgstr "Veneçuela"
 
 msgid "Version"
 msgstr "Versió"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/locale/cs_CZ/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/cs_CZ/openmediavault.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>, 2014-2021\n"
 "Language-Team: Czech (Czech Republic) (http://app.transifex.com/openmediavault/openmediavault/language/cs_CZ/)\n"
@@ -3203,6 +3203,9 @@ msgstr "Vyzkoušet"
 msgid "Thailand"
 msgstr "Thajsko"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "Kolonka NT popisu."
 
@@ -3950,6 +3953,9 @@ msgstr "Venezuela"
 
 msgid "Version"
 msgstr " Verze"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/locale/da_DA/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/da_DA/openmediavault.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Stefan Thrane Overby <stoverby@gmail.com>, 2012-2018,2020-2022\n"
 "Language-Team: Danish (http://app.transifex.com/openmediavault/openmediavault/language/da/)\n"
@@ -3202,6 +3202,9 @@ msgstr "Test"
 msgid "Thailand"
 msgstr "Thailand"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "NT beskrivelses felt."
 
@@ -3949,6 +3952,9 @@ msgstr "Venezuela"
 
 msgid "Version"
 msgstr "Version"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/locale/de_DE/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/de_DE/openmediavault.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Volker Theile <votdev@gmx.de>, 2021-2023\n"
 "Language-Team: German (http://app.transifex.com/openmediavault/openmediavault/language/de/)\n"
@@ -3214,6 +3214,9 @@ msgstr "Test"
 msgid "Thailand"
 msgstr "Thailand"
 
+msgid "The NFS versions provided by the service."
+msgstr "Die vom Dienst bereitgestellten NFS-Versionen."
+
 msgid "The NT description field."
 msgstr "Feld für Beschreibung nach Windows NT."
 
@@ -3961,6 +3964,9 @@ msgstr "Venezuela"
 
 msgid "Version"
 msgstr "Version"
+
+msgid "Versions"
+msgstr "Versionen"
 
 msgid "Vietnam"
 msgstr "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/locale/el_GR/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/el_GR/openmediavault.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Kostas Moho, 2012-2023\n"
 "Language-Team: Greek (Greece) (http://app.transifex.com/openmediavault/openmediavault/language/el_GR/)\n"
@@ -1289,7 +1289,7 @@ msgid "Force SSL/TLS"
 msgstr "Επιβολή SSL/TLS"
 
 msgid "Force a specific MAC address on this interface."
-msgstr ""
+msgstr "Επιβολή συγκεκριμένης διεύθυνσης MAC σε αυτήν την διεπαφή."
 
 msgid "Force secure connection only."
 msgstr "Να απαιτείται μόνο ασφαλής σύνδεση."
@@ -3202,6 +3202,9 @@ msgstr "Δοκιμή"
 msgid "Thailand"
 msgstr "Thailand"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "Το πεδίο περιγραφής ΝΤ."
 
@@ -3428,7 +3431,7 @@ msgid "This field should be a IP network address in CIDR notation."
 msgstr "Αυτό το πεδίο δέχεται διεύθυνση ΙΡ σε μορφή CIDR."
 
 msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
-msgstr ""
+msgstr "Αυτό το πεδίο δέχεται διεύθυνση MAC , π.χ. 00:80:41:ae:fd:7e."
 
 msgid "This field should be a domain name or an IP address."
 msgstr "Αυτό το πεδίο δέχεται όνομα τομέα ή διεύθυνση ΙΡ."
@@ -3949,6 +3952,9 @@ msgstr "Venezuela"
 
 msgid "Version"
 msgstr "Έκδοση"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/locale/es_ES/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/es_ES/openmediavault.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Raul Fernandez Garcia <raulfg3@gmail.com>, 2012-2023\n"
 "Language-Team: Spanish (Spain) (http://app.transifex.com/openmediavault/openmediavault/language/es_ES/)\n"
@@ -1292,7 +1292,7 @@ msgid "Force SSL/TLS"
 msgstr "Forzar SSL/TLS"
 
 msgid "Force a specific MAC address on this interface."
-msgstr ""
+msgstr "Forzar una MAC especifica para esta interfaz."
 
 msgid "Force secure connection only."
 msgstr "Forzar conexión segura"
@@ -3205,6 +3205,9 @@ msgstr "Test"
 msgid "Thailand"
 msgstr "Tailandia"
 
+msgid "The NFS versions provided by the service."
+msgstr "Versión NFS proporcionada por el sistema."
+
 msgid "The NT description field."
 msgstr "El campo NT de descripción"
 
@@ -3431,7 +3434,7 @@ msgid "This field should be a IP network address in CIDR notation."
 msgstr "Este campo debe ser una dirección de red IP en notación CIDR."
 
 msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
-msgstr ""
+msgstr "Este campo debe ser una dirección MAC, Ej. 00:80:41:ae:fd:7e."
 
 msgid "This field should be a domain name or an IP address."
 msgstr "Este campo debe ser un nombre de dominio o una dirección IP."
@@ -3952,6 +3955,9 @@ msgstr "Venezuela"
 
 msgid "Version"
 msgstr "Versión"
+
+msgid "Versions"
+msgstr "Versiones"
 
 msgid "Vietnam"
 msgstr "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/locale/fr_FR/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/fr_FR/openmediavault.po
@@ -22,7 +22,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: M@T D., 2022-2023\n"
 "Language-Team: French (France) (http://app.transifex.com/openmediavault/openmediavault/language/fr_FR/)\n"
@@ -3216,6 +3216,9 @@ msgstr "Test"
 msgid "Thailand"
 msgstr "Thaïlande"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "Le champ de description NT."
 
@@ -3963,6 +3966,9 @@ msgstr "Venezuela"
 
 msgid "Version"
 msgstr "Version"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/locale/gl_ES/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/gl_ES/openmediavault.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Miguel Anxo Bouzada <mbouzada@gmail.com>, 2013,2015\n"
 "Language-Team: Galician (Spain) (http://app.transifex.com/openmediavault/openmediavault/language/gl_ES/)\n"
@@ -3205,6 +3205,9 @@ msgstr ""
 msgid "Thailand"
 msgstr "Tailandia"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "O campo de descrición NT"
 
@@ -3952,6 +3955,9 @@ msgstr "Venezuela"
 
 msgid "Version"
 msgstr "Versión"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/locale/hu_HU/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/hu_HU/openmediavault.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Gyuris Gellért <jobel@ujevangelizacio.hu>, 2021-2023\n"
 "Language-Team: Hungarian (Hungary) (http://app.transifex.com/openmediavault/openmediavault/language/hu_HU/)\n"
@@ -3208,6 +3208,9 @@ msgstr "Teszt"
 msgid "Thailand"
 msgstr "Thaiföld"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "NT leírás mező."
 
@@ -3955,6 +3958,9 @@ msgstr "Venezuela"
 
 msgid "Version"
 msgstr "Verzió"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "Vietnám"

--- a/deb/openmediavault/usr/share/openmediavault/locale/it_IT/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/it_IT/openmediavault.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Paolo Velati <paolo.velati@gmail.com>, 2013-2019,2021\n"
 "Language-Team: Italian (http://app.transifex.com/openmediavault/openmediavault/language/it/)\n"
@@ -3207,6 +3207,9 @@ msgstr ""
 msgid "Thailand"
 msgstr "Tailandia"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "Il campo descrizione di NT."
 
@@ -3954,6 +3957,9 @@ msgstr "Venezuela"
 
 msgid "Version"
 msgstr "Versione"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/locale/ja_JP/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/ja_JP/openmediavault.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Toshihiro Kan <kansuke4649@gmail.com>, 2014-2023\n"
 "Language-Team: Japanese (Japan) (http://app.transifex.com/openmediavault/openmediavault/language/ja_JP/)\n"
@@ -3202,6 +3202,9 @@ msgstr "テスト"
 msgid "Thailand"
 msgstr "タイ"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "NTの説明フィールド。"
 
@@ -3949,6 +3952,9 @@ msgstr "ベネズエラ"
 
 msgid "Version"
 msgstr "バージョン"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "ベトナム"

--- a/deb/openmediavault/usr/share/openmediavault/locale/ko_KR/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/ko_KR/openmediavault.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Ji-Hyeon Gim <potatogim@potatogim.net>, 2014-2015,2018,2020\n"
 "Language-Team: Korean (Korea) (http://app.transifex.com/openmediavault/openmediavault/language/ko_KR/)\n"
@@ -3205,6 +3205,9 @@ msgstr ""
 msgid "Thailand"
 msgstr "태국"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "NT 설명 항목"
 
@@ -3952,6 +3955,9 @@ msgstr "베네수엘라"
 
 msgid "Version"
 msgstr "버전"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "베트남"

--- a/deb/openmediavault/usr/share/openmediavault/locale/nl_NL/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/nl_NL/openmediavault.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Tim <co_ti@hotmail.com>, 2013-2014,2016-2017,2022\n"
 "Language-Team: Dutch (Netherlands) (http://app.transifex.com/openmediavault/openmediavault/language/nl_NL/)\n"
@@ -3208,6 +3208,9 @@ msgstr ""
 msgid "Thailand"
 msgstr "Thailand"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "Het veld met NT beschrijving."
 
@@ -3955,6 +3958,9 @@ msgstr "Venezuela"
 
 msgid "Version"
 msgstr "Versie"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/locale/no_NO/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/no_NO/openmediavault.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: runesudden <runesudden@gmail.com>, 2013\n"
 "Language-Team: Norwegian (http://app.transifex.com/openmediavault/openmediavault/language/no/)\n"
@@ -3203,6 +3203,9 @@ msgstr ""
 msgid "Thailand"
 msgstr "Tailand"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "NT beskrivelsesfelt"
 
@@ -3950,6 +3953,9 @@ msgstr "Venezuela"
 
 msgid "Version"
 msgstr "Versjon"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/locale/openmediavault.pot
+++ b/deb/openmediavault/usr/share/openmediavault/locale/openmediavault.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3080,6 +3080,9 @@ msgstr ""
 msgid "Thailand"
 msgstr ""
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr ""
 
@@ -3732,6 +3735,9 @@ msgid "Venezuela"
 msgstr ""
 
 msgid "Version"
+msgstr ""
+
+msgid "Versions"
 msgstr ""
 
 msgid "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/locale/pl_PL/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/pl_PL/openmediavault.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: jacekniedziolka71 <lucas71@interia.pl>, 2017,2022\n"
 "Language-Team: Polish (Poland) (http://app.transifex.com/openmediavault/openmediavault/language/pl_PL/)\n"
@@ -3207,6 +3207,9 @@ msgstr "Test"
 msgid "Thailand"
 msgstr "Thailand"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "Pole opisu NT."
 
@@ -3954,6 +3957,9 @@ msgstr "Venezuela"
 
 msgid "Version"
 msgstr "Wersja"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/locale/pt_PT/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/pt_PT/openmediavault.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Nelson Rosado <nelsontrosado@gmail.com>, 2012-2015,2017,2019\n"
 "Language-Team: Portuguese (Portugal) (http://app.transifex.com/openmediavault/openmediavault/language/pt_PT/)\n"
@@ -3203,6 +3203,9 @@ msgstr ""
 msgid "Thailand"
 msgstr "Tailândia"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "O campo de descrição NT."
 
@@ -3950,6 +3953,9 @@ msgstr "Venezuela"
 
 msgid "Version"
 msgstr "Versão"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "Vietname"

--- a/deb/openmediavault/usr/share/openmediavault/locale/ru_RU/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/ru_RU/openmediavault.po
@@ -22,7 +22,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Никита Геннадьевич <ex-er-sis@ya.ru>, 2023\n"
 "Language-Team: Russian (Russia) (http://app.transifex.com/openmediavault/openmediavault/language/ru_RU/)\n"
@@ -3216,6 +3216,9 @@ msgstr "Тест"
 msgid "Thailand"
 msgstr "Тайланд"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "Поле описания NT."
 
@@ -3963,6 +3966,9 @@ msgstr "Венесуэла"
 
 msgid "Version"
 msgstr "Версия"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "Вьетнам"

--- a/deb/openmediavault/usr/share/openmediavault/locale/sl_SI/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/sl_SI/openmediavault.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Miha Bezjak <miha@bezjak.info>, 2017\n"
 "Language-Team: Slovenian (Slovenia) (http://app.transifex.com/openmediavault/openmediavault/language/sl_SI/)\n"
@@ -3202,6 +3202,9 @@ msgstr ""
 msgid "Thailand"
 msgstr "Tajska"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr ""
 
@@ -3949,6 +3952,9 @@ msgstr "Venezuela"
 
 msgid "Version"
 msgstr "Različica"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/locale/sv_SV/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/sv_SV/openmediavault.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Jonatan Nyberg, 2021-2023\n"
 "Language-Team: Swedish (http://app.transifex.com/openmediavault/openmediavault/language/sv/)\n"
@@ -3205,6 +3205,9 @@ msgstr "Testa"
 msgid "Thailand"
 msgstr "Thailand"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "NT-beskrivningsfältet."
 
@@ -3952,6 +3955,9 @@ msgstr "Venezuela"
 
 msgid "Version"
 msgstr "Version"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/locale/tr_TR/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/tr_TR/openmediavault.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: Serhat SUT <serhat.sut@gmail.com>, 2012-2018,2020-2022\n"
 "Language-Team: Turkish (Turkey) (http://app.transifex.com/openmediavault/openmediavault/language/tr_TR/)\n"
@@ -3202,6 +3202,9 @@ msgstr "Test"
 msgid "Thailand"
 msgstr "Tayland"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "NT tanımlama alanı."
 
@@ -3949,6 +3952,9 @@ msgstr "Venezuella"
 
 msgid "Version"
 msgstr "Sürüm"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/locale/uk_UK/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/uk_UK/openmediavault.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: zubr139, 2013-2019,2021-2022\n"
 "Language-Team: Ukrainian (http://app.transifex.com/openmediavault/openmediavault/language/uk/)\n"
@@ -3204,6 +3204,9 @@ msgstr "Тест"
 msgid "Thailand"
 msgstr "Таїланд"
 
+msgid "The NFS versions provided by the service."
+msgstr ""
+
 msgid "The NT description field."
 msgstr "Опис поля NT."
 
@@ -3951,6 +3954,9 @@ msgstr "Венесуела"
 
 msgid "Version"
 msgstr "Версія"
+
+msgid "Versions"
+msgstr ""
 
 msgid "Vietnam"
 msgstr "В'єтнам"

--- a/deb/openmediavault/usr/share/openmediavault/locale/zh_CN/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/zh_CN/openmediavault.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: songming <by@songming.me>, 2013-2023\n"
 "Language-Team: Chinese (China) (http://app.transifex.com/openmediavault/openmediavault/language/zh_CN/)\n"
@@ -1295,7 +1295,7 @@ msgid "Force SSL/TLS"
 msgstr "强制使用 SSL/TLS"
 
 msgid "Force a specific MAC address on this interface."
-msgstr ""
+msgstr "強迫把一個特定的 MAC 地址用於此介面。"
 
 msgid "Force secure connection only."
 msgstr "强制只允许使用安全连接。"
@@ -3208,6 +3208,9 @@ msgstr "测试"
 msgid "Thailand"
 msgstr "泰国"
 
+msgid "The NFS versions provided by the service."
+msgstr "該服務所提供的 NFS 版本。"
+
 msgid "The NT description field."
 msgstr "NT 描述字段。"
 
@@ -3434,7 +3437,7 @@ msgid "This field should be a IP network address in CIDR notation."
 msgstr "此处应该是 CIDR 格式的 IP 地址。"
 
 msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
-msgstr ""
+msgstr "此欄位必須是一個 MAC 地址，例如：00:80:41:ae:fd:7e。"
 
 msgid "This field should be a domain name or an IP address."
 msgstr "此处应该是域名或者 IP 地址"
@@ -3954,6 +3957,9 @@ msgid "Venezuela"
 msgstr "委内瑞拉"
 
 msgid "Version"
+msgstr "版本"
+
+msgid "Versions"
 msgstr "版本"
 
 msgid "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/locale/zh_TW/openmediavault.po
+++ b/deb/openmediavault/usr/share/openmediavault/locale/zh_TW/openmediavault.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-13 16:26+0200\n"
+"POT-Creation-Date: 2023-07-16 18:28+0200\n"
 "PO-Revision-Date: 2012-03-17 01:48+0000\n"
 "Last-Translator: kochin <kochinc@outlook.com>, 2013-2023\n"
 "Language-Team: Chinese (Taiwan) (http://app.transifex.com/openmediavault/openmediavault/language/zh_TW/)\n"
@@ -702,7 +702,7 @@ msgid "Comoros"
 msgstr "科摩羅"
 
 msgid "Completion status"
-msgstr "完成狀態"
+msgstr "完成狀況"
 
 msgid "Compress"
 msgstr "壓縮"
@@ -1291,7 +1291,7 @@ msgid "Force SSL/TLS"
 msgstr "強制 SSL/TLS"
 
 msgid "Force a specific MAC address on this interface."
-msgstr ""
+msgstr "強迫把一個特定的 MAC 地址用於此介面。"
 
 msgid "Force secure connection only."
 msgstr "強制只能進行安全連線。"
@@ -3046,7 +3046,7 @@ msgstr "指定系統是否定期收集效能統計資料。"
 msgid ""
 "Specifies whether to monitor the system status and select the most "
 "appropriate CPU level."
-msgstr "指定是否監測系統狀態，並選擇最合適的 CPU 層級。"
+msgstr "指定是否監測系統狀況，並選擇最合適的 CPU 層級。"
 
 msgid "Specifies which slave is the primary device."
 msgstr "指定哪個隸屬介面是主要的裝置。"
@@ -3082,7 +3082,7 @@ msgid "Statistics collection and monitoring daemon."
 msgstr "统计信息收集和监视守护程序。"
 
 msgid "Status"
-msgstr "狀態"
+msgstr "狀況"
 
 msgid "Stop"
 msgstr "停止"
@@ -3203,6 +3203,9 @@ msgstr "測試"
 
 msgid "Thailand"
 msgstr "泰國"
+
+msgid "The NFS versions provided by the service."
+msgstr "該服務所提供的 NFS 版本。"
 
 msgid "The NT description field."
 msgstr "NT 的敘述欄位。"
@@ -3430,7 +3433,7 @@ msgid "This field should be a IP network address in CIDR notation."
 msgstr "此欄位應該是一個以 CIDR 表示法的 IP 網路位址。"
 
 msgid "This field should be a MAC address, e.g. 00:80:41:ae:fd:7e."
-msgstr ""
+msgstr "此欄位必須是一個 MAC 地址，例如：00:80:41:ae:fd:7e。"
 
 msgid "This field should be a domain name or an IP address."
 msgstr "此欄位應該是一個網域名稱或 IP 位址。"
@@ -3950,6 +3953,9 @@ msgid "Venezuela"
 msgstr "委內瑞拉"
 
 msgid "Version"
+msgstr "版本"
+
+msgid "Versions"
 msgstr "版本"
 
 msgid "Vietnam"

--- a/deb/openmediavault/usr/share/openmediavault/templates/config.xml
+++ b/deb/openmediavault/usr/share/openmediavault/templates/config.xml
@@ -392,6 +392,7 @@
 		</ssh>
 		<nfs>
 			<enable>0</enable>
+			<versions>3,4,4.1,4.2</versions>
 			<shares>
 				<!--
 				<share>

--- a/deb/openmediavault/workbench/src/app/pages/services/nfs/nfs-settings-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/nfs/nfs-settings-form-page.component.ts
@@ -41,6 +41,26 @@ export class NfsSettingsFormPageComponent extends BaseFormPageComponent {
         name: 'enable',
         label: gettext('Enabled'),
         value: false
+      },
+      {
+        type: 'select',
+        name: 'versions',
+        label: gettext('Versions'),
+        hint: gettext('The NFS versions provided by the service.'),
+        value: [],
+        multiple: true,
+        validators: {
+          required: true
+        },
+        store: {
+          data: [
+            ['2', 'NFSv2'],
+            ['3', 'NFSv3'],
+            ['4', 'NFSv4'],
+            ['4.1', 'NFSv4.1'],
+            ['4.2', 'NFSv4.2']
+          ]
+        }
       }
     ],
     buttons: [


### PR DESCRIPTION
References:
- https://manpages.debian.org/bullseye/nfs-kernel-server/nfsd.8.en.html
- https://manpages.debian.org/bullseye/nfs-kernel-server/rpc.mountd.8.en.html
- https://wiki.debian.org/NFSServerSetup
- https://www.willhaley.com/blog/ubuntu-nfs-server


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
