### PR TITLE
Issue #1569: Shared folder references are not correctly queried

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,6 @@
 openmediavault (6.5.4-1) stable; urgency=low
 
-  *
+  * Issue #1569: Shared folder references are not correctly queried.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Sat, 29 Jul 2023 14:51:43 +0200
 

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.system.sharedfolder.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.system.sharedfolder.json
@@ -6,7 +6,7 @@
 		"xpath": "//system/shares/sharedfolder",
 		"iterable": true,
 		"idproperty": "uuid",
-		"refproperty": "sharedfolderref"
+		"refproperty": "*[substring(name(), string-length(name()) - string-length('sharedfolderref') + 1) = 'sharedfolderref']"
 	},
 	"properties": {
 		"uuid": {

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.system.sharedfolder.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.system.sharedfolder.json
@@ -6,7 +6,7 @@
 		"xpath": "//system/shares/sharedfolder",
 		"iterable": true,
 		"idproperty": "uuid",
-		"refproperty": "*[substring(name(), string-length(name()) - string-length('sharedfolderref') + 1) = 'sharedfolderref']"
+		"refproperty": "*[contains(name(), 'sharedfolderref')]"
 	},
 	"properties": {
 		"uuid": {


### PR DESCRIPTION
The Photoprism plugin is using element/tag names like `xxx_sharedfolderref` for references to shared folders. These are not identified by `Database::isReferenced` because the XPath query is searching for `sharedfolderref` only.

Fixes: #1569
Signed-off-by: Volker Theile <votdev@gmx.de>

<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
