### PR TITLE
[Workbench] Changing forms from page-width to a more reasonable size

### DIFF
--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form-page/form-page.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form-page/form-page.component.html
@@ -8,7 +8,7 @@
                  type="error">
   {{ error | httpErrorResponse:'message' }}
 </omv-alert-panel>
-<mat-card [ngClass]="{'omv-display-none': loading || error}">
+<mat-card [class.omv-display-none]="loading || error" class="{{config.styling?.cardClasses}}">
   <ng-container *ngTemplateOutlet="renderCardHeader"></ng-container>
   <mat-card-content>
     <omv-intuition-form [id]="config.id"

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/models/form-page-config.type.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/models/form-page-config.type.ts
@@ -98,6 +98,7 @@ export type FormPageConfig = {
   // Form pages can have buttons in their footer.
   buttonAlign?: 'start' | 'center' | 'end';
   buttons?: Array<FormPageButtonConfig>;
+  styling?: FormPageStylingConfig;
 };
 
 export type FormPageButtonConfig = {
@@ -173,3 +174,7 @@ export type FormPageButtonExecute = {
   // A callback function. Internal only.
   click?: (buttonConfig: FormPageButtonConfig, values: FormValues) => void;
 };
+
+export interface FormPageStylingConfig {
+  cardClasses: string;
+}

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/models/form-page-config.type.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/models/form-page-config.type.ts
@@ -175,6 +175,6 @@ export type FormPageButtonExecute = {
   click?: (buttonConfig: FormPageButtonConfig, values: FormValues) => void;
 };
 
-export interface FormPageStylingConfig {
+export type FormPageStylingConfig {
   cardClasses: string;
 }

--- a/deb/openmediavault/workbench/src/app/core/pages/login-page/login-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/core/pages/login-page/login-page.component.ts
@@ -76,10 +76,7 @@ export class LoginPageComponent implements OnInit {
           click: this.onLogin.bind(this)
         }
       }
-    ],
-    styling: {
-      cardClasses: 'test'
-    }
+    ]
   };
 
   constructor(

--- a/deb/openmediavault/workbench/src/app/core/pages/login-page/login-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/core/pages/login-page/login-page.component.ts
@@ -76,7 +76,10 @@ export class LoginPageComponent implements OnInit {
           click: this.onLogin.bind(this)
         }
       }
-    ]
+    ],
+    styling: {
+      cardClasses: 'test'
+    }
   };
 
   constructor(

--- a/deb/openmediavault/workbench/src/app/pages/diagnostics/system-logs/system-logs-remote-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/diagnostics/system-logs/system-logs-remote-form-page.component.ts
@@ -89,6 +89,9 @@ export class SystemLogsRemoteFormPageComponent extends BaseFormPageComponent {
           url: '/diagnostics/system-logs'
         }
       }
-    ]
+    ],
+    styling: {
+      cardClasses: 'omv-w-xs'
+    }
   };
 }

--- a/deb/openmediavault/workbench/src/app/pages/network/general/general-network-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/general/general-network-form-page.component.ts
@@ -68,6 +68,9 @@ export class GeneralNetworkFormPageComponent extends BaseFormPageComponent {
           url: '/network'
         }
       }
-    ]
+    ],
+    styling: {
+      cardClasses: 'omv-w-xs'
+    }
   };
 }

--- a/deb/openmediavault/workbench/src/app/pages/network/proxy/proxy-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/proxy/proxy-form-page.component.ts
@@ -264,6 +264,9 @@ export class ProxyFormPageComponent extends BaseFormPageComponent {
           url: '/network'
         }
       }
-    ]
+    ],
+    styling: {
+      cardClasses: 'omv-w-xs'
+    }
   };
 }

--- a/deb/openmediavault/workbench/src/app/pages/services/nfs/nfs-settings-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/nfs/nfs-settings-form-page.component.ts
@@ -74,6 +74,9 @@ export class NfsSettingsFormPageComponent extends BaseFormPageComponent {
           url: '/services/nfs'
         }
       }
-    ]
+    ],
+    styling: {
+      cardClasses: 'omv-w-xs'
+    }
   };
 }

--- a/deb/openmediavault/workbench/src/app/pages/services/rsync/rsync-module-settings-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/rsync/rsync-module-settings-form-page.component.ts
@@ -75,6 +75,9 @@ export class RsyncModuleSettingsFormPageComponent extends BaseFormPageComponent 
           url: '/services/rsync/server'
         }
       }
-    ]
+    ],
+    styling: {
+      cardClasses: 'omv-w-xs'
+    }
   };
 }

--- a/deb/openmediavault/workbench/src/app/pages/services/smb/smb-settings-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/smb/smb-settings-form-page.component.ts
@@ -205,6 +205,9 @@ export class SmbSettingsFormPageComponent extends BaseFormPageComponent {
           url: '/services/smb'
         }
       }
-    ]
+    ],
+    styling: {
+      cardClasses: 'omv-w-xs'
+    }
   };
 }

--- a/deb/openmediavault/workbench/src/app/pages/services/ssh/ssh-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/ssh/ssh-form-page.component.ts
@@ -120,6 +120,9 @@ export class SshFormPageComponent extends BaseFormPageComponent {
           url: '/services'
         }
       }
-    ]
+    ],
+    styling: {
+      cardClasses: 'omv-w-xs'
+    }
   };
 }

--- a/deb/openmediavault/workbench/src/app/pages/system/date-time/date-time-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/system/date-time/date-time-form-page.component.ts
@@ -103,6 +103,9 @@ export class DateTimeFormPageComponent extends BaseFormPageComponent {
           url: '/system'
         }
       }
-    ]
+    ],
+    styling: {
+      cardClasses: 'omv-w-xs'
+    }
   };
 }

--- a/deb/openmediavault/workbench/src/app/pages/system/monitoring/monitoring-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/system/monitoring/monitoring-form-page.component.ts
@@ -57,6 +57,9 @@ export class MonitoringFormPageComponent extends BaseFormPageComponent {
           url: '/system'
         }
       }
-    ]
+    ],
+    styling: {
+      cardClasses: 'omv-w-xs'
+    }
   };
 }

--- a/deb/openmediavault/workbench/src/app/pages/system/notification/notification-settings-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/system/notification/notification-settings-form-page.component.ts
@@ -179,6 +179,9 @@ export class NotificationSettingsFormPageComponent extends BaseFormPageComponent
           }
         }
       }
-    ]
+    ],
+    styling: {
+      cardClasses: 'omv-w-xs'
+    }
   };
 }

--- a/deb/openmediavault/workbench/src/app/pages/system/powermgmt/powermgmt-settings-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/system/powermgmt/powermgmt-settings-form-page.component.ts
@@ -100,6 +100,9 @@ export class PowermgmtSettingsFormPageComponent extends BaseFormPageComponent {
           url: '/system/powermgmt'
         }
       }
-    ]
+    ],
+    styling: {
+      cardClasses: 'omv-w-xs'
+    }
   };
 }

--- a/deb/openmediavault/workbench/src/app/pages/system/updates/update-settings-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/system/updates/update-settings-form-page.component.ts
@@ -82,6 +82,9 @@ export class UpdateSettingsFormPageComponent extends BaseFormPageComponent {
           url: '/system/updatemgmt'
         }
       }
-    ]
+    ],
+    styling: {
+      cardClasses: 'omv-w-xs'
+    }
   };
 }

--- a/deb/openmediavault/workbench/src/app/pages/system/workbench/workbench-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/system/workbench/workbench-form-page.component.ts
@@ -172,6 +172,9 @@ export class WorkbenchFormPageComponent extends BaseFormPageComponent {
           url: '/system'
         }
       }
-    ]
+    ],
+    styling: {
+      cardClasses: 'omv-w-xs'
+    }
   };
 }

--- a/deb/openmediavault/workbench/src/app/pages/usermgmt/users/user-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/usermgmt/users/user-form-page.component.ts
@@ -212,6 +212,9 @@ export class UserFormPageComponent extends BaseFormPageComponent {
           url: '/usermgmt/users'
         }
       }
-    ]
+    ],
+    styling: {
+      cardClasses: 'omv-w-xs'
+    }
   };
 }

--- a/deb/openmediavault/workbench/src/app/pages/usermgmt/users/user-settings-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/usermgmt/users/user-settings-form-page.component.ts
@@ -69,6 +69,9 @@ export class UserSettingsFormPageComponent extends BaseFormPageComponent {
           url: '/usermgmt'
         }
       }
-    ]
+    ],
+    styling: {
+      cardClasses: 'omv-w-xs'
+    }
   };
 }

--- a/deb/openmediavault/workbench/src/styles.scss
+++ b/deb/openmediavault/workbench/src/styles.scss
@@ -99,6 +99,21 @@ $omv-dark-theme: mat.define-dark-theme(
   width: auto;
 }
 
+// center all cards with omv-w-* classes
+.mat-card[class^=omv-w-] {
+  margin-left: auto !important;
+  margin-right: auto !important;
+}
+.mat-card.omv-w-xs {
+  max-width: 450px;
+}
+.mat-card.omv-w-sm {
+  max-width: 768px;
+}
+.mat-card.omv-w-md {
+  max-width: 1280px;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Spacing
 //

--- a/deb/openmediavault/workbench/src/styles.scss
+++ b/deb/openmediavault/workbench/src/styles.scss
@@ -99,16 +99,15 @@ $omv-dark-theme: mat.define-dark-theme(
   width: auto;
 }
 
-// center all cards with omv-w-* classes
-.mat-card[class^=omv-w-] {
+.mat-card.omv-w-xs {
+  max-width: 450px;
   margin-left: auto !important;
   margin-right: auto !important;
 }
-.mat-card.omv-w-xs {
-  max-width: 450px;
-}
 .mat-card.omv-w-sm {
   max-width: 768px;
+  margin-left: auto !important;
+  margin-right: auto !important;
 }
 .mat-card.omv-w-md {
   max-width: 1280px;


### PR DESCRIPTION
Changed every form in the angular workbench to a more reasonable size.

By adding some global classes and extending the FormPageConfig-Interface, there's now the possibilty to style each mat-card with one or more css classes.

I really don't want to do these CLA things - just copy my code if you want to. 