### PR TITLE
Add setting to choose the minimum SMB protocol version

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,8 @@
-openmediavault (6.7.2-1) stable; urgency=low
+openmediavault (6.8.0-1) stable; urgency=low
 
-  *
+  * Add setting to choose the minimum SMB protocol version. This
+    way SMB1 can be enabled to allow legacy systems to access your
+    SMB shares.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Mon, 28 Aug 2023 20:28:10 +0200
 

--- a/deb/openmediavault/srv/salt/omv/deploy/samba/files/global.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/samba/files/global.j2
@@ -25,6 +25,7 @@
 {%- set fruit_aapl = salt['pillar.get']('default:OMV_SAMBA_FRUIT_AAPL', 'yes') -%}
 {%- set fruit_nfs_aces = salt['pillar.get']('default:OMV_SAMBA_SHARE_FRUIT_NFSACES', 'no') -%}
 {%- set fruit_copyfile = salt['pillar.get']('default:OMV_SAMBA_SHARE_FRUIT_COPYFILE', 'yes') -%}
+{%- set server_min_protocols = {'SMB1': 'NT1', 'SMB2': 'SMB2_02', 'SMB3': 'SMB3_00'} -%}
 {{ pillar['headers']['multiline'] -}}
 #======================= Global Settings =======================
 [global]
@@ -65,6 +66,10 @@ wins server = {{ config.winsserver }}
 {%- endif %}
 disable netbios = {{ config.netbios | to_bool | not | yesno }}
 multicast dns register = no
+server min protocol = {{ server_min_protocols | get(config.minprotocol) }}
+{%- if config.minprotocol == 'SMB1' %}
+ntlm auth = ntlmv1-permitted
+{%- endif %}
 # Special configuration for Apple's Time Machine
 fruit:aapl = {{ fruit_aapl }}
 fruit:copyfile = {{ fruit_copyfile }}

--- a/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_6.8.0.sh
+++ b/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_6.8.0.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env dash
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+set -e
+
+. /usr/share/openmediavault/scripts/helper-functions
+
+omv_config_add_key "/config/services/smb" "minprotocol" "SMB2"
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smb.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smb.json
@@ -60,6 +60,11 @@
 			"type": "boolean",
 			"default": false
 		},
+		"minprotocol": {
+			"type": "string",
+			"enum": [ "SMB1", "SMB2", "SMB3" ],
+			"default": "SMB2"
+		},
 		"extraoptions": {
 			"type": "string"
 		},

--- a/deb/openmediavault/usr/share/openmediavault/locale/openmediavault.pot
+++ b/deb/openmediavault/usr/share/openmediavault/locale/openmediavault.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-13 16:31+0200\n"
+"POT-Creation-Date: 2023-08-29 09:40+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1883,6 +1883,9 @@ msgstr ""
 msgid "Minimum performance, minimum acoustic output"
 msgstr ""
 
+msgid "Minimum protocol version"
+msgstr ""
+
 msgid "Minute"
 msgstr ""
 
@@ -2067,6 +2070,9 @@ msgid "Not mounted"
 msgstr ""
 
 msgid "Not running"
+msgstr ""
+
+msgid "Note that SMB1 is deprecated and should only be used in mandatory cases."
 msgstr ""
 
 msgid "Nothing"
@@ -3260,6 +3266,9 @@ msgstr ""
 msgid "This field contains invalid characters, only alphanumeric characters and underscore are allowed."
 msgstr ""
 
+msgid "This field is automatically filled with the subject of the certificate if left blank."
+msgstr ""
+
 msgid "This field is required."
 msgstr ""
 
@@ -3354,6 +3363,9 @@ msgid "This parameter can be used to ensure that if default acls exist on parent
 msgstr ""
 
 msgid "This parameter controls whether files starting with a dot appear as hidden files"
+msgstr ""
+
+msgid "This setting controls the minimum protocol version that the server will allow the client to use."
 msgstr ""
 
 msgid "This specifies what to do if the packet matches."
@@ -3659,9 +3671,6 @@ msgstr ""
 msgid "Uruguay"
 msgstr ""
 
-msgid "Usage"
-msgstr ""
-
 msgid "Usage Warning Threshold"
 msgstr ""
 
@@ -3713,6 +3722,9 @@ msgstr ""
 msgid "Users must be assigned to the <em>ssh</em> group to be able to log in via SSH."
 msgstr ""
 
+msgid "Utilization"
+msgstr ""
+
 msgid "Uzbekistan"
 msgstr ""
 
@@ -3720,6 +3732,9 @@ msgid "VLAN"
 msgstr ""
 
 msgid "VLAN id"
+msgstr ""
+
+msgid "Valid from"
 msgstr ""
 
 msgid "Valid to"

--- a/deb/openmediavault/usr/share/openmediavault/templates/config.xml
+++ b/deb/openmediavault/usr/share/openmediavault/templates/config.xml
@@ -446,6 +446,10 @@
 			</scheduledtests>
 		</smart>
 		<smb>
+			<!--
+			<enable>0|1</enable>
+			<minprotocol>SMB1|SMB2|SMB3</minprotocol>
+			-->
 			<enable>0</enable>
 			<workgroup>WORKGROUP</workgroup>
 			<serverstring>%h server</serverstring>
@@ -459,6 +463,7 @@
 			<homesbrowseable>1</homesbrowseable>
 			<homesrecyclebin>0</homesrecyclebin>
 			<netbios>0</netbios>
+			<minprotocol>SMB2</minprotocol>
 			<extraoptions></extraoptions>
 			<shares>
 				<!--

--- a/deb/openmediavault/workbench/src/app/pages/services/smb/smb-settings-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/smb/smb-settings-form-page.component.ts
@@ -103,6 +103,25 @@ export class SmbSettingsFormPageComponent extends BaseFormPageComponent {
         title: gettext('Advanced settings')
       },
       {
+        type: 'select',
+        name: 'minprotocol',
+        label: gettext('Minimum protocol version'),
+        hint:
+          gettext(
+            'This setting controls the minimum protocol version that the server will allow the client to use.'
+          ) +
+          ' ' +
+          gettext('Note that SMB1 is deprecated and should only be used in mandatory cases.'),
+        value: 'SMB2',
+        store: {
+          data: [
+            ['SMB1', 'SMB1'],
+            ['SMB2', 'SMB2'],
+            ['SMB3', 'SMB3']
+          ]
+        }
+      },
+      {
         type: 'checkbox',
         name: 'netbios',
         label: gettext('Enable NetBIOS'),


### PR DESCRIPTION
This way SMB1 can be enabled to allow legacy systems to access your SMB shares.


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
