### PR TITLE
Issue #1588: Support SMART information for devices connected via RTL9210B-CG

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -6,6 +6,8 @@ openmediavault (6.8.0-1) stable; urgency=low
   * Add setting to choose the minimum SMB protocol version. This
     way SMB1 can be enabled to allow legacy systems to access your
     SMB shares.
+  * Issue #1588: Support SMART information for devices connected
+    via RTL9210B-CG.
   * Issue #1589: Fix a problem in the netplan.io configuration for
     ethernet network interfaces with non-permanent MAC addresses.
 

--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevicesd.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevicesd.inc
@@ -82,6 +82,12 @@ class StorageDeviceSD extends StorageDevice implements SmartInterface {
 				if (("174c" == $vendorId) && ("2362" == $modelId)) {
 					return "sntasmedia";
 				}
+				// Realtek RTL9210B-CG USB 3.1 GEN2 to PCI EXPRESS GEN3x2/SATA Gen3. BRIDGE
+				// https://www.realtek.com/en/products/connected-media-ics/item/rtl9210b-cg
+				// https://devicehunt.com/view/type/usb/vendor/0BDA/device/9210
+				if (("0bda" == $vendorId) && ("9210" == $modelId)) {
+					return "";
+				}
 			}
 			// Identify by ID_MODEL_ID or `/sys/block/<XXX>/device/model`.
 			$modelMap = [


### PR DESCRIPTION
Devices connected via USB adapter that are using Realtek RTL9210B-CG USB 3.1 GEN2 to PCI EXPRESS GEN3x2/SATA Gen3. BRIDGE do not need the `-d sat` argument for `smartctl`.

Fixes: https://github.com/openmediavault/openmediavault/issues/1588

References:
- https://devicehunt.com/view/type/usb/vendor/0BDA/device/9210
- https://de.aliexpress.com/item/1005005300200449.html?gatewayAdapt=glo2deu


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
