### PR TITLE
Replace distutils.Python distutils.version.LooseVersion

### DIFF
--- a/deb/openmediavault/debian/control
+++ b/deb/openmediavault/debian/control
@@ -26,7 +26,7 @@ Depends: php-fpm, libpam-modules, php-json, dpkg, patch, dash, mawk | gawk,
  python3-netifaces, udev, python3-lxml, salt-minion (>= 3006.0),
  libnss-myhostname, php-yaml, python3-click, python3-cached-property,
  python3-polib, libnss-systemd, libnss-resolve, debian-archive-keyring,
- openmediavault-keyring, systemd-resolved, ${misc:Depends}
+ openmediavault-keyring, systemd-resolved, python3-packaging, ${misc:Depends}
 Description: openmediavault - The open network attached storage solution
  openmediavault is a small and simple to use network attached storage system
  with a smart WebGUI.

--- a/deb/openmediavault/usr/share/openmediavault/confdbadm/commands.d/migrate.py
+++ b/deb/openmediavault/usr/share/openmediavault/confdbadm/commands.d/migrate.py
@@ -23,11 +23,11 @@ import os
 import os.path
 import re
 import sys
-from distutils.version import LooseVersion
 
 import openmediavault.confdbadm
 import openmediavault.log
 import openmediavault.procutils
+import packaging.version
 
 import openmediavault
 
@@ -41,8 +41,8 @@ class Command(
 
     def argparse_is_version(self, arg):
         try:
-            _ = LooseVersion(arg)
-        except Exception:
+            _ = packaging.version.Version(arg)
+        except packaging.version.InvalidVersion:
             raise argparse.ArgumentTypeError("No valid version")
 
         # Extract the upstream version.
@@ -83,7 +83,7 @@ class Command(
                 continue
             if cmd_args.id != parts[0]:
                 continue
-            if LooseVersion(parts[1]) < LooseVersion(cmd_args.version):
+            if packaging.version.Version(parts[1]) < packaging.version.Version(cmd_args.version):
                 continue
             migrations[parts[1]] = name
         try:
@@ -91,7 +91,7 @@ class Command(
             self.create_backup()
             # Execute the configuration database migration scripts.
             for cmd_args.version in sorted(
-                migrations, key=lambda v: LooseVersion(v)
+                migrations, key=lambda v: packaging.version.Version(v)
             ):
                 name = "%s_%s" % (cmd_args.id, cmd_args.version)
                 path = os.path.join(


### PR DESCRIPTION
Replace the package distutils by packaging because the former will be deprecated in 3.12. Even if Debian Bookworm and Trixie still use 3.11.x it should be ensured that OMV does not break when users install a newer version.


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
