### PR TITLE
ClamAV cannot start - AppArmor blocks access to log file

### DIFF
--- a/deb/openmediavault-clamav/srv/salt/omv/deploy/clamav/default.sls
+++ b/deb/openmediavault-clamav/srv/salt/omv/deploy/clamav/default.sls
@@ -77,6 +77,9 @@ configure_clamd_apparmor_local_profile:
         # execute mode.
         /usr/bin/dash muxr,
 
+        # Allow user clamav to access log files at /var/log/clamav
+        capability chown,
+
 # https://help.ubuntu.com/community/AppArmor#Reload_one_profile
 reload_clamd_apparmor_profile:
   cmd.run:


### PR DESCRIPTION
Fix a problem with accessing the log file that prevents clamav to start

ClamAV runs with an own user clamav. The logs in /var/log/clamav belongs to that user, but AppArmor prevents ClamAV to access these logs.

Solution found here: https://www.mail-archive.com/clamav-users@lists.clamav.net/msg50435.html
