### PR TITLE
Add omv-release-upgrade infrastructure

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,8 @@
 openmediavault (6.9.10-1) stable; urgency=low
 
-  *
+  * Add omv-release-upgrade to allow users to migrate their
+    systems to OMV7 (Sandworm) which is based on Debian 12
+    (Bookworm).
 
  -- Volker Theile <volker.theile@openmediavault.org>  Fri, 08 Dec 2023 11:48:57 +0100
 

--- a/deb/openmediavault/usr/sbin/omv-release-upgrade
+++ b/deb/openmediavault/usr/sbin/omv-release-upgrade
@@ -1,0 +1,95 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+set -e
+
+. /etc/default/openmediavault
+
+OMV_UPGRADE_SCRIPTS_DIR=${OMV_UPGRADE_SCRIPTS_DIR:-"/usr/share/openmediavault/release-upgrade"}
+OMV_UPGRADE_RELEASEVERSION=${OMV_UPGRADE_RELEASEVERSION:-"7.0"}
+OMV_UPGRADE_RELEASENAME=${OMV_UPGRADE_RELEASENAME:-"Sandworm"}
+
+export LANG=C
+export DEBIAN_FRONTEND=noninteractive
+export APT_LISTCHANGES_FRONTEND=none
+
+export OMV_UPGRADE_RELEASEVERSION
+export OMV_UPGRADE_RELEASENAME
+export OMV_UPGRADE_PRODNAME=$(xmlstarlet sel -t -v "//name" ${OMV_PRODUCTINFO_FILE} | xmlstarlet unesc)
+export OMV_UPGRADE_PRODCOPYRIGHT=$(xmlstarlet sel -t -v "//copyright" ${OMV_PRODUCTINFO_FILE} | xmlstarlet unesc)
+
+whiptail --clear --backtitle "${OMV_UPGRADE_PRODNAME} - ${OMV_UPGRADE_PRODCOPYRIGHT}" \
+  --title "Release upgrade" \
+  --yesno "Do you really want to upgrade your system to release version ${OMV_UPGRADE_RELEASEVERSION} (${OMV_UPGRADE_RELEASENAME})? Please ensure that all your installed plugins are available for this release." \
+  9 56 6
+[ $? -ne 0 ] && exit 0
+echo "Upgrading system to ${OMV_UPGRADE_RELEASEVERSION} (${OMV_UPGRADE_RELEASENAME}) ..."
+
+# Immediately abort the upgrade process if there is a side-by-side installation
+# with a desktop environment.
+if dpkg -l | grep -Eqw "gdm3|sddm|lxdm|xdm|lightdm|slim|wdm"; then
+  echo "This system is running a desktop environment! This setup is not supported."
+  exit 1
+fi
+
+# Backup the release upgrade scripts to a temporary directory. This is
+# necessary because the scripts directory is removed when the package
+# openmediavault x.y.z is installed (which does not contain these files).
+tmpdir=$(mktemp --tmpdir=/var/tmp --directory)
+cp -r ${OMV_UPGRADE_SCRIPTS_DIR}/* ${tmpdir}
+
+# Ensure the latest packages of the current release are installed.
+echo "Ensure the system is up-to-date before doing the release upgrade ..."
+omv-upgrade
+
+# Execute scripts before upgrade.
+echo "Running pre-upgrade scripts ..."
+run-parts --exit-on-error ${tmpdir}/pre.d
+
+# Upgrade to latest distribution.
+echo "Starting release upgrade ..."
+apt-get update
+apt-get --yes --force-yes --fix-missing --auto-remove --allow-unauthenticated \
+  --show-upgraded --option Dpkg::Options::="--force-confdef" \
+  --option DPkg::Options::="--force-confold" --no-install-recommends \
+  dist-upgrade
+
+# Execute scripts after upgrade.
+echo "Running post-upgrade scripts ..."
+run-parts ${tmpdir}/post.d
+
+# Install the latest packages by using the new APT settings that were
+# deployed during the release upgrade. Do not fail here if something
+# is not working to do not abort the whole upgrade.
+echo "Ensure the latest packages are installed ..."
+omv-upgrade || :
+
+# Cleanup
+echo "Cleanup ..."
+rm -rf ${tmpdir}
+
+# Display final message.
+whiptail --clear --backtitle "${OMV_UPGRADE_PRODNAME} - ${OMV_UPGRADE_PRODCOPYRIGHT}" \
+  --title "Release upgrade" \
+  --msgbox "The upgrade has completed successfully. Please reboot the system." \
+  8 43
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/10-enable-cron-apt
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/10-enable-cron-apt
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+rm -f /etc/cron-apt/refrain
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/10-enable-omv-mkaptidx
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/10-enable-omv-mkaptidx
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+rm -f /usr/sbin/omv-mkaptidx
+dpkg-divert --remove --rename /usr/sbin/omv-mkaptidx
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/50-set-dirty-apt
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/50-set-dirty-apt
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+. /usr/share/openmediavault/scripts/helper-functions
+
+omv_module_set_dirty apt
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/50-set-dirty-nfs
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/50-set-dirty-nfs
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+. /usr/share/openmediavault/scripts/helper-functions
+
+omv_module_set_dirty nfs
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/50-set-dirty-nginx
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/50-set-dirty-nginx
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+. /usr/share/openmediavault/scripts/helper-functions
+
+omv_module_set_dirty nginx
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/50-set-dirty-phpfpm
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/50-set-dirty-phpfpm
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+. /usr/share/openmediavault/scripts/helper-functions
+
+omv_module_set_dirty phpfpm
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/50-set-dirty-samba
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/50-set-dirty-samba
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+. /usr/share/openmediavault/scripts/helper-functions
+
+omv_module_set_dirty samba
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/70-deploy-config
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/70-deploy-config
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+omv-salt deploy run --append-dirty || :
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/80-apt-autoremove
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/80-apt-autoremove
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+apt-get --yes autoremove
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/90-apt-clean
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/90-apt-clean
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+apt-get clean
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/95-mdadm-note
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/95-mdadm-note
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+whiptail --clear --backtitle "${OMV_UPGRADE_PRODNAME} - ${OMV_UPGRADE_PRODCOPYRIGHT}" \
+  --title "Software RAID Management" \
+  --msgbox "Please note that the Software RAID management has been removed from the core system. Please install the openmediavault-md plugin if necessary." \
+  9 53
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/99-reboot-required
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/99-reboot-required
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+touch /run/reboot-required
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/pre.d/05-install-usrmerge
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/pre.d/05-install-usrmerge
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+# https://wiki.debian.org/UsrMerge/
+# https://www.freedesktop.org/wiki/Software/systemd/TheCaseForTheUsrMerge/
+
+# Do not try to install the package if the system has already been converted.
+[ "$(readlink -f /lib)" != "/usr/lib" ] || exit 0
+
+apt-get --yes install usrmerge || :
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/pre.d/10-apt-purge-local-archive
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/pre.d/10-apt-purge-local-archive
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+. /etc/default/openmediavault
+
+OMV_DPKGARCHIVE_DIR=${OMV_DPKGARCHIVE_DIR:-"/var/cache/openmediavault/archives"}
+
+# Cleanup local package archive.
+rm -fv ${OMV_DPKGARCHIVE_DIR}/*.deb
+cd ${OMV_DPKGARCHIVE_DIR} && apt-ftparchive packages . > Packages
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/pre.d/10-disable-cron-apt
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/pre.d/10-disable-cron-apt
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+touch /etc/cron-apt/refrain
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/pre.d/10-disable-omv-mkaptidx
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/pre.d/10-disable-omv-mkaptidx
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+# Make sure the command does not do anything during the distribution upgrade.
+dpkg-divert --rename --divert /usr/sbin/omv-mkaptidx.real /usr/sbin/omv-mkaptidx
+touch /usr/sbin/omv-mkaptidx
+chmod 755 /usr/sbin/omv-mkaptidx
+cat > /usr/sbin/omv-mkaptidx <<EOF
+#!/bin/sh
+exit 0
+EOF
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/pre.d/20-apt-remove-kernel-backports
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/pre.d/20-apt-remove-kernel-backports
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+# Remove kernel backports repository and configuration.
+rm -rf /etc/apt/sources.list.d/openmediavault-kernel-backports.list
+rm -rf /etc/apt/preferences.d/openmediavault-kernel-backports.pref
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/pre.d/20-apt-update-source-list
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/pre.d/20-apt-update-source-list
@@ -1,0 +1,63 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+. /etc/default/openmediavault
+
+OMV_UPGRADE_RELEASENAME=${OMV_UPGRADE_RELEASENAME:-"Sandworm"}
+OMV_UPGRADE_APTSOURCESLIST=${OMV_UPGRADE_APTSOURCESLIST:-"/etc/apt/sources.list.d/openmediavault.list"}
+OMV_UPGRADE_DEBIAN_RELEASENAME_CURRENT=${OMV_UPGRADE_DEBIAN_RELEASENAME_CURRENT:-"bullseye"}
+OMV_UPGRADE_DEBIAN_RELEASENAME_NEXT=${OMV_UPGRADE_DEBIAN_RELEASENAME_NEXT:-"bookworm"}
+
+# Upgrade OpenMediaVault source list file.
+relname=$(echo ${OMV_UPGRADE_RELEASENAME} | tr "[:upper:]" "[:lower:]" | tr -d "[:space:]")
+cat <<EOF > ${OMV_UPGRADE_APTSOURCESLIST}
+deb [signed-by=/usr/share/keyrings/openmediavault-archive-keyring.gpg] http://packages.openmediavault.org/public ${relname} main
+deb [signed-by=/usr/share/keyrings/openmediavault-archive-keyring.gpg] http://openmediavault.github.io/packages/ ${relname} main
+
+## Uncomment the following line to add software from the proposed repository.
+# deb [signed-by=/usr/share/keyrings/openmediavault-archive-keyring.gpg] http://packages.openmediavault.org/public ${relname}-proposed main
+# deb [signed-by=/usr/share/keyrings/openmediavault-archive-keyring.gpg] http://openmediavault.github.io/packages/ ${relname}-proposed main
+
+## This software is not part of OpenMediaVault, but is offered by third-party
+## developers as a service to OpenMediaVault users.
+# deb [signed-by=/usr/share/keyrings/openmediavault-archive-keyring.gpg] http://packages.openmediavault.org/public ${relname} partner
+# deb [signed-by=/usr/share/keyrings/openmediavault-archive-keyring.gpg] http://openmediavault.github.io/packages/ ${relname} partner
+EOF
+
+# Remove the OS security repository.
+rm -f /etc/apt/sources.list.d/openmediavault-debian-security.list
+rm -f /etc/apt/sources.list.d/openmediavault-os-security.list
+
+if [ -e "/etc/apt/sources.list" ]; then
+  # Upgrade Debian source list file.
+	sed -i -r "s/${OMV_UPGRADE_DEBIAN_RELEASENAME_CURRENT}(-lts)?/${OMV_UPGRADE_DEBIAN_RELEASENAME_NEXT}/g" /etc/apt/sources.list
+	# Remove and uncomment the OS security repository.
+  sed -i -e '/^[^#].+security.debian.org/s/^/#/' /etc/apt/sources.list
+  # Uncomment the Debian backports repository.
+  sed -i -r "/^[^#].+${OMV_UPGRADE_DEBIAN_RELEASENAME_CURRENT}-backports/s/^/#/" /etc/apt/sources.list
+fi
+
+# Modify default release.
+if [ -e "/etc/apt/apt.conf" ]; then
+	sed -i -r "s/${OMV_UPGRADE_DEBIAN_RELEASENAME_CURRENT}(-lts)?/${OMV_UPGRADE_DEBIAN_RELEASENAME_NEXT}/g" /etc/apt/apt.conf
+fi
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/pre.d/90-backup-config-db
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/pre.d/90-backup-config-db
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2023 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+. /etc/default/openmediavault
+
+OMV_CONFIG_BACKUP_FILE=${OMV_CONFIG_BACKUP_FILE:-"${OMV_CONFIG_FILE}.6x.bak"}
+
+# Create a configuration backup.
+if [ ! -e "${OMV_CONFIG_BACKUP_FILE}" ]; then
+	cp -v ${OMV_CONFIG_FILE} ${OMV_CONFIG_BACKUP_FILE}
+fi
+
+exit 0


### PR DESCRIPTION
Add infrastructure to allow plugins to customize the distribution upgrade from OMV6/Debian11 to OMV7/Debian12.