### PR TITLE
Add UTF8 support for SSL certificates created in Web UI

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/certificatemgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/certificatemgmt.inc
@@ -320,6 +320,7 @@ class CertificateMgmt extends \OMV\Rpc\ServiceAbstract {
 		$cmdArgs[] = "-nodes";
 		$cmdArgs[] = sprintf("-days %d", $params['days']);
 		$cmdArgs[] = "-sha256";
+		$cmdArgs[] = "-utf8";
 		$cmdArgs[] = "-batch";
 		$cmdArgs[] = sprintf("-newkey rsa:%d", $params['size']);
 		$cmdArgs[] = sprintf("-keyout %s", escapeshellarg($keyFile));


### PR DESCRIPTION
By default SSL certificates created with `openssl req -x509` do not properly decode UTF8 strings in the subject (Organization Name, Unit, City, etc), and are not correctly displayed in "Show Certificate" UIs in browsers and other GUI tools (although they are properly displayed in OMV's Web GUI)

Add `-utf8` command-line option to `openssl` so all clients properly interpret the UTF8 strings in the certificate.