### PR TITLE
Add email to SSL certificate's SAN in its own field

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/certificatemgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/certificatemgmt.inc
@@ -281,7 +281,7 @@ class CertificateMgmt extends \OMV\Rpc\ServiceAbstract {
 		// Validate the parameters of the RPC service method.
 		$this->validateMethodParams($params, "rpc.certificatemgmt.create");
 		// Generate the certificate subject string.
-		$rdnFields = [ "c", "st", "l", "o", "ou", "cn" ];
+		$rdnFields = [ "c", "st", "l", "o", "ou", "cn", "email" ];
 		$subject = "";
 		foreach ($rdnFields as $rdnFieldk => $rdnFieldv) {
 			if (empty($params[$rdnFieldv]))
@@ -298,16 +298,24 @@ class CertificateMgmt extends \OMV\Rpc\ServiceAbstract {
 			$params[$rdnFieldv] = addcslashes($params[$rdnFieldv], '"\\');
 			// Append to subject.
 			switch ($rdnFieldv) {
-			case "cn":
+			case "email":
 				// Append the email address.
-				if (!empty($params['email'])) {
-					$params[$rdnFieldv] = sprintf("%s/emailAddress=%s",
-					  $params[$rdnFieldv], $params['email']);
-				}
+				$subject .= sprintf("/emailAddress=%s", $params['email']);
+				break;
 			default:
 				$subject .= sprintf("/%s=%s", mb_strtoupper($rdnFieldv),
 				  $params[$rdnFieldv]);
 			}
+		}
+		// Generate the certificate Subject Alternative Name (SAN) array.
+		$subjectAltName = [];
+		if (!empty($params['cn'])) {
+			$subjectAltName[] = sprintf("%s:%s",
+				is_ipaddr($params['cn']) ? "IP" : "DNS",
+				$params['cn']);
+		}
+		if (!empty($params['email'])) {
+			$subjectAltName[] = "email:copy";
 		}
 		// Create the requested certificate.
 		// http://www.zytrax.com/tech/survival/ssl.html
@@ -328,10 +336,9 @@ class CertificateMgmt extends \OMV\Rpc\ServiceAbstract {
 		if (!empty($subject)) {
 			$cmdArgs[] = sprintf("-subj %s", escapeshellarg($subject));
 		}
-		if (!empty($params['cn'])) {
-			$cmdArgs[] = sprintf("-addext 'subjectAltName=%s:%s'",
-				is_ipaddr($params['cn']) ? "IP" : "DNS",
-				$params['cn']);
+		if (!empty($subjectAltName)) {
+			$cmdArgs[] = sprintf("-addext 'subjectAltName=%s'",
+				join(",", $subjectAltName));
 		}
 		$cmd = new \OMV\System\Process("openssl", $cmdArgs);
 		$cmd->setRedirect2to1();


### PR DESCRIPTION
Currently, email is added to subjectAltName in the DNS field (from commonName), as `DNS:hostname/emailAddress=x@a.com`, which renders as a single field, as if the email was part of the hostname. While accepted by Firefox (and possibly others), this is not the correct syntax.

This PR changes the SAN to `DNS:hostname,email:copy`, which properly copies the emailAddress value from the subject and renders as `DNS:hostname, email:x@a.com` (2 distinct fields).

Note 1: Current codebase seems to use both `<TAB>` and `  ` (2 spaces) as alignment for continuation lines (after indentation). Since recent commits seems to favor `<TAB>`, I've used that in the PR

Note 2: Isn't it supposed to have a Comment field in the SSL certificate creation form? I can see it in the code (both in the HTML template and in the form processing code), and I also noticed a recent commit changing it from Text Input to Tag Input, but I don't see the field anywhere in the UI form (using latest OMV6): 
![image](https://github.com/openmediavault/openmediavault/assets/992317/30ee21ee-2946-404b-9664-ef986b04173f)

