### PR TITLE
convert numbers from exponential if needed

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/unittests/php/test_openmediavault_functions.php
+++ b/deb/openmediavault/usr/share/openmediavault/unittests/php/test_openmediavault_functions.php
@@ -466,6 +466,21 @@ class test_openmediavault_functions extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals($str, "438.83 MiB");
 	}
 
+	public function test_binary_format_3() {
+		$str = binary_format(1.0654267673149E+14);
+		$this->assertEquals($str, "96.89 TiB");
+	}
+
+	public function test_binary_format_4() {
+		$str = binary_format(106502234262448);
+		$this->assertEquals($str, "96.86 TiB");
+	}
+
+	public function test_binary_format_5() {
+		$str = binary_format("2667600");
+		$this->assertEquals($str, "2.54 MiB");
+	}
+
 	public function test_array_remove_value_1() {
 		$d = ["a", "b"];
 		$this->assertTrue(array_remove_value($d, "a"));

--- a/deb/openmediavault/usr/share/php/openmediavault/functions.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/functions.inc
@@ -705,7 +705,7 @@ function binary_format($number, $options = NULL) {
 			$maxExp = array_search($options['maxPrefix'], $prefixes);
 	}
 
-	$number = number_format(strval($number), 0, "", "");
+	$number = number_format($number, 0, "", "");
 	while ((-1 != bccomp($number, "1024")) && ($exp < $maxExp)) {
 		$exp++;
 		$number = bcdiv($number, "1024", $decimalPlaces);

--- a/deb/openmediavault/usr/share/php/openmediavault/functions.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/functions.inc
@@ -705,7 +705,7 @@ function binary_format($number, $options = NULL) {
 			$maxExp = array_search($options['maxPrefix'], $prefixes);
 	}
 
-	$number = strval($number);
+	$number = number_format(strval($number), 0, "", "");
 	while ((-1 != bccomp($number, "1024")) && ($exp < $maxExp)) {
 		$exp++;
 		$number = bcdiv($number, "1024", $decimalPlaces);


### PR DESCRIPTION
convert numbers from exponential if very large

Filesystems over 100TB will have have their size converted to an exponential number.  This breaks formatting.  Found in this thread on the forum - https://forum.openmediavault.org/index.php?thread/50772-omv-7-zfs/

Signed-off-by: Aaron Murray <plugins@omv-extras.org>

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
