### PR TITLE
Add support for hints on datatable pages

### DIFF
--- a/deb/openmediavault-filebrowser/debian/changelog
+++ b/deb/openmediavault-filebrowser/debian/changelog
@@ -1,4 +1,4 @@
-openmediavault-filebrowser (7.0-2) unstable; urgency=low
+openmediavault-filebrowser (7.0-3) unstable; urgency=low
 
   * Adapt to openmediavault 7 (Sandworm).
 

--- a/deb/openmediavault-filebrowser/usr/share/openmediavault/workbench/component.d/omv-services-filebrowser-form-page.yaml
+++ b/deb/openmediavault-filebrowser/usr/share/openmediavault/workbench/component.d/omv-services-filebrowser-form-page.yaml
@@ -10,11 +10,12 @@ data:
         method: get
       post:
         method: set
-    fields:
-      - type: hint
+    hints:
+      - type: info
         text: _("Use the <em>admin:admin</em> credentials when logging in for the first time. Please do not forget to change the password immediately.")
         dismissible: true
         stateId: 9853961a-41e8-471e-bc28-f81e995dae43
+    fields:
       - type: checkbox
         name: enable
         label: _("Enabled")

--- a/deb/openmediavault-onedrive/debian/changelog
+++ b/deb/openmediavault-onedrive/debian/changelog
@@ -1,4 +1,4 @@
-openmediavault-onedrive (7.0-1) unstable; urgency=low
+openmediavault-onedrive (7.0-2) unstable; urgency=low
 
   * Adapt to openmediavault 7 (Sandworm).
 

--- a/deb/openmediavault-onedrive/usr/share/openmediavault/workbench/component.d/omv-services-onedrive-form-page.yaml
+++ b/deb/openmediavault-onedrive/usr/share/openmediavault/workbench/component.d/omv-services-onedrive-form-page.yaml
@@ -10,15 +10,16 @@ data:
         method: get
       post:
         method: set
-    fields:
-      - type: hint
+    hints:
+      - type: info
         text: _("After enabling and deploying this service the first time please run the command <em>omv-onedrive-auth</em> as <em>root</em> user in the CLI to authenticate the application in Microsoft OneDrive.")
         dismissible: true
         stateId: c563faed-4331-493b-937d-20489be8c203
-      - type: hint
+      - type: info
         text: _("Use the <em>omv-onedrive</em> command in the CLI to perform additional actions according to the documentation of the OneDrive Linux client.")
         dismissible: true
         stateId: 88ac9240-3e8a-4372-8a63-74baa4276cf2
+    fields:
       - type: checkbox
         name: enable
         label: _("Enabled")

--- a/deb/openmediavault-photoprism/debian/changelog
+++ b/deb/openmediavault-photoprism/debian/changelog
@@ -1,4 +1,4 @@
-openmediavault-photoprism (7.0-2) unstable; urgency=low
+openmediavault-photoprism (7.0-3) unstable; urgency=low
 
   * Adapt to openmediavault 7 (Sandworm).
 

--- a/deb/openmediavault-photoprism/usr/share/openmediavault/workbench/component.d/omv-services-photoprism-form-page.yaml
+++ b/deb/openmediavault-photoprism/usr/share/openmediavault/workbench/component.d/omv-services-photoprism-form-page.yaml
@@ -10,11 +10,12 @@ data:
         method: get
       post:
         method: set
-    fields:
-      - type: hint
+    hints:
+      - type: info
         text: _("Use the <em>admin:admin</em> credentials when logging in for the first time. Please do not forget to change the password immediately.")
         dismissible: true
         stateId: 76f127fb-092d-43af-8479-c035da5e0ba3
+    fields:
       - type: checkbox
         name: enable
         label: _("Enabled")

--- a/deb/openmediavault/usr/share/openmediavault/workbench/component.d/omv-storage-filesystem-btrfs-create-form-page.yaml
+++ b/deb/openmediavault/usr/share/openmediavault/workbench/component.d/omv-storage-filesystem-btrfs-create-form-page.yaml
@@ -4,11 +4,12 @@ data:
   name: omv-storage-filesystem-btrfs-create-form-page
   type: formPage
   config:
-    fields:
-      - type: hint
+    hints:
+      - type: info
         text: _("If a device is not listed here, it is usually because the device already contains a file system or partitions. With the former, the file system can be mounted <a href='#/storage/filesystems/mount'>here<a>. For the latter, please <a href='#/storage/disks'>wipe<a> the device as partitions are not supported.")
         dismissible: true
         stateId: 199e8c7a-ee3b-11ed-9fb1-2750842abc68
+    fields:
       - type: textInput
         name: type
         label: _("Type")

--- a/deb/openmediavault/usr/share/openmediavault/workbench/component.d/omv-storage-filesystem-generic-create-form-page.yaml
+++ b/deb/openmediavault/usr/share/openmediavault/workbench/component.d/omv-storage-filesystem-generic-create-form-page.yaml
@@ -4,11 +4,12 @@ data:
   name: omv-storage-filesystem-generic-create-form-page
   type: formPage
   config:
-    fields:
-      - type: hint
+    hints:
+      - type: info
         text: _("If a device is not listed here, it is usually because the device already contains a file system or partitions. With the former, the file system can be mounted <a href='#/storage/filesystems/mount'>here<a>. For the latter, please <a href='#/storage/disks'>wipe<a> the device as partitions are not supported.")
         dismissible: true
         stateId: 199e8c7a-ee3b-11ed-9fb1-2750842abc68
+    fields:
       - type: textInput
         name: type
         label: _("Type")

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/abstract-page-component.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/abstract-page-component.ts
@@ -28,6 +28,7 @@ import { ActivatedRoute, Params, Route, Router } from '@angular/router';
 import * as _ from 'lodash';
 import { combineLatest, Subscription } from 'rxjs';
 
+import { PageHintConfig } from '~/app/core/components/intuition/models/page-config.type';
 import { decodeURIComponentDeep, formatDeep, isFormatable } from '~/app/functions.helper';
 import { AuthSessionService } from '~/app/shared/services/auth-session.service';
 
@@ -106,20 +107,33 @@ export abstract class AbstractPageComponent<T> implements AfterViewInit, OnInit,
    * Sanitize the configuration, e.g. set default values or convert
    * properties.
    */
-  protected sanitizeConfig() {}
+  protected sanitizeConfig(): void {}
+
+  /**
+   * Sanitize the hint configuration.
+   */
+  protected sanitizeHints(): void {
+    const hints: PageHintConfig[] = _.get(this.config, 'hints', []) as PageHintConfig[];
+    _.forEach(hints, (config: PageHintConfig) => {
+      _.defaultsDeep(config, {
+        type: 'info',
+        dismissible: false
+      });
+    });
+  }
 
   /**
    * A callback method that is invoked immediately after the observable
    * of the matrix parameters scoped to this route have been resolved.
    */
-  protected onRouteParams() {}
+  protected onRouteParams(): void {}
 
   /**
    * Format the given configuration properties.
    *
    * @param paths The paths of the properties to format.
    */
-  protected formatConfig(paths: Array<string>) {
+  protected formatConfig(paths: Array<string>): void {
     _.forEach(paths, (path) => {
       const value = _.get(this.config as Record<string, any>, path);
       if (isFormatable(value)) {

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/datatable-page/datatable-page.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/datatable-page/datatable-page.component.html
@@ -1,3 +1,15 @@
+<div *ngIf="config.hints"
+     class="omv-display-flex omv-flex-column">
+  <omv-alert-panel *ngFor="let hint of config.hints"
+                   class="omv-flex-1 omv-m omv-mb-z"
+                   [type]="hint.type"
+                   [hasTitle]="false"
+                   [hasMargin]="false"
+                   [dismissible]="hint.dismissible"
+                   [stateId]="hint.stateId">
+    <span [innerHtml]="hint.text | transloco | nl2br | sanitizeHtml"></span>
+  </omv-alert-panel>
+</div>
 <mat-card>
   <ng-container *ngTemplateOutlet="renderCardHeader"></ng-container>
   <mat-card-content>

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/datatable-page/datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/datatable-page/datatable-page.component.ts
@@ -31,6 +31,7 @@ import { DatatablePageActionConfig } from '~/app/core/components/intuition/model
 import { DatatablePageConfig } from '~/app/core/components/intuition/models/datatable-page-config.type';
 import { DatatablePageButtonConfig } from '~/app/core/components/intuition/models/datatable-page-config.type';
 import { FormFieldConfig } from '~/app/core/components/intuition/models/form-field-config.type';
+import { PageHintConfig } from '~/app/core/components/intuition/models/page-config.type';
 import { format, formatDeep, isFormatable } from '~/app/functions.helper';
 import { translate } from '~/app/i18n.helper';
 import {
@@ -356,6 +357,8 @@ export class DatatablePageComponent extends AbstractPageComponent<DatatablePageC
     this.config.icon = _.get(Icon, this.config.icon, this.config.icon);
     // Pre-setup actions based on the specified template type.
     this.sanitizeActions(this.config.actions);
+    // Set the default hint properties.
+    this.sanitizeHints();
     // Set the default values of the buttons.
     _.forEach(this.config.buttons, (button) => {
       const template = _.get(button, 'template');
@@ -396,9 +399,16 @@ export class DatatablePageComponent extends AbstractPageComponent<DatatablePageC
       'store.proxy.get.params',
       'store.filters'
     ]);
+    if (_.isArray(this.config.hints)) {
+      _.forEach(this.config.hints, (hintConfig: PageHintConfig) => {
+        if (isFormatable(hintConfig.text)) {
+          hintConfig.text = format(hintConfig.text, this.pageContext);
+        }
+      });
+    }
   }
 
-  private sanitizeActions(actions) {
+  private sanitizeActions(actions: DatatablePageActionConfig[]) {
     _.forEach(actions, (action: DatatablePageActionConfig) => {
       _.defaultsDeep(action, {
         click: this.onActionClick.bind(this)

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form-page/form-page.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form-page/form-page.component.html
@@ -8,6 +8,19 @@
                  type="error">
   {{ error | httpErrorResponse:'message' }}
 </omv-alert-panel>
+<div *ngIf="config.hints"
+     [ngClass]="{'omv-display-none': loading || error}"
+     class="omv-display-flex omv-flex-column">
+  <omv-alert-panel *ngFor="let hint of config.hints"
+                   class="omv-flex-1 omv-m omv-mb-z"
+                   [type]="hint.type"
+                   [hasTitle]="false"
+                   [hasMargin]="false"
+                   [dismissible]="hint.dismissible"
+                   [stateId]="hint.stateId">
+    <span [innerHtml]="hint.text | transloco | nl2br | sanitizeHtml"></span>
+  </omv-alert-panel>
+</div>
 <mat-card [ngClass]="{'omv-display-none': loading || error}">
   <ng-container *ngTemplateOutlet="renderCardHeader"></ng-container>
   <mat-card-content>

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form-page/form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form-page/form-page.component.ts
@@ -445,6 +445,8 @@ export class FormPageComponent
       buttonAlign: 'end',
       buttons: []
     });
+    // Set the default hint properties.
+    this.sanitizeHints();
     // Populate the datamodel identifier field. This must be done here
     // in addition to the `FormComponent`, since the form has not yet
     // been initialized at this point in time and the fields have

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/models/datatable-page-config.type.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/models/datatable-page-config.type.ts
@@ -16,23 +16,26 @@
  * GNU General Public License for more details.
  */
 import { DatatablePageActionConfig } from '~/app/core/components/intuition/models/datatable-page-action-config.type';
+import { PageHintConfig } from '~/app/core/components/intuition/models/page-config.type';
 import { DataStore } from '~/app/shared/models/data-store.type';
 import { DatatableColumn } from '~/app/shared/models/datatable-column.type';
 import { Sorter } from '~/app/shared/models/sorter.type';
 
 export type DatatablePageConfig = {
-  // A title within the header.
+  // A list of hints to be displayed at the top of the page.
+  hints?: Array<PageHintConfig>;
+  // A title within the datatable header.
   title?: string;
-  // A subtitle within the header.
+  // A subtitle within the datatable header.
   subTitle?: string;
-  // An image used as an avatar within the header.
+  // An image used as an avatar within the datatable header.
   icon?: string;
   // An identifier which identifies this datatable uniquely.
   // This is used to store/restore the column state.
   stateId?: string;
   // The name of the property that identifies a row uniquely.
   rowId?: string;
-  // The format string that is used to generate a human readable
+  // The format string that is used to generate a human-readable
   // identifier of a row. This is used, for example, in the delete
   // dialog to enumerate the selected row(s).
   rowEnumFmt?: string;

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/models/form-page-config.type.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/models/form-page-config.type.ts
@@ -17,11 +17,14 @@
  */
 import { FormValues } from '~/app/core/components/intuition/models/form.type';
 import { FormFieldConfig } from '~/app/core/components/intuition/models/form-field-config.type';
+import { PageHintConfig } from '~/app/core/components/intuition/models/page-config.type';
 import { Constraint } from '~/app/shared/models/constraint.type';
 import { ModalDialogConfig } from '~/app/shared/models/modal-dialog-config.type';
 import { TaskDialogConfig } from '~/app/shared/models/task-dialog-config.type';
 
 export type FormPageConfig = {
+  // A list of hints to be displayed at the top of the page.
+  hints?: Array<PageHintConfig>;
   // Specifies a unique ID for the form.
   id?: string;
   // A title within the header.

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/models/page-config.type.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/models/page-config.type.ts
@@ -1,0 +1,31 @@
+/**
+ * This file is part of OpenMediaVault.
+ *
+ * @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+ * @author    Volker Theile <volker.theile@openmediavault.org>
+ * @copyright Copyright (c) 2009-2023 Volker Theile
+ *
+ * OpenMediaVault is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * OpenMediaVault is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+export type PageHintConfig = {
+  // Depending on the type, different icons and colors are used.
+  type?: 'info' | 'warning';
+  // Display a close icon to allow the user to hide the hint.
+  // The state is stored in the browser local storage.
+  dismissible?: boolean;
+  // A unique identifier, e.g. an UUIDv4, that is used to store
+  // the of the hint in the browser local storage. This property
+  // is required when `dismissible` is `true`.
+  stateId?: string;
+  // The text that is displayed.
+  text: string;
+};

--- a/deb/openmediavault/workbench/src/app/pages/services/ssh/ssh-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/ssh/ssh-form-page.component.ts
@@ -35,15 +35,17 @@ export class SshFormPageComponent extends BaseFormPageComponent {
         method: 'set'
       }
     },
-    fields: [
+    hints: [
       {
-        type: 'hint',
+        type: 'info',
         text: gettext(
           'Users must be assigned to the <em>_ssh</em> group to be able to log in via SSH.'
         ),
         dismissible: true,
         stateId: '1f7e0754-e049-4578-9272-8cbb365fad97'
-      },
+      }
+    ],
+    fields: [
       {
         type: 'checkbox',
         name: 'enable',

--- a/deb/openmediavault/workbench/src/app/pages/storage/shared-folders/shared-folder-permissions-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/storage/shared-folders/shared-folder-permissions-datatable-page.component.ts
@@ -40,11 +40,14 @@ export class SharedFolderPermissionsDatatablePageComponent {
     limit: 0,
     hasFooter: false,
     hasSearchField: true,
-    icon: 'information',
-    subTitle: gettext(
-      // eslint-disable-next-line max-len
-      'These settings are used by the services to configure the user and group access rights. Please note that these settings have no effect on file system permissions.'
-    ),
+    hints: [
+      {
+        type: 'info',
+        text: gettext(
+          'These settings are used by the services to configure the user and group access rights. Please note that these settings have no effect on file system permissions.'
+        )
+      }
+    ],
     selectionType: 'none',
     columns: [
       { name: gettext('Name'), prop: 'name', flexGrow: 2, sortable: true },

--- a/deb/openmediavault/workbench/src/app/pages/system/certificates/ssh/ssh-certificate-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/system/certificates/ssh/ssh-certificate-datatable-page.component.ts
@@ -95,11 +95,14 @@ export class SshCertificateDatatablePageComponent {
           type: 'formDialog',
           formDialog: {
             title: gettext('Copy public SSH key'),
-            subTitle: gettext(
-              // eslint-disable-next-line max-len
-              'Installs the public SSH key on a remote system as an authorized key. Make sure password authentication is enabled on that remote system.'
-            ),
             fields: [
+              {
+                type: 'hint',
+                hintType: 'info',
+                text: gettext(
+                  'Installs the public SSH key on a remote system as an authorized key. Make sure password authentication is enabled on that remote system.'
+                )
+              },
               {
                 type: 'hidden',
                 name: 'uuid',

--- a/deb/openmediavault/workbench/src/app/pages/usermgmt/groups/group-shared-folder-permissions-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/usermgmt/groups/group-shared-folder-permissions-datatable-page.component.ts
@@ -41,11 +41,14 @@ export class GroupSharedFolderPermissionsDatatablePageComponent {
     limit: 0,
     hasFooter: false,
     hasSearchField: true,
-    icon: 'information',
-    subTitle: gettext(
-      // eslint-disable-next-line max-len
-      'These settings are used by the services to configure the access rights for the group "{{ _routeParams.name }}". Please note that these settings have no effect on file system permissions.'
-    ),
+    hints: [
+      {
+        type: 'info',
+        text: gettext(
+          'These settings are used by the services to configure the access rights for the group "{{ _routeParams.name }}". Please note that these settings have no effect on file system permissions.'
+        )
+      }
+    ],
     selectionType: 'none',
     columns: [
       { name: gettext('Shared folder'), prop: 'name', flexGrow: 1, sortable: true },

--- a/deb/openmediavault/workbench/src/app/pages/usermgmt/usermgmt-routing.module.ts
+++ b/deb/openmediavault/workbench/src/app/pages/usermgmt/usermgmt-routing.module.ts
@@ -78,6 +78,9 @@ const routes: Routes = [
         component: UserSharedFolderPermissionsDatatablePageComponent,
         data: {
           title: gettext('Permissions'),
+          breadcrumb: {
+            text: '{{ "Permissions" | translate }} @ {{ _routeParams.name }}'
+          },
           notificationTitle: gettext('Updated permissions of user "{{ name }}".')
         }
       }
@@ -119,6 +122,9 @@ const routes: Routes = [
         component: GroupSharedFolderPermissionsDatatablePageComponent,
         data: {
           title: gettext('Permissions'),
+          breadcrumb: {
+            text: '{{ "Permissions" | translate }} @ {{ _routeParams.name }}'
+          },
           notificationTitle: gettext('Updated permissions of group "{{ name }}".')
         }
       }

--- a/deb/openmediavault/workbench/src/app/pages/usermgmt/users/user-shared-folder-permissions-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/usermgmt/users/user-shared-folder-permissions-datatable-page.component.ts
@@ -41,11 +41,14 @@ export class UserSharedFolderPermissionsDatatablePageComponent {
     limit: 0,
     hasFooter: false,
     hasSearchField: true,
-    icon: 'information',
-    subTitle: gettext(
-      // eslint-disable-next-line max-len
-      'These settings are used by the services to configure the access rights for the user "{{ _routeParams.name }}". Please note that these settings have no effect on file system permissions.'
-    ),
+    hints: [
+      {
+        type: 'info',
+        text: gettext(
+          'These settings are used by the services to configure the access rights for the user "{{ _routeParams.name }}". Please note that these settings have no effect on file system permissions.'
+        )
+      }
+    ],
     selectionType: 'none',
     columns: [
       { name: gettext('Shared folder'), prop: 'name', flexGrow: 1, sortable: true },

--- a/deb/openmediavault/workbench/src/app/shared/components/alert-panel/alert-panel.component.html
+++ b/deb/openmediavault/workbench/src/app/shared/components/alert-panel/alert-panel.component.html
@@ -1,5 +1,5 @@
 <mat-card class="alert-{{ type }}"
-          [ngClass]="{'omv-m': hasMargin, 'omv-display-none': dismissed}">
+          [ngClass]="{'omv-m': hasMargin}">
   <div class="omv-display-flex omv-flex-row">
     <mat-icon *ngIf="icon"
               class="alert-icon omv-icon-lg"

--- a/deb/openmediavault/workbench/src/app/shared/components/alert-panel/alert-panel.component.ts
+++ b/deb/openmediavault/workbench/src/app/shared/components/alert-panel/alert-panel.component.ts
@@ -15,7 +15,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, HostBinding, Input, OnInit, Output } from '@angular/core';
 import { marker as gettext } from '@ngneat/transloco-keys-manager/marker';
 import * as _ from 'lodash';
 
@@ -72,6 +72,15 @@ export class AlertPanelComponent implements OnInit {
   public dismissed = false;
 
   constructor(private userLocalStorageService: UserLocalStorageService) {}
+
+  @HostBinding('class')
+  get class(): string {
+    const result: string[] = [];
+    if (this.dismissed) {
+      result.push('omv-display-none');
+    }
+    return result.join(' ');
+  }
 
   ngOnInit(): void {
     if (this.dismissible) {


### PR DESCRIPTION
These hints are displayed above the datatable. These should integrate more beautifully into the UI design than the use of the 'subTitle' property.

![Bildschirmfoto vom 2023-12-29 14-51-22](https://github.com/openmediavault/openmediavault/assets/1897962/e5de039b-24dc-4df2-bb4e-508ede5ba55a)

![grafik](https://github.com/openmediavault/openmediavault/assets/1897962/73ba0ac0-99ba-4da4-84a3-1b1b114d612d)
