### PR TITLE
Add download resolver

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -13,6 +13,11 @@ openmediavault (7.0-24) unstable; urgency=low
     upgraded.
   * Issue #1649: Rearrange the `Storage | Shared Folders | ACL`
     page.
+  * Issue #1676: Add an UI endpoint to trigger a download via RPC.
+    Plugins can use `/download?service=xxx&method=xxx&params=xxx`
+    to start a download that is implemented in the specified RPC.
+    Note, the JSON content of the `params` argument may be encoded.
+    Check the `encodeURIComponent` JS function for more details.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Mon, 24 Jul 2023 13:17:39 +0200
 

--- a/deb/openmediavault/usr/share/php/openmediavault/rpc/proxy/download.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/rpc/proxy/download.inc
@@ -28,12 +28,11 @@ namespace OMV\Rpc\Proxy;
 class Download extends Json {
 	protected function getParams() {
 		$this->params = $_POST;
-		if (empty($this->params))
-			return FALSE;
-		// Decode params field.
-		if (!empty($this->params['params'])) {
-			$this->params['params'] = json_decode(htmlspecialchars_decode(
-			  $this->params['params']), TRUE);
+		// Decode the `params` field.
+		$params = array_value($this->params, "params");
+		if (is_string($params) && !empty($params)) {
+		    $params = htmlspecialchars_decode($params);
+			$this->params['params'] = json_decode($params, TRUE);
 		}
 		return TRUE;
 	}

--- a/deb/openmediavault/workbench/src/app/shared/services/rpc.service.ts
+++ b/deb/openmediavault/workbench/src/app/shared/services/rpc.service.ts
@@ -157,7 +157,9 @@ export class RpcService {
       const body = new URLSearchParams();
       body.set('service', rpcService);
       body.set('method', rpcMethod);
-      body.set('params', JSON.stringify(rpcParams));
+      if (!(_.isUndefined(rpcParams) || _.isNull(rpcParams))) {
+        body.set('params', JSON.stringify(rpcParams));
+      }
       const request = new XMLHttpRequest();
       request.open('POST', 'download.php', true);
       request.responseType = 'blob';


### PR DESCRIPTION
Plugins can now initialize a file download by calling the URL `download?service=XXX&method=XXX&params=XXX` where the query params `service` and `method` are adressing the RPC to be called and `params` contains the RPC parameters as JSON string.

# Example 1
`/download?service=LogFile&method=getContent&params={"id":"syslog"}`

# Example 2
The specification of an action button on a datatable page.
```
{
  type: 'iconButton',
  icon: 'mdi:download',
  tooltip: gettext('Download'),
  execute: {
    type: 'url',
    url: '/download?service=LogFile&method=getContent&params={"id":"syslog"}'
  }
}
```

# Example 3
```
{
  type: 'iconButton',
  icon: 'mdi:download',
  tooltip: gettext('Download'),
  execute: {
    type: 'url',
    url: '/download?service=LogFile&method=getContent&params={{ xxx | encodeuricomponent }}'
  }
}
```

Fixes: https://github.com/openmediavault/openmediavault/issues/1676