### PR TITLE
Add API authentication via HTTP header

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -11,6 +11,10 @@ openmediavault (7.0-25) unstable; urgency=low
   * The `apt-listchanges` package will send you an email with
     a summary of the latest changes whenever packages are
     upgraded.
+  * Add the ability to authenticate an RPC call by using the
+    `X-OPENMEDIAVAULT-SESSIONID` header instead of a cookie.
+    The session ID is returned with the response of the
+    `Session::login` RPC.
   * Issue #1649: Rearrange the `Storage | Shared Folders | ACL`
     page.
   * Issue #1676: Add an UI endpoint to trigger a download via RPC.

--- a/deb/openmediavault/srv/salt/omv/deploy/phpfpm/10webgui.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/phpfpm/10webgui.sls
@@ -60,7 +60,7 @@ configure_phpfpm_webgui:
 
         ; Name of the session (used as cookie name).
         ; http://php.net/session.name
-        php_value[session.name] = X-OPENMEDIAVAULT-SESSIONID
+        php_value[session.name] = OPENMEDIAVAULT-SESSIONID
 
         ; Whether or not to add the httpOnly flag to the cookie, which makes it
         ; inaccessible to browser scripting languages such as JavaScript.

--- a/deb/openmediavault/usr/share/php/openmediavault/session.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/session.inc
@@ -21,6 +21,8 @@
  */
 namespace OMV;
 
+require_once("openmediavault/functions.inc");
+
 /**
  * @ingroup api
  */
@@ -31,8 +33,9 @@ class Session {
 	 */
 	public static function &getInstance() {
 		static $instance = NULL;
-		if (!isset($instance))
+		if (!isset($instance)) {
 			$instance = new Session();
+		}
 		return $instance;
 	}
 
@@ -40,14 +43,25 @@ class Session {
 	 * Start session.
 	 */
 	public function start() {
-		session_start();
+		$sessionId = array_value($_SERVER,
+			"HTTP_X_OPENMEDIAVAULT_SESSIONID", FALSE);
+		if (FALSE !== $sessionId) {
+			session_id($sessionId);
+		}
+		if (FALSE === session_start()) {
+			throw new HttpErrorException(500,
+				_("Failed to start session."));
+		}
 	}
 
 	/**
 	 * Write session data and end session.
 	 */
 	public function commit() {
-		session_commit();
+		if (FALSE === session_commit()) {
+			throw new HttpErrorException(500,
+				_("Failed to write session data."));
+		}
 	}
 
 	/**
@@ -68,10 +82,12 @@ class Session {
 		$_SESSION['authenticated'] = TRUE;
 		$_SESSION['username'] = $username;
 		$_SESSION['role'] = $role;
-		if (array_key_exists("REMOTE_ADDR", $_SERVER))
+		if (array_key_exists("REMOTE_ADDR", $_SERVER)) {
 			$_SESSION['ipaddress'] = $_SERVER['REMOTE_ADDR'];
-		if (array_key_exists("HTTP_USER_AGENT", $_SERVER))
+		}
+		if (array_key_exists("HTTP_USER_AGENT", $_SERVER)) {
 			$_SESSION['useragent'] = $_SERVER['HTTP_USER_AGENT'];
+		}
 		$this->updateLastAccess();
 		return session_id();
 	}
@@ -81,19 +97,15 @@ class Session {
 	 * @return Returns the user role, otherwise FALSE.
 	 */
 	public function getRole() {
-		if (!isset($_SESSION['role']))
-			return FALSE;
-		return $_SESSION['role'];
+		return array_value($_SESSION, "role", FALSE);
 	}
 
 	/**
 	 * Is this session authenticated?
 	 * @return Returns TRUE if the session is authenticated, otherwise FALSE.
 	 */
-	public function isAuthenticated() {
-		if (!isset($_SESSION['authenticated']) || !$_SESSION['authenticated'])
-			return FALSE;
-		return TRUE;
+	public function isAuthenticated(): bool {
+		return array_value($_SESSION, "authenticated", FALSE);
 	}
 
 	/**
@@ -101,9 +113,7 @@ class Session {
 	 * @return Returns the current user name, otherwise FALSE.
 	 */
 	public function getUsername() {
-		if (!isset($_SESSION['username']))
-			return FALSE;
-		return $_SESSION['username'];
+		return array_value($_SESSION, "username", FALSE);
 	}
 
 	/**
@@ -117,9 +127,10 @@ class Session {
 	 * Check if the last access if not older than the defined timeout value.
 	 * @return TRUE if the session is timed out, otherwise FALSE.
 	 */
-	public function isTimeout() {
-		if (!isset($_SESSION['lastaccess']))
+	public function isTimeout(): bool {
+		if (!isset($_SESSION['lastaccess'])) {
 			return FALSE;
+		}
 		try {
 			// Get session timeout from the configuration.
 			$db = &\OMV\Config\Database::getInstance();
@@ -131,8 +142,9 @@ class Session {
 		}
 		// If the timeout value is set the 0 the session timeout
 		// validation is disabled.
-		if (0 == $timeout)
+		if (0 == $timeout) {
 			return FALSE;
+		}
 		return ((time() - $_SESSION['lastaccess']) > $timeout) ? TRUE : FALSE;
 	}
 
@@ -177,10 +189,12 @@ class Session {
 	 * destroyed and an exception is thrown.
 	 */
 	public function validateIpAddress() {
-		if (!array_key_exists("REMOTE_ADDR", $_SERVER))
+		if (!array_key_exists("REMOTE_ADDR", $_SERVER)) {
 			return;
-		if ($_SESSION['ipaddress'] == $_SERVER['REMOTE_ADDR'])
+		}
+		if ($_SESSION['ipaddress'] == $_SERVER['REMOTE_ADDR']) {
 			return;
+		}
 		$this->destroy();
 		throw new HttpErrorException(401, _("Invalid IP address."));
 	}
@@ -190,10 +204,12 @@ class Session {
 	 * is destroyed and an exception is thrown.
 	 */
 	public function validateUserAgent() {
-		if (!array_key_exists("HTTP_USER_AGENT", $_SERVER))
+		if (!array_key_exists("HTTP_USER_AGENT", $_SERVER)) {
 			return;
-		if ($_SESSION['useragent'] == $_SERVER['HTTP_USER_AGENT'])
+		}
+		if ($_SESSION['useragent'] == $_SERVER['HTTP_USER_AGENT']) {
 			return;
+		}
 		$this->destroy();
 		throw new HttpErrorException(401, _("Invalid User-Agent."));
 	}
@@ -211,7 +227,7 @@ class Session {
 	}
 
 	/**
-	 * Dump the current session informations.
+	 * Dump the current session information.
 	 */
 	public function dump() {
 		$this->debug(var_export([

--- a/deb/openmediavault/var/www/openmediavault/rpc/session.inc
+++ b/deb/openmediavault/var/www/openmediavault/rpc/session.inc
@@ -50,6 +50,7 @@ class OMVRpcServiceSession extends \OMV\Rpc\ServiceAbstract {
 		$this->validateMethodParams($params, "rpc.session.login");
 		$authenticated = FALSE;
 		$permissions = [];
+		$sessionId = "";
 		// Strip whitespaces from the user name.
 		if (is_string($params['username'])) {
 			$params['username'] = trim($params['username']);
@@ -74,7 +75,8 @@ class OMVRpcServiceSession extends \OMV\Rpc\ServiceAbstract {
 				// Initialize session.
 				$role = ("admin" == $permissions['role']) ?
 					OMV_ROLE_ADMINISTRATOR : OMV_ROLE_USER;
-				$session->initialize($params['username'], $role);
+				$sessionId = $session->initialize($params['username'],
+					$role);
 			}
 			$authenticated = $session->isAuthenticated();
 			$session->commit();
@@ -83,7 +85,7 @@ class OMVRpcServiceSession extends \OMV\Rpc\ServiceAbstract {
 		// and cookie name.
 		$prd = new \OMV\ProductInfo();
 		$ident = mb_strtolower(sprintf("%s-webgui", $prd->getName()));
-		$prefix = mb_strtoupper(sprintf("X-%s-LOGIN", $prd->getName()));
+		$prefix = mb_strtoupper(sprintf("%s-LOGIN", $prd->getName()));
 		// Open connection to system logger.
 		openlog($ident, LOG_PID | LOG_PERROR, LOG_AUTH);
 		if (TRUE === $authenticated) {
@@ -159,7 +161,8 @@ class OMVRpcServiceSession extends \OMV\Rpc\ServiceAbstract {
 		return [
 			"authenticated" => $authenticated,
 			"username" => $params['username'],
-			"permissions" => $permissions
+			"permissions" => $permissions,
+			"sessionid" => $sessionId
 		];
 	}
 


### PR DESCRIPTION
... in addition to cookies. This should simplify accessing the API for external callers.

- The login RPC responce now contains the current session ID of the user. This can be submitted via a header named `X-OPENMEDIAVAULT-SESSIONID` instead of using a cookie.
- Several functions will now raise an exception when they fail. This might help to identify systems where the root file system is full and PHP can not write the session data.
- Session IDs are valid for 24h if the session is not actively closed via the logout RPC.
