### PR TITLE
Mark `smartmontools` as dirty because hdparm is replaced by smartctl OMV7

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/50-set-dirty-smartmontools
+++ b/deb/openmediavault/usr/share/openmediavault/release-upgrade/post.d/50-set-dirty-smartmontools
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2024 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+
+. /usr/share/openmediavault/scripts/helper-functions
+
+# https://github.com/openmediavault/openmediavault/pull/1692
+omv_module_set_dirty smartmontools
+
+exit 0


### PR DESCRIPTION
See https://github.com/openmediavault/openmediavault/pull/1692
