### PR TITLE
when fstab is modified, systemctl daemon-reload needs to be executed.

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/fstab/default.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/fstab/default.sls
@@ -34,3 +34,7 @@ include:
   - .{{ file | replace('.sls', '') }}
 {% endif %}
 {% endfor %}
+
+systemd-reload:
+  cmd.run:
+   - name: systemctl --system daemon-reload


### PR DESCRIPTION
When trying to remount a filesystem after changing /etc/fstab, this message is displayed.

> mount: (hint) your fstab has been modified, but systemd still uses
>        the old version; use 'systemctl daemon-reload' to reload.

Adding a systemctl --system daemon-reload to the saltstack fstab module to be executed after all fstab changes are made.

Signed-off-by: Aaron Murray <plugins@omv-extras.org>