### PR TITLE
add search field to Shared Folders datatable

### DIFF
--- a/deb/openmediavault/workbench/src/app/pages/storage/shared-folders/shared-folder-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/storage/shared-folders/shared-folder-datatable-page.component.ts
@@ -27,6 +27,7 @@ export class SharedFolderDatatablePageComponent {
   public config: DatatablePageConfig = {
     stateId: 'c0a05d92-2d72-11ea-9b29-33dda9c523cc',
     autoReload: false,
+    hasSearchField: true,
     remoteSorting: true,
     remotePaging: true,
     sorters: [


### PR DESCRIPTION
Add search field to Shared Folders datatable to make finding shared folder(s) easier when there are many setup on a system.

Signed-off-by: Aaron Murray <plugins@omv-extras.org>