### PR TITLE
remove double slashes in shared folder path

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/scripts/helper-functions
+++ b/deb/openmediavault/usr/share/openmediavault/scripts/helper-functions
@@ -816,7 +816,8 @@ omv_get_sharedfolder_path() {
 	xmlstarlet sel -t -m "//system/shares/sharedfolder[uuid='$1']" \
 	  -v "//system/fstab/mntent[uuid=current()/mntentref]/dir" \
 	  -v "concat('/',reldirpath)" \
-	  ${OMV_CONFIG_FILE} | xmlstarlet unesc | omv_rtrim -c "/"
+	  ${OMV_CONFIG_FILE} | xmlstarlet unesc | omv_rtrim -c "/" | \
+	  sed 's/\/\//\//g'
 }
 
 # omv_mkdir_sharedfolder <uuid>


### PR DESCRIPTION
remove double slashes in shared folder path which is typical with a shared folder on the root filesystem (using sharerootfs)

Signed-off-by: Aaron Murray <plugins@omv-extras.org>