### PR TITLE
Update homes.j2

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/samba/files/homes.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/samba/files/homes.j2
@@ -4,7 +4,7 @@
 {%- set force_create_mode = salt['pillar.get']('default:OMV_SAMBA_HOMES_FORCECREATEMODE', '0600') -%}
 {%- set directory_mask = salt['pillar.get']('default:OMV_SAMBA_HOMES_DIRECTORYMASK', '0700') -%}
 {%- set force_directory_mode = salt['pillar.get']('default:OMV_SAMBA_HOMES_FORCEDIRECTORYMODE', '0700') -%}
-{%- set valid_users = salt['pillar.get']('default:OMV_SAMBA_HOMES_VALIDUSERS', '%S') -%}
+{%- set valid_users = salt['pillar.get']('default:OMV_SAMBA_HOMES_VALIDUSERS', '%U') -%}
 {%- set hide_special_files = salt['pillar.get']('default:OMV_SAMBA_HOMES_HIDESPECIALFILES', 'yes') -%}
 {%- set follow_symlinks = salt['pillar.get']('default:OMV_SAMBA_HOMES_FOLLOWSYMLINKS', 'yes') -%}
 {%- set vfs_objects = salt['pillar.get']('default:OMV_SAMBA_HOMES_VFSOBJECTS', '') -%}


### PR DESCRIPTION

Active directory fix. When logging using a AD you login as CORP\username so the folder is CORP/username and that errors out and %U will only set the username

When having Samba connected to an AD DC Server you are required to connect to the server as shown above (CORP\username) which means when you are logged in and you use %S it will show CORP\username and that isn't what you want to create as your home directory (Which would be useful). But that doesn't work when creating a folder. I'm not sure why since I even tried making the folder called HOME (or CORP in the example) and it would still give an error and it would only work when i made the all the folders manually. Home directory would be a great feature on Active Directory if it worked thank you!

example error from samba (HOME = workgroup of ad dc):
[2024/04/13 18:20:23.813679, 0] ../../source3/smbd/smb2_service.c:772(make_connection_snum)
make_connection_snum: canonicalize_connect_path failed for service m.brode, path /home/HOME/username

Signed-off-by: Yew2362 <dev.nuzfk@passinbox.com>