### PR TITLE
Fix VirtualBox support

### DIFF
--- a/vagrant/debian/README.md
+++ b/vagrant/debian/README.md
@@ -15,11 +15,6 @@ $ sudo apt-get install nfs-kernel-server
 $ sudo apt-get install vagrant
 ```
 
-4. Install vagrant-reload plugin (https://github.com/aidanns/vagrant-reload/tree/master)
-```
-$ vagrant plugin install vagrant-reload
-```
-
 # Using libvirt
 
 1. Install

--- a/vagrant/debian/Vagrantfile
+++ b/vagrant/debian/Vagrantfile
@@ -25,34 +25,32 @@ hostname = "omv7box"
 Vagrant.configure("2") do |config|
 	config.vm.box = "debian/bookworm64"
 	config.vm.define hostname
-	config.vm.provision :shell, :path => "patch.sh"
-	config.vm.provision :reload
 	config.vm.provision :shell, :path => "install.sh"
 	config.vm.network "private_network", ip: "192.172.16.24", auto_config: false
 	config.vm.network "private_network", ip: "192.172.16.25"
 	config.vm.hostname = hostname
-	config.vm.provider :virtualbox do |prov|
+	
+	config.vm.provider :virtualbox do |prov, overwrite|
 		prov.name = hostname
 		prov.memory = "4096"
+		
 		# Add some disks.
-		for i in 0..2 do
-			filename = "./disks/#{hostname}-disk#{i}.vmdk"
-			unless File.exist?(filename)
-				prov.customize ["createmedium", "disk", "--filename", filename,
-					"--size", 1000 * 1024]
-				prov.customize ["storageattach", :id, "--storagectl",
-					"SATA Controller", "--port", i + 1, "--device", 0,
-					"--type", "hdd", "--medium", filename]
-			end
+		(0..2).each do |i|
+			overwrite.vm.disk :disk, size: "100GB", name: "#{hostname}-disk-#{i}"
 		end
 	end
-	config.vm.provider :libvirt do |prov|
+	
+	config.vm.provider :libvirt do |prov, overwrite|
+		overwrite.vm.provision :shell, :path => "patch.sh"
+		overwrite.vm.provision :reload
 		prov.memory = "4096"
+		
 		# Add some disks.
 		for i in 0..2 do
 			prov.storage :file, :size => "1G", :bus => "scsi"
 		end
 	end
+	
 	config.vm.synced_folder "../../deb", "/home/vagrant/openmediavault",
 		type: "nfs",
 		nfs_version: 4


### PR DESCRIPTION
The VirtualBox provider did not work as is.

- Made `patch.sh` libvirt only, avoids VirtualBox (re)boot issues
- Use integrated disk support, prevents `VERR_ALREADY_EXISTS` errors

As far as I can tell, the issue addressed with `patch.sh` only applied to libvirt anyway.
The way disk were added caused issues like https://github.com/hashicorp/vagrant/issues/8107. The only 'drawback' of the new way of adding the disks is that they are put in the default VirtualBox location instead of the `disks` folder with the Vagrantfile file.