### PR TITLE
Issue #1751: Handle empty objects correctly

### DIFF
--- a/deb/openmediavault/usr/sbin/omv-engined
+++ b/deb/openmediavault/usr/sbin/omv-engined
@@ -517,12 +517,24 @@ while(FALSE === $sigTerm) {
 			require_once("openmediavault/env.inc");
 
 			try {
-				// Decode JSON string to a PHP array.
-				if (NULL === ($request = json_decode($request, TRUE))) {
+				// Decode JSON string to a PHP object.
+				if (NULL === ($request = json_decode_safe($request))) {
 					throw new \OMV\Exception(
 						"Failed to decode JSON string: %s",
 						json_last_error_msg());
 				}
+
+				// Bring the variable into the expected form.
+				// Note, `params` shouldn't be converted to an array here,
+				// but this will break existing code in core and all plugins, so
+				// the current implementation will be kept for compatibility
+				// reasons.
+				$request = [
+					"service" => $request->service,
+					"method" => $request->method,
+					"params" => (array)$request->params,
+					"context" => (array)$request->context
+				];
 
 				////////////////////////////////////////////////////////////////
 				// Execute RPC.

--- a/deb/openmediavault/usr/sbin/omv-rpc
+++ b/deb/openmediavault/usr/sbin/omv-rpc
@@ -91,13 +91,13 @@ $service = $argv[1];
 $method = $argv[2];
 $params = null;
 
-// Decode RPC method parameters from JSON to a PHP array.
+// Decode RPC method parameters from JSON to a PHP object.
 if($argc > 3) {
 	if(!is_json($argv[3])) {
 		print gettext("ERROR: The params argument is no valid JSON\n");
 		exit(1);
 	}
-	$params = json_decode($argv[3], TRUE);
+	$params = json_decode_safe($argv[3]);
 }
 
 // Execute the RPC and print the response.

--- a/deb/openmediavault/usr/share/php/openmediavault/json/schema.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/json/schema.inc
@@ -391,7 +391,7 @@ class Schema {
 	}
 
 	protected function validateObject($value, $schema, $name) {
-		if (!is_object($value)) {
+		if (!empty($value) && !is_object($value)) {
 			throw new SchemaValidationException(
 				"%s: The value %s is not an object.",
 				$name, json_encode_safe($value));
@@ -612,7 +612,10 @@ class Schema {
 			  "%s: No 'properties' attribute defined.",
 			  $name);
 		}
-		$valueProps = get_object_vars($value);
+		// Note, this is a workaround to process empty objects
+		// correctly that are submitted as arrays because of
+		// historical reasons.
+		$valueProps = !empty($value) ? get_object_vars($value) : [];
 		foreach ($schema['properties'] as $propk => $propv) {
 			// Build the new path. Strip empty parts.
 			$parts = [ $name, $propk ];

--- a/deb/openmediavault/usr/share/php/openmediavault/rpc/rpc.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/rpc/rpc.inc
@@ -46,22 +46,22 @@ class Rpc {
 
 	/**
 	 * Execute the given RPC.
-	 * @param service The name of the service.
-	 * @param method The name of the method.
-	 * @param params The parameters hash object to be passed to the method
-	 *   of the given service.
-	 * @param context The context hash object of the caller containing the
-	 *   fields \em username and \em role.
-	 * @param mode The mode how to execute this RPC. The following modes
-	 *   are available:<ul>
+	 * @param string $service The name of the service.
+	 * @param string $method The name of the method.
+	 * @param array $params The parameters to be passed to the method of
+	 *   the given service.
+	 * @param array $context The context of the caller containing the keys
+	 *   \em username and \em role.
+	 * @param int $mode The mode how to execute this RPC. The following
+	 *   modes are available:<ul>
 	 *   \li MODE_LOCAL
 	 *   \li MODE_REMOTE
 	 *   </ul>
 	 *   Defaults to MODE_LOCAL.
-	 * @param restoreSrvEnv Restore various web server and execution
+	 * @param bool $restoreSrvEnv Restore various web server and execution
 	 *   environment information. This might be helpful in some cases if
 	 *   these information are required in the engine backend. Note, this
-	 *   only takes action when mode is MODE_REMOTE. Defauts to FALSE.
+	 *   only takes action when mode is MODE_REMOTE. Defaults to FALSE.
 	 * @return The RPC response.
 	 */
 	public static function call($service, $method, $params, $context,


### PR DESCRIPTION
Note, the whole handling of the `params` argument of the RPC implementation is faulty, but it can not be fixed without breaking existing code and behavior in core and all existing plugins. Therefore, the current implementation will be retained, even if it is wrong. The error is the processing of the `params` argument. This is not converted and processed as PHP objects but converted into an associative array. As a result, the information is lost as to whether it is an empty object or an empty array.

Relates to: https://github.com/openmediavault/openmediavault/issues/1751


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
