### PR TITLE
Show the drive power state in the drives table

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/diskmgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/diskmgmt.inc
@@ -84,6 +84,7 @@ class DiskMgmt extends \OMV\Rpc\ServiceAbstract {
 				"devicefile" => $sd->getPredictableDeviceFile(),
 				"devicelinks" => $sd->getDeviceFileSymlinks(),
 				"model" => $sd->getModel(),
+				"powerstate" => (($sd instanceof \OMV\System\Storage\StorageDeviceSD) ? $sd->getPowerModeState() : "unknown"),
 				"size" => $sd->getSize(),
 				"description" => $sd->getDescription(),
 				"vendor" => $sd->getVendor(),

--- a/deb/openmediavault/workbench/src/app/pages/storage/disks/disk-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/storage/disks/disk-datatable-page.component.ts
@@ -84,6 +84,33 @@ export class DiskDatatablePageComponent {
         flexGrow: 1,
         sortable: true,
         cellTemplateName: 'binaryUnit'
+      },
+      {
+        name: gettext('Power State'),
+        prop: 'powerstate',
+        flexGrow: 1,
+        sortable: true,
+        cellTemplateName: 'chip',
+        cellTemplateConfig: {
+          map: {
+            "unknown": {
+              value: gettext("Unknown"),
+              class: 'omv-background-color-pair-gray'
+            },
+            "active/idle": {
+              value: gettext("Active/Idle"),
+              class: 'omv-background-color-pair-green'
+            },
+            "standby": {
+              value: gettext("Standby"),
+              class: 'omv-background-color-pair-blue'
+            },
+            "sleeping": {
+              value: gettext("Sleeping"),
+              class: 'omv-background-color-pair-dark'
+            }
+          }
+        }
       }
     ],
     store: {


### PR DESCRIPTION
Basically I'm adding the missing table column to the drives section that had the data gathering already implemented for it in `OMV\System\Storage\StorageDeviceSD`.

I added it to the drives section since it seems that just by going to the SMART section, the drives are spun up because the SMART calls wake them up.

Also, I wanted to mention that, according to some stackoverflow answers there's some hint that `hdparm` might sometimes also wake the drives, and I've seen it recommended to use `smartctl` instead, so maybe it will need to be changed at some point to avoid that. I looked into the `hdparm` issues and changelogs and there's no mention of this problem there, so either no one has reported it, it has been silently fixed, or is still there for some drives. Here's the references to this issue: https://serverfault.com/a/204235 https://serverfault.com/questions/275364/get-drive-power-state-without-waking-it-up 
