### PR TITLE
Refactor disk power mode detection

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,7 @@
 openmediavault (7.3.0-1) stable; urgency=low
 
   * Refactor the RPC parameter handling.
+  * Display `Power Mode` of disks in the `Storage | Disks` page.
   * Issue #1774: Improve foundation for plugins.
   * Refactor UI to get rid of `::ng-deep`, which was an obstacle to
     migrating to Angular >= 15.

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/diskmgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/diskmgmt.inc
@@ -78,6 +78,15 @@ class DiskMgmt extends \OMV\Rpc\ServiceAbstract {
 			// without an inserted media.
 			if (FALSE === $sd->IsMediaAvailable())
 				continue;
+			$powerMode = "UNKNOWN";
+			$temperature = FALSE;
+			if (TRUE === $sd->hasSmartSupport()) {
+				$si = $sd->getSmartInformation();
+				$si->setPowerMode("standby");
+				$info = $si->getInformation();
+				$powerMode = array_value($info, "powermodeis", "UNKNOWN");
+				$temperature = $si->getTemperature();
+			}
 			$objects[] = [
 				"devicename" => $sd->getDeviceName(),
 				"canonicaldevicefile" => $sd->getCanonicalDeviceFile(),
@@ -92,7 +101,10 @@ class DiskMgmt extends \OMV\Rpc\ServiceAbstract {
 				"israid" => $sd->isRaid(),
 				"isroot" => \OMV\System\System::isRootDeviceFile(
 					$sd->getCanonicalDeviceFile(), FALSE),
-				"isreadonly" => $sd->isReadOnly()
+				"isreadonly" => $sd->isReadOnly(),
+				"powermode" => $powerMode,
+				"temperature" => (FALSE === $temperature) ?
+					"" : $temperature,
 			];
 		}
 		return $objects;

--- a/deb/openmediavault/usr/share/openmediavault/locale/openmediavault.pot
+++ b/deb/openmediavault/usr/share/openmediavault/locale/openmediavault.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-16 08:34+0200\n"
+"POT-Creation-Date: 2024-06-21 22:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -264,6 +264,9 @@ msgid "Action"
 msgstr ""
 
 msgid "Activate S.M.A.R.T. monitoring for this device. Note that only monitored devices are listed in the scheduled tasks. Monitoring cannot be switched off as long as there are scheduled tasks for this device."
+msgstr ""
+
+msgid "Active"
 msgstr ""
 
 msgid "Add"
@@ -2295,6 +2298,9 @@ msgid "Power"
 msgstr ""
 
 msgid "Power Management"
+msgstr ""
+
+msgid "Power Mode"
 msgstr ""
 
 msgid "Power Off"

--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/smartinformation.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/smartinformation.inc
@@ -28,6 +28,7 @@ namespace OMV\System\Storage;
  */
 class SmartInformation {
 	protected $sd = NULL;
+	protected $powerMode = NULL;
 	private $cmdOutput = NULL;
 	private $dataCached = FALSE;
 	private $dataCachedKind = NULL;
@@ -149,6 +150,10 @@ class SmartInformation {
 			$cmdArgs[] = "--health";
 			$cmdArgs[] = "--log=selftest";
 		}
+		if (!is_null($this->powerMode)) {
+			$cmdArgs[] = sprintf("--nocheck=%s", escapeshellarg(
+				$this->powerMode));
+		}
 		if (!empty($this->sd->getSmartDeviceType())) {
 			$cmdArgs[] = sprintf("--device=%s", $this->sd->getSmartDeviceType());
 		}
@@ -178,6 +183,18 @@ class SmartInformation {
 	public function refresh() {
 		$this->dataCached = FALSE;
 		$this->getData($this->dataCachedKind);
+	}
+
+	/**
+	 * Set the power mode that is used for the `--nocheck=POWERMODE` smartctl
+	 * command line option.
+	 * @see https://www.smartmontools.org/browser/trunk/smartmontools/smartctl.8.in#n
+	 * @param string $powerMode The power mode, e.g. `never`, `sleep`,
+	 *   `standby` or `idle`. Defaults to NULL.
+	 * @return void
+	 */
+	public function setPowerMode($powerMode = NULL) {
+		$this->powerMode = $powerMode;
 	}
 
 	/**
@@ -355,6 +372,7 @@ class SmartInformation {
 		// Local Time is:    Tue Mar 11 10:18:42 2014 CET
 		// SMART support is: Available - device has SMART capability.
 		// SMART support is: Enabled
+		// Power mode is:    ACTIVE
 		//
 		// === START OF READ SMART DATA SECTION ===
 		// ...

--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevicesd.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevicesd.inc
@@ -31,42 +31,6 @@ class StorageDeviceSD extends StorageDevice implements SmartInterface {
 	use SmartTrait;
 
 	/**
-	 * Get the current power mode status.
-	 * @return string The current power mode status which can be
-	 *   <ul>
-	 *   \li unknown
-	 *   \li active/idle
-	 *   \li standby
-	 *   \li sleeping
-	 *   </ul>
-	 * @throw \OMV\ExecException
-	 */
-	public function getPowerModeState() {
-		$result = "unknown";
-		// Get the current power mode status.
-		$cmdArgs = [];
-		$cmdArgs[] = "-C";
-		$cmdArgs[] = escapeshellarg($this->getDeviceFile());
-		$cmd = new \OMV\System\Process("hdparm", $cmdArgs);
-		$cmd->setRedirect2to1();
-		$cmd->execute($output);
-		// Parse command output:
-		// /dev/sda:
-		//  drive state is:  active/idle
-		//
-		// /dev/sdb:
-		//  drive state is:  standby
-		foreach ($output as $outputk => $outputv) {
-			$regex = "/^\s+drive state is:\s+(\S+)$/i";
-			if (1 == preg_match($regex, $outputv, $matches)) {
-				$result = $matches[1];
-				break;
-			}
-		}
-		return $result;
-	}
-
-	/**
 	 * See \OMV\System\Storage\SmartInterface interface definition.
 	 */
 	public function getSmartDeviceType() {

--- a/deb/openmediavault/workbench/src/app/pages/storage/disks/disk-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/storage/disks/disk-datatable-page.component.ts
@@ -84,6 +84,46 @@ export class DiskDatatablePageComponent {
         flexGrow: 1,
         sortable: true,
         cellTemplateName: 'binaryUnit'
+      },
+      {
+        name: gettext('Power Mode'),
+        prop: 'powermode',
+        flexGrow: 1,
+        sortable: true,
+        hidden: true,
+        cellTemplateName: 'chip',
+        cellTemplateConfig: {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          map: {
+            ACTIVE: {
+              value: gettext('Active'),
+              class: 'omv-background-color-pair-orange'
+            },
+            IDLE: {
+              value: gettext('Idle'),
+              class: 'omv-background-color-pair-yellow'
+            },
+            STANDBY: {
+              value: gettext('Standby'),
+              class: 'omv-background-color-pair-blue'
+            },
+            SLEEP: {
+              value: gettext('Sleep'),
+              class: 'omv-background-color-pair-green'
+            },
+            UNKNOWN: {
+              value: gettext('Unknown'),
+              class: 'omv-background-color-pair-gray'
+            }
+          }
+        }
+      },
+      {
+        name: gettext('Temperature'),
+        prop: 'temperature',
+        flexGrow: 1,
+        sortable: true,
+        hidden: true
       }
     ],
     store: {
@@ -93,6 +133,9 @@ export class DiskDatatablePageComponent {
           method: 'getListBg',
           task: true
         }
+      },
+      transform: {
+        temperature: '{% if temperature %}{{ temperature }} °C{% endif %}'
       }
     },
     actions: [


### PR DESCRIPTION
`hdparm` has been removed previously, so the current implementation does not work anymore. `smartctl` will replace `hdparm` to detect the power mode of a disk.

- Add `Power Mode` column to `Storage | Disks` page.
- Add `Temperature` column to `Storage | Disks` page (since the SMART values have already been read out anyway and it therefore costs nothing).

Please note that not all power modes may be displayed correctly as they are not specified in `map`; this may affect NVMe devices in particular. These power modes must then be added subsequently.

Superseeds: https://github.com/openmediavault/openmediavault/pull/1779


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
