### PR TITLE
Fix crash reading the config when a list of objects is empty

### DIFF
--- a/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/config/database.py
+++ b/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/config/database.py
@@ -445,8 +445,13 @@ class DatabaseQuery(abc.ABC):
                     # Convert existing entry into a list.
                     result[tag] = [result[tag], value]
                 except KeyError:
-                    # Add a new entry.
-                    result[tag] = [value]
+                    if value == "":
+                        # Create an empty list if the value is an empty string.
+                        result[tag] = []
+                    else:
+                        # Add a new entry.
+                        result[tag] = [value]
+
             elif tag in self._force_dict_tags and value == "":
                 # Create an empty dictionary if value is an empty string.
                 result[tag] = {}


### PR DESCRIPTION
I noticed that for a datamodel defining a list of objects, if the config database is queried for that datamodel when the list is empty, the program crashes with:

```
Traceback (most recent call last):
  File "/usr/sbin/omv-confdbadm", line 76, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/sbin/omv-confdbadm", line 72, in main
    return cmd_inst.execute(*sys.argv)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/openmediavault/confdbadm/commands.d/read.py", line 73, in execute
    objs = db.get(cmd_args.id, cmd_args.uuid)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/openmediavault/config/database.py", line 85, in get
    query.execute()
  File "/usr/lib/python3/dist-packages/openmediavault/config/database.py", line 735, in execute
    self._response = self._elements_to_object(elements)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/openmediavault/config/database.py", line 493, in _elements_to_object
    result.validate()
  File "/usr/lib/python3/dist-packages/openmediavault/config/object.py", line 236, in validate
    self.model.validate(self.get_dict())
  File "/usr/lib/python3/dist-packages/openmediavault/config/datamodel.py", line 202, in validate
    self.schema.validate(data)
  File "/usr/lib/python3/dist-packages/openmediavault/json/schema.py", line 175, in validate
    self._validate_type(value, schema, name)
  File "/usr/lib/python3/dist-packages/openmediavault/json/schema.py", line 230, in _validate_type
    raise last_exception
  File "/usr/lib/python3/dist-packages/openmediavault/json/schema.py", line 201, in _validate_type
    self._validate_object(value, schema, name)
  File "/usr/lib/python3/dist-packages/openmediavault/json/schema.py", line 306, in _validate_object
    self._check_properties(value, schema, name)
  File "/usr/lib/python3/dist-packages/openmediavault/json/schema.py", line 521, in _check_properties
    self._validate_type(value[propk], propv, path)
  File "/usr/lib/python3/dist-packages/openmediavault/json/schema.py", line 230, in _validate_type
    raise last_exception
  File "/usr/lib/python3/dist-packages/openmediavault/json/schema.py", line 195, in _validate_type
    self._validate_array(value, schema, name)
  File "/usr/lib/python3/dist-packages/openmediavault/json/schema.py", line 297, in _validate_array
    self._check_items(value, schema, name)
  File "/usr/lib/python3/dist-packages/openmediavault/json/schema.py", line 549, in _check_items
    self._validate_type(itemv, schema['items'], path)
  File "/usr/lib/python3/dist-packages/openmediavault/json/schema.py", line 230, in _validate_type
    raise last_exception
  File "/usr/lib/python3/dist-packages/openmediavault/json/schema.py", line 201, in _validate_type
    self._validate_object(value, schema, name)
  File "/usr/lib/python3/dist-packages/openmediavault/json/schema.py", line 301, in _validate_object
    raise SchemaValidationException(
openmediavault.json.schema.SchemaValidationException: drives[0]: The value '' is not an object.
```

Because in the reader, None values are converted to empty string, and then that value is added into a list as if it wasn't actually an empty list but a list with an empty string inside.

This solution might break a different kind of use case though: if a list of strings is defined, then this would skip the first string if it's the empty string. I think that problem might be less common, but solving it would require checking the model schema for the type of the sub-elements and act according to that.

Not directly related to this, but when debugging the file I also noticed a possible issue, but not sure if it really is: `_force_list_tags` and `_force_dict_tags` seem to keep just the name of the tag that should be a list, not the path, so it might be that if a name is repeated in different places of the same datamodel, objects could be converted to lists inadvertently.