### PR TITLE
Add support for basic auth

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/rpc/proxy/json.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/rpc/proxy/json.inc
@@ -101,10 +101,23 @@ class Json {
 	}
 
 	/**
+	 * Set the RPC parameters.
+	 * Note, this is only for internal use.
+	 */
+	public function setParams($params) {
+		if (is_assoc_array($params)) {
+			$this->params = $params;
+		}
+	}
+
+	/**
 	 * Get the RPC parameters from POST or GET.
 	 * @return TRUE if successful, otherwise FALSE.
 	 */
 	protected function getParams() {
+		if (is_assoc_array($this->params)) {
+			return TRUE;
+		}
 		if (!empty($_GET)) {
 			$this->params = [];
 		 	foreach ($_GET as $key => $value) {

--- a/deb/openmediavault/var/www/openmediavault/login.php
+++ b/deb/openmediavault/var/www/openmediavault/login.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of OpenMediaVault.
+ *
+ * @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+ * @author    Volker Theile <volker.theile@openmediavault.org>
+ * @copyright Copyright (c) 2009-2024 Volker Theile
+ *
+ * OpenMediaVault is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * OpenMediaVault is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
+ */
+try {
+	require_once("openmediavault/autoloader.inc");
+	require_once("openmediavault/env.inc");
+	require_once("openmediavault/functions.inc");
+
+	if (!(isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW']))) {
+		header("WWW-Authenticate: Basic");
+		http_response_code(401);
+		die("Authentication required");
+	}
+
+	// Load and initialize the RPC services that are not handled by the
+	// engine daemon.
+	$directory = build_path(DIRECTORY_SEPARATOR, \OMV\Environment::get(
+		"OMV_DOCUMENTROOT_DIR"), "rpc");
+	foreach (listdir($directory, "inc") as $path) {
+		require_once $path;
+	}
+	$rpcServiceMngr = &\OMV\Rpc\ServiceManager::getInstance();
+	$rpcServiceMngr->initializeServices();
+
+	$session = &\OMV\Session::getInstance();
+	$session->start();
+
+	$server = new \OMV\Rpc\Proxy\Json();
+	$server->setParams([
+		"service" => "Session",
+		"method" => "login",
+		"params" => [
+			"username" => $_SERVER['PHP_AUTH_USER'],
+			"password" => $_SERVER['PHP_AUTH_PW']
+		]
+	]);
+	$server->handle();
+} catch(\Exception $e) {
+	http_response_code(($e instanceof \OMV\BaseException) ?
+		$e->getHttpStatusCode() : 500);
+	die($e->getMessage());
+} finally {
+	if (isset($server)) {
+		$server->cleanup();
+	}
+}
+?>


### PR DESCRIPTION
- Add new login.php endpoint

To trigger a login, simply call `curl http://omv7box.local/login.php -u "admin:admin"` from a command line or an equal call via Python request/whatever.

On successful log in the following response will be returned:
```
{"response":{"authenticated":true,"username":"admin","permissions":"role":"admin"},"sessionid":"5o0lbvnsbr6r1dt6ql4hm5v3be"},"error":null}
```
The session ID is only returned at the first log in attempt of a user. It is also submitted via
```
Set-Cookie OPENMEDIAVAULT-SESSIONID=5o0lbvnsbr6r1dt6ql4hm5v3be; path=/; HttpOnly; SameSite=Strict
```
header.

The session ID can be sent via the `X-OPENMEDIAVAULT-SESSIONID` header or cookie on all following RPC requests.

Fixes: https://github.com/openmediavault/openmediavault/issues/1747


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
