### PR TITLE
Leave "ipv6-privacy" options in netplan to system defaults

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/bond.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/bond.j2
@@ -51,9 +51,6 @@ network:
 {%- if interface.method6 == "static" %}
       accept-ra: false
 {%- endif %}
-{%- if interface.method6 in ["static", "auto"] %}
-      ipv6-privacy: true
-{%- endif %}
 {%- if interface.method == "manual" and interface.method6 == "manual" %}
       addresses: []
 {%- endif %}

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/bridge.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/bridge.j2
@@ -51,9 +51,6 @@ network:
 {%- if interface.method6 == "static" %}
       accept-ra: false
 {%- endif %}
-{%- if interface.method6 in ["static", "auto"] %}
-      ipv6-privacy: true
-{%- endif %}
 {%- if interface.method == "manual" and interface.method6 == "manual" %}
       addresses: []
 {%- endif %}

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/ethernet.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/ethernet.j2
@@ -44,9 +44,6 @@ network:
 {%- if interface.method6 == "static" %}
       accept-ra: false
 {%- endif %}
-{%- if interface.method6 in ["static", "auto"] %}
-      ipv6-privacy: true
-{%- endif %}
 {%- if interface.method == "manual" and interface.method6 == "manual" %}
       addresses: []
 {%- endif %}

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/vlan.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/vlan.j2
@@ -37,9 +37,6 @@ network:
 {%- if interface.method6 == "static" %}
       accept-ra: false
 {%- endif %}
-{%- if interface.method6 in ["static", "auto"] %}
-      ipv6-privacy: true
-{%- endif %}
 {%- if interface.method == "manual" and interface.method6 == "manual" %}
       addresses: []
 {%- endif %}

--- a/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/wifi.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/systemd-networkd/netplan/files/wifi.j2
@@ -37,9 +37,6 @@ network:
 {%- if interface.method6 == "static" %}
       accept-ra: false
 {%- endif %}
-{%- if interface.method6 in ["static", "auto"] %}
-      ipv6-privacy: true
-{%- endif %}
 {%- if interface.method == "manual" and interface.method6 == "manual" %}
       addresses: []
 {%- endif %}


### PR DESCRIPTION
### Leave "ipv6-privacy" options in netplan to system defaults (either /etc/sysctl.conf or /etc/systemd/network/...) instead of manually overriding without any option for users to change.

OMV lacks an option to enable/disable IPv6 privacy extensions. Currently it overrides privacy extensions for every interface to be set enabled. Since there is no option, it should leave it at the default values set by either /etc/sysctl.conf or configuration files in /etc/systemd/network/ instead of trying to enforce them to be enabled.