### PR TITLE
Enable TLS Encryption for MinIO's API Endpoint via Caddy

### DIFF
--- a/deb/openmediavault-s3/srv/salt/omv/deploy/minio/files/Caddyfile.j2
+++ b/deb/openmediavault-s3/srv/salt/omv/deploy/minio/files/Caddyfile.j2
@@ -11,3 +11,12 @@
     header_down X-XSS-Protection "1; mode=block"
   }
 }
+:9000 {
+  tls /data/cert.crt /data/cert.key
+  header -Server
+  reverse_proxy http://minio-app:8081 {
+    header_down X-Frame-Options "SAMEORIGIN"
+    header_down X-Content-Type-Options "nosniff"
+    header_down X-XSS-Protection "1; mode=block"
+  }
+}

--- a/deb/openmediavault-s3/srv/salt/omv/deploy/minio/files/container-minio-app.service.j2
+++ b/deb/openmediavault-s3/srv/salt/omv/deploy/minio/files/container-minio-app.service.j2
@@ -22,7 +22,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/container-minio-app.pid %t/container-minio-app.ctr-id
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/container-minio-app.pid --cidfile %t/container-minio-app.ctr-id --cgroups=no-conmon --pod-id-file %t/pod-minio.pod-id -d --replace --pull=never --name=minio-app -u {{ uid }}:{{ gid }} -e MINIO_ROOT_USER="{{ config.rootname }}" -e MINIO_ROOT_PASSWORD="{{ config.rootpassword }}" -v "{{ sf_path }}":/data/ {{ options }} {{ image }} server /data/ --address ":9000" --console-address ":{{ ssl_enabled | yesno('8080,9001') }}" {{ cmd_args }}
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/container-minio-app.pid --cidfile %t/container-minio-app.ctr-id --cgroups=no-conmon --pod-id-file %t/pod-minio.pod-id -d --replace --pull=never --name=minio-app -u {{ uid }}:{{ gid }} -e MINIO_ROOT_USER="{{ config.rootname }}" -e MINIO_ROOT_PASSWORD="{{ config.rootpassword }}" -v "{{ sf_path }}":/data/ {{ options }} {{ image }} server /data/ --address ":{{ ssl_enabled | yesno('8081,9000') }}" --console-address ":{{ ssl_enabled | yesno('8080,9001') }}" {{ cmd_args }}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/container-minio-app.ctr-id
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/container-minio-app.ctr-id
 PIDFile=%t/container-minio-app.pid


### PR DESCRIPTION
This pull request introduces TLS encryption for MinIO's API endpoint using Caddy when TLS is enabled for the OMV7 web GUI. The same certificate used for the web GUI will be employed for MinIO, ensuring a consistent and secure setup.

#### Changes
- Configured Caddy to serve MinIO's API endpoint with TLS when TLS is enabled for the OMV7 web GUI.
- Updated the configuration to use the same TLS certificate and key as the web GUI, ensuring consistency and reducing the need for additional certificate management.

#### Benefits
- Enhances security by encrypting traffic to MinIO's API endpoint.
- Simplifies the configuration process by reusing the existing TLS certificate and key from the web GUI.
- Provides a seamless and secure experience for users accessing MinIO via HTTPS.

#### Testing
- Verified that MinIO's API endpoint is accessible via HTTPS when TLS is enabled for the web GUI.
- Confirmed that the same certificate used for the web GUI is correctly applied to MinIO.
- Ensured no disruption to existing services and configurations.

#### Notes
- Users must have TLS enabled for the OMV7 web GUI for this configuration to take effect.
