### PR TITLE
Quote shared folder paths only

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/rsync/files/cron-rsync-script.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/rsync/files/cron-rsync-script.j2
@@ -74,7 +74,17 @@ rsync --verbose --log-file="{{ logfile }}"
 {%- if job.optionxattrs | to_bool %}{{ separator }}--xattrs{%- endif %}
 {%- if job.optionpartial | to_bool %}{{ separator }}--partial{%- endif %}
 {%- if job.extraoptions | length > 0 %}{{ separator }}{{ job.extraoptions }}{%- endif -%}
-{{ separator }}"{{ srcuri }}" "{{ desturi }}" & wait $!
+{%- if job.type == 'local' -%}
+  {%- set srcuri = srcuri | quote -%}
+  {%- set desturi = desturi | quote -%}
+{%- elif job.type == 'remote' -%}
+  {%- if job.mode == 'push' -%}
+    {%- set srcuri = srcuri | quote -%}
+  {%- elif job.mode == 'pull' -%}
+    {%- set desturi = desturi | quote -%}
+  {%- endif -%}
+{%- endif -%}
+{{ separator }}{{ srcuri }}{{ separator }}{{ desturi }} & wait $!
 {%- if not job.optionquiet | to_bool %}
 if [ $? -eq 0 ]; then
     omv_log "The synchronisation has completed successfully."


### PR DESCRIPTION
... otherwise rsync arguments like `user@host:/dir1 :/dir2 :/dir3` will get quoted as well.

Fixes: https://github.com/openmediavault/openmediavault/issues/1801


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
