### PR TITLE
Update hostname format check to RFC1123

### DIFF
--- a/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/json/schema.py
+++ b/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/json/schema.py
@@ -415,7 +415,7 @@ class Schema:
                 )
         elif schema['format'] in ["host-name", "hostname"]:
             if not re.match(
-                r'^[a-zA-Z]([-a-zA-Z0-9]{0,61}[a-zA-Z0-9])?$', value
+                r'^[a-zA-Z0-9]([-a-zA-Z0-9]{0,61}[a-zA-Z0-9])?$', value
             ):
                 raise SchemaValidationException(
                     name, "The value '%s' is not a valid hostname." % value


### PR DESCRIPTION
RFC1123 clearly states that hostnames may start with a digit: https://www.rfc-editor.org/rfc/rfc1123.html#page-13 "...software MUST support this..."

Updating format regex to allow installation of OMV on a host named in this way


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
