### PR TITLE
Add `OMV_FSTAB_MNTOPS_REISERFS` and `OMV_FSTAB_MNTOPS_REISER4` env variables

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,8 @@
 openmediavault (7.4.14-1) stable; urgency=low
 
-  *
+  * Add rudimentary support for the obsolete file systems `reiserfs`
+    and `reiser4`. The userland apps must be installed manually via
+    the Debian packages `reiserfsprogs` and `reiser4progs`.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Mon, 18 Nov 2024 15:02:55 +0100
 

--- a/deb/openmediavault/usr/share/php/openmediavault/globals.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/globals.inc
@@ -90,6 +90,8 @@ define("OMV_NETWORK_INTERFACE_TYPE_ALL", 0xFF);
 \OMV\Environment::set("OMV_FSTAB_MNTOPS_UDF", "ro");
 \OMV\Environment::set("OMV_FSTAB_MNTOPS_BIND", "nofail");
 \OMV\Environment::set("OMV_FSTAB_MNTOPS_F2FS", "defaults,nofail,user_xattr,usrjquota=aquota.user,grpjquota=aquota.group,jqfmt=vfsv1"); // https://www.kernel.org/doc/Documentation/filesystems/f2fs.txt
+\OMV\Environment::set("OMV_FSTAB_MNTOPS_REISERFS", "defaults,nofail,user_xattr,acl");
+\OMV\Environment::set("OMV_FSTAB_MNTOPS_REISER4", "defaults,nofail,txmod=journal");
 \OMV\Environment::set("OMV_APT_PLUGINS_INDEX_FILE", "/var/lib/openmediavault/apt/pluginsindex.json");
 \OMV\Environment::set("OMV_APT_UPGRADE_INDEX_FILE", "/var/lib/openmediavault/apt/upgradeindex.json");
 \OMV\Environment::set("OMV_DUNE_QUOTES", [ // http://www.nightsolo.net/dune/god.html

--- a/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/backend/reiser4.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/backend/reiser4.inc
@@ -23,13 +23,15 @@ namespace OMV\System\Filesystem\Backend;
 
 /**
  * References:
- * - https://en.wikipedia.org/wiki/ReiserFS
+ * - https://en.wikipedia.org/wiki/Reiser4
+ * - https://archive.kernel.org/oldwiki/reiser4.wiki.kernel.org/
+ * - https://wiki.archlinux.org/title/Reiser4/
  */
-class Reiserfs extends BackendAbstract {
+class Reiser4 extends BackendAbstract {
 	public function __construct() {
-		$this->type = "reiserfs";
-		$this->properties = self::PROP_MNTENT | self::PROP_POSIX_ACL;
+		$this->type = "reiser4";
+		$this->properties = self::PROP_MNTENT;
 		$this->mntOptions = explode(",", \OMV\Environment::get(
-			"OMV_FSTAB_MNTOPS_REISERFS"));
+			"OMV_FSTAB_MNTOPS_REISER4"));
 	}
 }


### PR DESCRIPTION
Use mount options that fit for most users. Power users can use the openmediavault-mounteditor (https://github.com/OpenMediaVault-Plugin-Developers/openmediavault-mounteditor) to adapt them to their needs.

Note, the filesystems can be mounted only when the `reiserfsprogs` and `reiser4progs` packages are installed. These package will not be installed by default.

[Bildschirmaufzeichnung vom 2024-11-19 13-38-19.webm](https://github.com/user-attachments/assets/52f6dc10-f26d-4014-88fe-d4ee140b5280)

<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
