### PR TITLE
Use LC_ALL locale environment variable instead of LANG

### DIFF
--- a/deb/openmediavault-diskstats/debian/changelog
+++ b/deb/openmediavault-diskstats/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-diskstats (7.0.2-1) stable; urgency=low
+
+  * Issue #1862: Use LC_ALL environment variable instead of LANG.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Mon, 25 Nov 2024 13:25:35 +0100
+
 openmediavault-diskstats (7.0.1-2) stable; urgency=low
 
   * Update locale files.

--- a/deb/openmediavault-diskstats/debian/openmediavault-diskstats.postinst
+++ b/deb/openmediavault-diskstats/debian/openmediavault-diskstats.postinst
@@ -27,7 +27,7 @@ set -e
 case "$1" in
 	configure)
 		if [ -z "$2" ]; then
-			LANG=C.UTF-8 omv-salt deploy run --no-color --quiet collectd || :
+			LC_ALL=C.UTF-8 omv-salt deploy run --no-color --quiet collectd || :
 		fi
 
 		########################################################################

--- a/deb/openmediavault-k8s/debian/changelog
+++ b/deb/openmediavault-k8s/debian/changelog
@@ -5,6 +5,7 @@ openmediavault-k8s (7.4.2-1) stable; urgency=low
     an upgrade, create the file `/var/lib/openmediavault/upgrade_k3s`
     and run `omv-salt deploy run k3s`.
   * Fix Traefik port configuration issue.
+  * Issue #1862: Use LC_ALL environment variable instead of LANG.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Tue, 19 Nov 2024 10:43:47 +0100
 

--- a/deb/openmediavault-k8s/debian/openmediavault-k8s.postinst
+++ b/deb/openmediavault-k8s/debian/openmediavault-k8s.postinst
@@ -46,7 +46,7 @@ case "$1" in
 		########################################################################
 		if [ -z "$2" ]; then
 			echo "Installing k3s ..."
-			LANG=C.UTF-8 omv-salt deploy run --no-color --quiet k3s || :
+			LC_ALL=C.UTF-8 omv-salt deploy run --no-color --quiet k3s || :
 		fi
 
 		########################################################################

--- a/deb/openmediavault-md/debian/changelog
+++ b/deb/openmediavault-md/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-md (7.0.3-1) stable; urgency=low
+
+  * Issue #1862: Use LC_ALL environment variable instead of LANG.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Mon, 25 Nov 2024 13:25:53 +0100
+
 openmediavault-md (7.0.2-1) stable; urgency=low
 
   * Relocate mdadm cron job into this plugin.

--- a/deb/openmediavault-md/etc/cron.daily/openmediavault-mdadm
+++ b/deb/openmediavault-md/etc/cron.daily/openmediavault-mdadm
@@ -21,7 +21,7 @@
 MAILTO=""
 MDADM=/sbin/mdadm
 
-export LANG=C
+export LC_ALL=C.UTF-8
 
 set -eu
 

--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -4,6 +4,7 @@ openmediavault (7.4.14-1) stable; urgency=low
     and `reiser4`. The userland apps must be installed manually via
     the Debian packages `reiserfsprogs` and `reiser4progs`.
   * Issue #1859: Fix a problem when disabling the user home directory.
+  * Issue #1862: Use LC_ALL environment variable instead of LANG.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Mon, 18 Nov 2024 15:02:55 +0100
 

--- a/deb/openmediavault/debian/openmediavault.postinst
+++ b/deb/openmediavault/debian/openmediavault.postinst
@@ -243,7 +243,7 @@ case "$1" in
 
 			# Deploy the configuration for various services.
 			echo "Deploying service configurations ..."
-			LANG=C.UTF-8 omv-salt deploy run --no-color --quiet \
+			LC_ALL=C.UTF-8 omv-salt deploy run --no-color --quiet \
 				apt apticron cpufrequtils chrony rsyslog \
 				watchdog monit rrdcached avahi ssh nginx collectd \
 				phpfpm issue sysctl systemd systemd-logind || :
@@ -266,7 +266,7 @@ case "$1" in
 			# - collectd: uptime plugin has been added
 			# - chrony: The ntp replacement
 			# - postfix: Config must be recreated
-			LANG=C.UTF-8 omv-salt deploy run --no-color --quiet collectd chrony postfix || :
+			LC_ALL=C.UTF-8 omv-salt deploy run --no-color --quiet collectd chrony postfix || :
 		fi
 		if dpkg --compare-versions "$2" lt-nl "5.1.3"; then
 			omv_module_set_dirty monit
@@ -329,7 +329,7 @@ case "$1" in
 			omv_module_set_dirty samba
 		fi
 		if dpkg --compare-versions "$2" lt-nl "5.6.3"; then
-			LANG=C.UTF-8 omv-salt deploy run --no-color --quiet apt cronapt || :
+			LC_ALL=C.UTF-8 omv-salt deploy run --no-color --quiet apt cronapt || :
 		fi
 		if dpkg --compare-versions "$2" lt-nl "5.6.6"; then
 			useradd --system --user-group --no-create-home \
@@ -366,7 +366,7 @@ case "$1" in
 			omv_module_set_dirty samba
 		fi
 		if dpkg --compare-versions "$2" lt-nl "6.0"; then
-			LANG=C.UTF-8 omv-salt deploy run --no-color --quiet nginx rsyslog phpfpm || :
+			LC_ALL=C.UTF-8 omv-salt deploy run --no-color --quiet nginx rsyslog phpfpm || :
 		fi
 		if dpkg --compare-versions "$2" lt-nl "6.0.1"; then
 			omv_module_set_dirty nfs
@@ -550,7 +550,7 @@ case "$1" in
 		fi
 		if dpkg --compare-versions "$2" lt-nl "7.4.12"; then
 			# Convert existing diversions created by the `divert_add` Salt state.
-			for file in $(LANG=C dpkg-divert --list | grep -oP '(?<=local diversion of )[^\s]+'); do
+			for file in $(LC_ALL=C.UTF-8 dpkg-divert --list | grep -oP '(?<=local diversion of )[^\s]+'); do
 				dpkg-divert --local --no-rename --remove "${file}" || :
 				_divert_to="/tmp/$(echo "${file}" | sed 's|/|_|g')"
 				dpkg-divert --add --local --no-rename --divert "${_divert_to}" "${file}" || :

--- a/deb/openmediavault/etc/cron.daily/openmediavault-check_btrfs_errors
+++ b/deb/openmediavault/etc/cron.daily/openmediavault-check_btrfs_errors
@@ -20,7 +20,7 @@
 # along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
 MAILTO=""
 
-export LANG=C
+export LC_ALL=C.UTF-8
 
 . /etc/default/openmediavault
 . /usr/share/openmediavault/scripts/helper-functions

--- a/deb/openmediavault/etc/cron.daily/openmediavault-check_locked_users
+++ b/deb/openmediavault/etc/cron.daily/openmediavault-check_locked_users
@@ -20,7 +20,7 @@
 # along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
 MAILTO=""
 
-export LANG=C
+export LC_ALL=C.UTF-8
 
 . /etc/default/openmediavault
 . /usr/share/openmediavault/scripts/helper-functions

--- a/deb/openmediavault/etc/cron.daily/openmediavault-check_ssl_cert_expiry
+++ b/deb/openmediavault/etc/cron.daily/openmediavault-check_ssl_cert_expiry
@@ -20,7 +20,7 @@
 # along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
 MAILTO=""
 
-export LANG=C
+export LC_ALL=C.UTF-8
 
 . /etc/default/openmediavault
 . /usr/share/openmediavault/scripts/helper-functions

--- a/deb/openmediavault/etc/cron.daily/openmediavault-flush-mailq
+++ b/deb/openmediavault/etc/cron.daily/openmediavault-flush-mailq
@@ -26,7 +26,7 @@
 # service is disabled.
 MAILTO=""
 
-export LANG=C
+export LC_ALL=C.UTF-8
 
 . /etc/default/openmediavault
 . /usr/share/openmediavault/scripts/helper-functions

--- a/deb/openmediavault/etc/cron.daily/openmediavault-reboot_required
+++ b/deb/openmediavault/etc/cron.daily/openmediavault-reboot_required
@@ -20,7 +20,7 @@
 # along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
 MAILTO=""
 
-export LANG=C
+export LC_ALL=C.UTF-8
 
 . /usr/share/openmediavault/scripts/helper-functions
 

--- a/deb/openmediavault/etc/cron.weekly/openmediavault-update-smart-drivedb
+++ b/deb/openmediavault/etc/cron.weekly/openmediavault-update-smart-drivedb
@@ -29,7 +29,7 @@
 MAILTO=""
 TERM=dumb
 
-export LANG=C
+export LC_ALL=C.UTF-8
 
 . /etc/default/openmediavault
 . /usr/share/openmediavault/scripts/helper-functions

--- a/deb/openmediavault/srv/salt/omv/deploy/smartmontools/20hdparm.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/smartmontools/20hdparm.sls
@@ -57,7 +57,7 @@ smartmontools_hdparm_enable_smart_{{ device.uuid }}:
     - user: root
     - group: root
     - mode: 744
-    - onlyif: "export LANG=C; smartctl -i '{{ device.devicefile }}' | grep -q 'SMART support is: Disabled'"
+    - onlyif: "export LC_ALL=C.UTF-8; smartctl -i '{{ device.devicefile }}' | grep -q 'SMART support is: Disabled'"
 
 {% endfor %}
 

--- a/deb/openmediavault/usr/sbin/nginx_ensite
+++ b/deb/openmediavault/usr/sbin/nginx_ensite
@@ -18,7 +18,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
-export LANG=C
+export LC_ALL=C.UTF-8
 
 . /usr/share/openmediavault/scripts/helper-functions
 

--- a/deb/openmediavault/usr/sbin/omv-btrfs-scrub
+++ b/deb/openmediavault/usr/sbin/omv-btrfs-scrub
@@ -18,7 +18,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
-export LANG=C
+export LC_ALL=C.UTF-8
 
 . /etc/default/openmediavault
 . /usr/share/openmediavault/scripts/helper-functions

--- a/deb/openmediavault/usr/sbin/omv-mkraid
+++ b/deb/openmediavault/usr/sbin/omv-mkraid
@@ -21,7 +21,7 @@
 
 # Documentation/Howto:
 # https://www.thomas-krenn.com/de/wiki/Software_RAID_mit_MDADM_verwalten#RAID_0_mit_MDADM
-export LANG=C
+export LC_ALL=C.UTF-8
 
 . /etc/default/openmediavault
 

--- a/deb/openmediavault/usr/sbin/omv-run
+++ b/deb/openmediavault/usr/sbin/omv-run
@@ -18,7 +18,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
-export LANG=C
+export LC_ALL=C.UTF-8
 
 . /etc/default/openmediavault
 

--- a/deb/openmediavault/usr/sbin/omv-sysinfo
+++ b/deb/openmediavault/usr/sbin/omv-sysinfo
@@ -18,7 +18,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with OpenMediaVault. If not, see <http://www.gnu.org/licenses/>.
-export LANG=C
+export LC_ALL=C.UTF-8
 
 . /etc/default/openmediavault
 . /usr/share/openmediavault/scripts/helper-functions

--- a/deb/openmediavault/usr/sbin/omv-upgrade
+++ b/deb/openmediavault/usr/sbin/omv-upgrade
@@ -21,7 +21,7 @@
 
 set -e
 
-export LANG=C
+export LC_ALL=C.UTF-8
 export DEBIAN_FRONTEND=noninteractive
 
 # Update package database and update distribution. This is done via

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/apt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/apt.inc
@@ -294,7 +294,7 @@ class Apt extends \OMV\Rpc\ServiceAbstract {
 		}
 		// Create the 'Packages' file required by local APT archives.
 		// The 'packages' command should be run in the root of the tree.
-		$cmd = sprintf("export LANG=C; cd %s && apt-ftparchive " .
+		$cmd = sprintf("export LC_ALL=C.UTF-8; cd %s && apt-ftparchive " .
 		  "packages . > Packages", \OMV\Environment::get(
 		  "OMV_DPKGARCHIVE_DIR"));
 		if (0 !== $this->exec($cmd, $output))
@@ -377,7 +377,7 @@ class Apt extends \OMV\Rpc\ServiceAbstract {
 				throw new \OMV\Exception(
 				  "Failed to created a temporary directory.");
 			}
-			$cmd = sprintf("export LANG=C; dpkg-deb --fsys-tarfile %s | ".
+			$cmd = sprintf("export LC_ALL=C.UTF-8; dpkg-deb --fsys-tarfile %s | ".
 			  "tar --extract --wildcards --directory=%s ".
 			  "./usr/share/doc/%s/changelog\* 2>&1",
 			  escapeshellarg($packagePath), escapeshellarg($tmpDir),

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/certificatemgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/certificatemgmt.inc
@@ -430,7 +430,7 @@ class CertificateMgmt extends \OMV\Rpc\ServiceAbstract {
 		$cmdArgs[] = sprintf("-C %s", escapeshellarg(trim(array_value(
 			$params, "comment", ""))));
 		$cmdArgs[] = sprintf("-f %s", escapeshellarg($file));
-		$cmd = sprintf("export LANG=C; (echo y) | ssh-keygen %s 2>&1",
+		$cmd = sprintf("export LC_ALL=C.UTF-8; (echo y) | ssh-keygen %s 2>&1",
 			implode(" ", $cmdArgs));
 		if (0 !== ($exitStatus = $this->exec($cmd, $output))) {
 			throw new \OMV\ExecException($cmd, $output, $exitStatus);

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/pluginmgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/pluginmgmt.inc
@@ -179,7 +179,7 @@ class PluginMgmt extends \OMV\Rpc\ServiceAbstract {
 		// Validate the parameters of the RPC service method.
 		$this->validateMethodParams($params, "rpc.plugin.upload");
 		// Extract the package name.
-		$cmd = sprintf("export LANG=C; dpkg --field %s | ".
+		$cmd = sprintf("export LC_ALL=C.UTF-8; dpkg --field %s | ".
 		  "grep 'Package: ' | awk '{print \$2}'", escapeshellarg(
 		  $params['filepath']));
 		if (0 !== $this->exec($cmd, $output))

--- a/deb/openmediavault/usr/share/openmediavault/scripts/helper-functions
+++ b/deb/openmediavault/usr/share/openmediavault/scripts/helper-functions
@@ -328,28 +328,28 @@ omv_get_if() {
 # omv_get_ipaddr <interface>
 # Get the IPv4 address from the given network interface.
 omv_get_ipaddr() {
-	export LANG=C;
+	export LC_ALL=C.UTF-8;
 	ip -4 addr show "$1" 2>/dev/null | sed -n 's/^\s\+inet \([0-9\.]\+\)\/[0-9]\+ brd.\+/\1/p'
 }
 
 # omv_get_ipaddr6 <interface>
 # Get the IPv6 address from the given network interface.
 omv_get_ipaddr6() {
-	export LANG=C;
+	export LC_ALL=C.UTF-8;
 	ip -6 addr show "$1" 2>/dev/null | sed -n 's/^\s\+inet6 \([a-f0-9:]\+\)\/[0-9]\+ scope global/\1/p'
 }
 
 # omv_get_gateway <interface>
 # Get the default IPv4 gateway for the given network interface.
 omv_get_gateway() {
-	export LANG=C;
+	export LC_ALL=C.UTF-8;
 	ip -4 route show dev "$1" 2>/dev/null | sed -n 's/default via \([0-9\.]\+\)/\1/p'
 }
 
 # omv_get_gateway6 <interface>
 # Get the default IPv6 gateway for the given network interface.
 omv_get_gateway6() {
-	export LANG=C;
+	export LC_ALL=C.UTF-8;
 	ip -6 route show dev "$1" 2>/dev/null | sed -n 's/default via \([a-f0-9:]\+\)/\1/p'
 }
 

--- a/deb/openmediavault/usr/share/php/openmediavault/system/process.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/process.inc
@@ -39,7 +39,7 @@ class Process {
 			"value" => "/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
 			"obfuscate" => FALSE
 		],
-		"LANG" => [
+		"LC_ALL" => [
 			"value" =>"C.UTF-8",
 			"obfuscate" => FALSE
 		],


### PR DESCRIPTION
... because there are systems where LC_ALL is set in `/etc/default/locale` which result in LANG environment variable is not taken into action.

Additionally LC_ALL makes more sense because we also want numbers and dates using the same format when we are parsing command output.

Fixes: https://github.com/openmediavault/openmediavault/issues/1862


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
