### PR TITLE
Issue #1865: Remove support for WPA3 authentication for wireless connections

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,3 +1,10 @@
+openmediavault (7.4.15-1) stable; urgency=low
+
+  * Issue #1865: Remove support for WPA3 authentication for wireless
+    connections. netplan does not support that in Debian 12.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Thu, 05 Dec 2024 19:28:18 +0100
+
 openmediavault (7.4.15-2) stable; urgency=low
 
   * Several improvements.

--- a/deb/openmediavault/usr/share/openmediavault/firstaid/modules.d/10configure_network.py
+++ b/deb/openmediavault/usr/share/openmediavault/firstaid/modules.d/10configure_network.py
@@ -405,7 +405,10 @@ class Module(openmediavault.firstaid.IModule):
                     )
             rpc_params["wpassid"] = wpa_ssid
             # Get the key management mode.
-            choices = [["psk", "WPA2-Personal"], ["sae", "WPA3-Personal"]]
+            choices = [
+                ["psk", "WPA2-Personal"],
+                # ["sae", "WPA3-Personal"]
+            ]
             (code, tag) = d.menu(
                 "Please select the key management mode.",
                 backtitle=self.description,

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-wifi-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-wifi-form-page.component.ts
@@ -103,8 +103,8 @@ export class InterfaceWifiFormPageComponent extends BaseFormPageComponent {
         value: 'psk',
         store: {
           data: [
-            ['psk', gettext('WPA2-Personal')],
-            ['sae', gettext('WPA3-Personal')]
+            ['psk', gettext('WPA2-Personal')]
+            // ['sae', gettext('WPA3-Personal')]
           ]
         },
         validators: {


### PR DESCRIPTION
netplan does not support that in Debian 12.

Note, this commit will only hide the configuration option. The datamodel will not be changed; with OMV8 this code will then be needed anyway.

Fixes: https://github.com/openmediavault/openmediavault/issues/1865


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
