### PR TITLE
Correct and clarify usermgmt.inc docs for disallowusermod setting

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/usermgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/usermgmt.inc
@@ -465,8 +465,8 @@ finish:
 	 *   \em password The plain password to use.
 	 *   \em email The users email address.
 	 *   \em comment Any text string. This field is optional.
-	 *   \em disallowusermod Set to FALSE to disallow the user to modify their
-	 *     account.
+	 *   \em disallowusermod Set to TRUE to disallow the user from modifying
+	 *     their account from within the OMV web interface.
 	 *   \em sshpubkeys The users SSH public keys.
 	 * @param context The context of the caller.
 	 * @return The stored configuration object.

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/usermgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/usermgmt.inc
@@ -466,7 +466,7 @@ finish:
 	 *   \em email The users email address.
 	 *   \em comment Any text string. This field is optional.
 	 *   \em disallowusermod Set to TRUE to disallow the user from modifying
-	 *     their account from within the OMV web interface.
+	 *     their account from within the web interface.
 	 *   \em sshpubkeys The users SSH public keys.
 	 * @param context The context of the caller.
 	 * @return The stored configuration object.


### PR DESCRIPTION
The description of the disallowusermod boolean's effect was accidentally reversed. Also clarified that the setting's effect is only enforced within the OMV web interface.


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
