### PR TITLE
Retry failed connections 5 times before failure out

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,7 @@
 openmediavault (7.4.18-1) stable; urgency=low
 
-  *
+  * Try to prevent connection errors when installing plugins
+    or package updates via UI.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Mon, 30 Dec 2024 13:10:58 +0100
 

--- a/deb/openmediavault/workbench/src/app/pages/system/plugins/plugins-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/system/plugins/plugins-datatable-page.component.ts
@@ -168,7 +168,8 @@ export class PluginsDatatablePageComponent implements OnInit {
                 method: 'install',
                 params: {
                   packages: ['{{ _selected[0].name }}']
-                }
+                },
+                maxRetries: 5
               }
             },
             successUrl: '/reload'

--- a/deb/openmediavault/workbench/src/app/pages/system/updates/update-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/system/updates/update-datatable-page.component.ts
@@ -145,7 +145,8 @@ export class UpdateDatatablePageComponent {
               },
               request: {
                 service: 'Apt',
-                method: 'upgrade'
+                method: 'upgrade',
+                maxRetries: 5
               }
             },
             successUrl: '/reload'

--- a/deb/openmediavault/workbench/src/app/shared/components/task-dialog/task-dialog.component.ts
+++ b/deb/openmediavault/workbench/src/app/shared/components/task-dialog/task-dialog.component.ts
@@ -104,7 +104,10 @@ export class TaskDialogComponent implements OnInit, OnDestroy {
       .requestTaskOutput(
         this.config.request.service,
         this.config.request.method,
-        this.config.request.params
+        this.config.request.params,
+        undefined,
+        undefined,
+        this.config.request.maxRetries
       )
       .pipe(
         tap((res: RpcBgResponse) => (this.filename = res.filename)),

--- a/deb/openmediavault/workbench/src/app/shared/models/task-dialog-config.type.ts
+++ b/deb/openmediavault/workbench/src/app/shared/models/task-dialog-config.type.ts
@@ -66,6 +66,8 @@ export type TaskDialogConfig = {
     method: string;
     // Additional parameters.
     params?: Record<string, any>;
+    // Number of retry attempts before failing.
+    maxRetries?: number;
   };
 };
 


### PR DESCRIPTION
The omv-engined process is restarted when plugins are installed/uninstalled or package updates are installed. This will lead to connection errors sometimes. Retry the RPC call 5 times (with 1 seconds delay per call) before raising an error message should solve the issue on most (slow) systems. 


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
