### PR TITLE
add In Use column for logical volumes

### DIFF
--- a/deb/openmediavault-lvm2/debian/changelog
+++ b/deb/openmediavault-lvm2/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-lvm2 (7.0.1-1) stable; urgency=low
+
+  * Add `Referenced` column to the `Logical Volumes` page.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Fri, 21 Mar 2025 08:32:29 +0100
+
 openmediavault-lvm2 (7.0-2) unstable; urgency=low
 
   * Adapt to openmediavault 7 (Sandworm).

--- a/deb/openmediavault-lvm2/usr/share/openmediavault/engined/rpc/logicalvolumemgmt.inc
+++ b/deb/openmediavault-lvm2/usr/share/openmediavault/engined/rpc/logicalvolumemgmt.inc
@@ -606,6 +606,9 @@ class OMVRpcServiceLogicalVolumeMgmt extends \OMV\Rpc\ServiceAbstract {
 			$lv = new \OMV\System\Storage\Lvm\LogicalVolume($lvv);
 			if (FALSE === $lv->exists())
 				continue;
+			$used = false;
+			if ($this->checkForMountedFilesystem($lv->getPreferredDeviceFile()))
+				$used = true;
 			$result[] = [
 				"devicefile" => $lv->getPreferredDeviceFile(),
 				"uuid" => $lv->getUuid(),
@@ -614,10 +617,72 @@ class OMVRpcServiceLogicalVolumeMgmt extends \OMV\Rpc\ServiceAbstract {
 				"vgname" => $lv->getVGName(),
 				"attributes" => $lv->getAttributes(),
 				"vgattributes" => $lv->getVGAttributes(),
-				"isavailable" => $lv->IsMediaAvailable()
+				"isavailable" => $lv->IsMediaAvailable(),
+				"_used" => $used
 			];
 		}
 		return $result;
+	}
+
+	/**
+	 * Checks /proc/mount for a mount point for a given LVM logical volume path.
+	 *
+	 * @param string $lvPath The full path of the LVM logical volume (can be /dev/dm-0, /dev/vgname/lvname, or /dev/mapper/vgname-lvname).
+	 * @return boolean true if a mount point is found
+	 */
+	private function checkForMountedFilesystem($lvPath) {
+		// Read the /proc/mounts file
+		$mounts = file('/proc/mounts', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+		// Get all paths for the logical volume
+		$paths = $this->getLvmPaths($lvPath);
+		// Iterate through each line of /proc/mounts
+		foreach ($mounts as $line) {
+			$columns = preg_split('/\s+/', $line);
+			if (count($columns) < 1) {
+				continue;
+			}
+			$device = $columns[0];
+			// Check if the device is in the array of volumes
+			if (in_array($device, $paths, true)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+        /**
+         * Get paths for logical volume
+         * @param string $path any logical volume path
+         * @return An array containing three logical volume paths.
+         */
+	private function getLvmPaths($path) {
+		$cmdArgs = [];
+                $cmdArgs[] = "--noheadings";
+                $cmdArgs[] = "--output TYPE,NAME,PKNAME";
+		$cmdArgs[] = escapeshellarg($path);
+		$cmd = new \OMV\System\Process("lsblk", $cmdArgs);
+		$cmd->setRedirect2toFile("/dev/null");
+		$cmd->setQuiet(true);
+		$cmd->execute($output);
+		if (!$output) return [];
+		$parts = preg_split('/\s+/', trim($output[0]));
+		if (count($parts) < 2) return [];
+		$type = $parts[0];
+		$name = $parts[1];
+		if ($type !== 'lvm') return [];
+		if (preg_match('/^([^-]+)-([^-]+)$/', $name, $matches)) {
+			$vg = $matches[1];
+			$lv = $matches[2];
+			$mapPath = sprintf("/dev/mapper/%s-%s", $vg, $lv);
+			$dmPath = readlink($mapPath);
+			$dmNumber = preg_replace('/^.*dm-(\d+).*$/', '$1', $dmPath);
+			return [
+				sprintf("/dev/%s/%s", $vg, $lv),
+				$mapPath,
+				sprintf("/dev/dm-%d", $dmNumber)
+			];
+		}
+		return [];
 	}
 
 	/**

--- a/deb/openmediavault-lvm2/usr/share/openmediavault/engined/rpc/logicalvolumemgmt.inc
+++ b/deb/openmediavault-lvm2/usr/share/openmediavault/engined/rpc/logicalvolumemgmt.inc
@@ -602,13 +602,22 @@ class OMVRpcServiceLogicalVolumeMgmt extends \OMV\Rpc\ServiceAbstract {
 		$lvs = \OMV\System\Storage\Lvm\LogicalVolume::enumerate();
 		$result = [];
 		foreach ($lvs as $lvk => $lvv) {
-			// Get the physical volume details.
+			// Get the logical volume details.
 			$lv = new \OMV\System\Storage\Lvm\LogicalVolume($lvv);
-			if (FALSE === $lv->exists())
+			if (FALSE === $lv->exists()) {
 				continue;
-			$used = false;
-			if ($this->checkForMountedFilesystem($lv->getPreferredDeviceFile()))
-				$used = true;
+			}
+			$used = FALSE;
+			// Check if the logical volume is in use:
+			// - Does it contain a file system?
+			// - Is it used by another storage device?
+			if (FALSE !== \OMV\Rpc\Rpc::call("FsTab", "getByFsName",
+					[ "fsname" => $lv->getDeviceFile() ], $context)) {
+				$used = TRUE;
+			} else if (\OMV\System\Storage\StorageDevice::isUsed(
+					$lv->getDeviceFile())) {
+				$used = TRUE;
+			}
 			$result[] = [
 				"devicefile" => $lv->getPreferredDeviceFile(),
 				"uuid" => $lv->getUuid(),
@@ -622,67 +631,6 @@ class OMVRpcServiceLogicalVolumeMgmt extends \OMV\Rpc\ServiceAbstract {
 			];
 		}
 		return $result;
-	}
-
-	/**
-	 * Checks /proc/mount for a mount point for a given LVM logical volume path.
-	 *
-	 * @param string $lvPath The full path of the LVM logical volume (can be /dev/dm-0, /dev/vgname/lvname, or /dev/mapper/vgname-lvname).
-	 * @return boolean true if a mount point is found
-	 */
-	private function checkForMountedFilesystem($lvPath) {
-		// Read the /proc/mounts file
-		$mounts = file('/proc/mounts', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-		// Get all paths for the logical volume
-		$paths = $this->getLvmPaths($lvPath);
-		// Iterate through each line of /proc/mounts
-		foreach ($mounts as $line) {
-			$columns = preg_split('/\s+/', $line);
-			if (count($columns) < 1) {
-				continue;
-			}
-			$device = $columns[0];
-			// Check if the device is in the array of volumes
-			if (in_array($device, $paths, true)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-        /**
-         * Get paths for logical volume
-         * @param string $path any logical volume path
-         * @return An array containing three logical volume paths.
-         */
-	private function getLvmPaths($path) {
-		$cmdArgs = [];
-                $cmdArgs[] = "--noheadings";
-                $cmdArgs[] = "--output TYPE,NAME,PKNAME";
-		$cmdArgs[] = escapeshellarg($path);
-		$cmd = new \OMV\System\Process("lsblk", $cmdArgs);
-		$cmd->setRedirect2toFile("/dev/null");
-		$cmd->setQuiet(true);
-		$cmd->execute($output);
-		if (!$output) return [];
-		$parts = preg_split('/\s+/', trim($output[0]));
-		if (count($parts) < 2) return [];
-		$type = $parts[0];
-		$name = $parts[1];
-		if ($type !== 'lvm') return [];
-		if (preg_match('/^([^-]+)-([^-]+)$/', $name, $matches)) {
-			$vg = $matches[1];
-			$lv = $matches[2];
-			$mapPath = sprintf("/dev/mapper/%s-%s", $vg, $lv);
-			$dmPath = readlink($mapPath);
-			$dmNumber = preg_replace('/^.*dm-(\d+).*$/', '$1', $dmPath);
-			return [
-				sprintf("/dev/%s/%s", $vg, $lv),
-				$mapPath,
-				sprintf("/dev/dm-%d", $dmNumber)
-			];
-		}
-		return [];
 	}
 
 	/**
@@ -704,17 +652,8 @@ class OMVRpcServiceLogicalVolumeMgmt extends \OMV\Rpc\ServiceAbstract {
 		]);
 		// Validate the parameters of the RPC service method.
 		$this->validateMethodParams($params, "rpc.common.getlist");
-		// Enumerate all volume groups on the system.
+		// Enumerate all logical volumes on the system.
 		$lvs = $this->callMethod("enumerateLogicalVolumes", NULL, $context);
-		foreach($lvs as $lvk => &$lvv) {
-			$lvv['_used'] = FALSE;
-			// Does the logical volume contain a filesystem and is it used?
-			if(FALSE !== \OMV\Rpc\Rpc::call("FsTab", "getByFsName", [
-				"fsname" => $lvv['devicefile']
-			], $context)) {
-				$lvv['_used'] = TRUE;
-			}
-		}
 		// Filter result.
 		return $this->applyFilter($lvs, $params['start'], $params['limit'],
 		  $params['sortfield'], $params['sortdir']);

--- a/deb/openmediavault-lvm2/usr/share/openmediavault/workbench/component.d/omv-storage-lvm-lv-datatable-page.yaml
+++ b/deb/openmediavault-lvm2/usr/share/openmediavault/workbench/component.d/omv-storage-lvm-lv-datatable-page.yaml
@@ -79,10 +79,6 @@ data:
         enabledConstraints:
           minSelected: 1
           maxSelected: 1
-          constraint:
-            - operator: falsy
-              arg0:
-                prop: inuse
         execute:
           type: url
           url: "/storage/lvm/lvs/reduce/{{ _selected[0].devicefile | encodeuricomponent }}"
@@ -96,6 +92,11 @@ data:
           type: url
           url: "/storage/lvm/lvs/extend/{{ _selected[0].devicefile | encodeuricomponent }}"
       - template: delete
+        enabledConstraints:
+          constraint:
+          - operator: falsy
+            arg0:
+              prop: _used
         execute:
           type: request
           request:

--- a/deb/openmediavault-lvm2/usr/share/openmediavault/workbench/component.d/omv-storage-lvm-lv-datatable-page.yaml
+++ b/deb/openmediavault-lvm2/usr/share/openmediavault/workbench/component.d/omv-storage-lvm-lv-datatable-page.yaml
@@ -39,6 +39,12 @@ data:
         flexGrow: 1
         sortable: true
         cellTemplateName: checkIcon
+      - name: _("Referenced")
+        prop: _used
+        flexGrow: 1
+        sortable: true
+        cellTemplateName: checkIcon
+        hidden: true
     actions:
       - template: create
         execute:
@@ -73,6 +79,10 @@ data:
         enabledConstraints:
           minSelected: 1
           maxSelected: 1
+          constraint:
+            - operator: falsy
+              arg0:
+                prop: inuse
         execute:
           type: url
           url: "/storage/lvm/lvs/reduce/{{ _selected[0].devicefile | encodeuricomponent }}"


### PR DESCRIPTION
Add In Use column for logical volumes

Add In Use column on LV datatable.  Hidden by default.
Determine if that logical volume is in use in a mount point or tgt target and disable LV reduce if mounted or part of a tgt target.

Fixes: https://forum.openmediavault.org/index.php?thread/55098-lvm-resize-volume-will-cause-filesystem-corruption/

Signed-off-by: Aaron Murray [plugins@omv-extras.org]