### PR TITLE
Issue #1883: Modify the hint for the extended attributes setting in the SMB share form

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -4,6 +4,8 @@ openmediavault (7.5.0-1) stable; urgency=low
     or package updates via UI.
   * Issue #1875: Add option to select the Wi-Fi frequency band.
   * Issue #1878: Fix netplan config parsing errors.
+  * Issue #1883: Modify the hint for the extended attributes
+    setting in the SMB share form. Enable them by default.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Mon, 30 Dec 2024 13:10:58 +0100
 

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smb.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smb.json
@@ -152,7 +152,7 @@
 							},
 							"easupport": {
 								"type": "boolean",
-								"default": false
+								"default": true
 							},
 							"storedosattributes": {
 								"type": "boolean",

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smb.share.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smb.share.json
@@ -62,7 +62,7 @@
 		},
 		"easupport": {
 			"type": "boolean",
-			"default": false
+			"default": true
 		},
 		"storedosattributes": {
 			"type": "boolean",

--- a/deb/openmediavault/usr/share/openmediavault/unittests/data/config.xml
+++ b/deb/openmediavault/usr/share/openmediavault/unittests/data/config.xml
@@ -869,7 +869,7 @@ iSrj/B/KRCZkkrDdYcDAvqRs6dA+ScRZ
           <hidedotfiles>1</hidedotfiles>
           <inheritacls>1</inheritacls>
           <inheritpermissions>0</inheritpermissions>
-          <easupport>0</easupport>
+          <easupport>1</easupport>
           <storedosattributes>0</storedosattributes>
           <hostsallow></hostsallow>
           <hostsdeny></hostsdeny>

--- a/deb/openmediavault/workbench/src/app/pages/services/smb/smb-share-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/smb/smb-share-form-page.component.ts
@@ -281,9 +281,9 @@ export class SmbShareFormPageComponent extends BaseFormPageComponent {
         name: 'easupport',
         label: gettext('Extended attributes'),
         hint: gettext(
-          'Allow clients to attempt to store OS/2 state extended attributes on a share.'
+          'Allow clients to attempt to access extended attributes on a share. The underlying filesystem exposed by the share must support extended attributes.'
         ),
-        value: false
+        value: true
       },
       {
         type: 'checkbox',


### PR DESCRIPTION
Enable xattrs by default.

Fixes: https://github.com/openmediavault/openmediavault/issues/1883


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
