### PR TITLE
Fix for SMART Information Retrieval on USB-to-SATA SSDs

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/smartinformation.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/smartinformation.inc
@@ -151,9 +151,19 @@ class SmartInformation {
 			$cmdArgs[] = "--log=selftest";
 		}
 		if (!is_null($this->noCheck)) {
-			$cmdArgs[] = sprintf("--nocheck=%s", escapeshellarg(
-				$this->noCheck));
+			$cmdArgs[] = sprintf("--nocheck=%s", escapeshellarg($this->noCheck));
 		}
+
+		// Check if the device is a USB device or a USB-to-SATA bridge
+		$deviceFile = $this->sd->getDeviceFile();
+		if (strpos($deviceFile, 'usb') !== false) {
+			// For Prolific-based USB-to-SATA bridges
+			$cmdArgs[] = '-d usbprolific';
+		} else {
+			// Use 'sat' for other types of USB-to-SATA or SATA devices
+			$cmdArgs[] = '-d sat';
+		}
+
 		if (!empty($this->sd->getSmartDeviceType())) {
 			$cmdArgs[] = sprintf("--device=%s", $this->sd->getSmartDeviceType());
 		}


### PR DESCRIPTION
**Problem:**
SMART data retrieval failed for USB-to-SATA connected SSDs. The device was not correctly identified, resulting in errors in the OMV UI. The issue occurred because the device type identification for USB-based devices was missing, preventing proper interaction with smartctl.

**Error Message:**
Failed to execute command 'export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin; export LC_ALL=C.UTF-8; export LANGUAGE=; smartctl --xall /dev/sdc 2>&1' with exit code '1': 
smartctl 7.3 2022-02-28 r5338 [x86_64-linux-6.1.0-28-amd64] (local build)
Copyright (C) 2002-22, Bruce Allen, Christian Franke, www.smartmontools.org

/dev/sdc: Unknown USB bridge [0x03f0:0x0c5c (0x148)]
Please specify device type with the -d option.

Use smartctl -h to get a usage summary


OMV\ExecException: Failed to execute command 'export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin; export LC_ALL=C.UTF-8; export LANGUAGE=; smartctl --xall /dev/sdc 2>&1' with exit code '1': 
smartctl 7.3 2022-02-28 r5338 [x86_64-linux-6.1.0-28-amd64] (local build)
Copyright (C) 2002-22, Bruce Allen, Christian Franke, www.smartmontools.org

/dev/sdc: Unknown USB bridge [0x03f0:0x0c5c (0x148)]
Please specify device type with the -d option.

Use smartctl -h to get a usage summary
in /usr/share/php/openmediavault/system/storage/smartinformation.inc:181
Stack trace:
#0 /usr/share/php/openmediavault/system/storage/smartinformation.inc(224): OMV\System\Storage\SmartInformation->getData()
#1 /usr/share/openmediavault/engined/rpc/smart.inc(407): OMV\System\Storage\SmartInformation->getExtendedInformation()
#2 [internal function]: Engined\Rpc\Smart->getExtendedInformation()
#3 /usr/share/php/openmediavault/rpc/serviceabstract.inc(124): call_user_func_array()
#4 /usr/share/php/openmediavault/rpc/rpc.inc(86): OMV\Rpc\ServiceAbstract->callMethod()
#5 /usr/sbin/omv-engined(544): OMV\Rpc\Rpc::call()
#6 {main}

**Solution:**
USB Device Identification: Added logic to detect if the connected device is a USB device by checking if the device path contains "usb".
Device-Specific Handling: For devices using Prolific-based USB-to-SATA bridges, the -d usbprolific option was added for smartctl. For other USB-to-SATA or SATA devices, the -d sat option is now used.

**Tested Devices:**
USB-to-SATA and SATA devices confirmed compatibility.