### PR TITLE
Issue #1898: OMV_NGINX_SITE_WEBGUI_LISTEN_IPV4_ADDRESS not working when ipv6 disabled

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,9 @@
 openmediavault (7.5.2-1) stable; urgency=low
 
   * Fix database migration issue introduced by issue #1875.
+  * Issue #1898: When IPv6 is deactivated, the environment
+    variable OMV_NGINX_SITE_WEBGUI_LISTEN_IPV4_ADDRESS isn't
+    taken into account when deploying the nginx configuration.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Fri, 17 Jan 2025 15:18:02 +0100
 

--- a/deb/openmediavault/srv/salt/omv/deploy/nginx/files/site-webgui.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/nginx/files/site-webgui.j2
@@ -50,7 +50,7 @@ server {
     listen {{ listen_ipv4_addr }}:{{ config.port }} {{ listen_params }};
     listen [{{ listen_ipv6_addr }}]:{{ config.port }} {{ listen_params }};
 {%- else %}
-    listen {{ config.port }} {{ listen_params }};
+    listen {{ listen_ipv4_addr }}:{{ config.port }} {{ listen_params }};
 {%- endif %}
 {%- if config.enablessl | to_bool and config.forcesslonly | to_bool %}
       if ($scheme = http) {
@@ -63,7 +63,7 @@ server {
     listen {{ listen_ipv4_addr }}:{{ config.sslport }} {{ listen_params }} {{ listen_http2_param }} ssl deferred;
     listen [{{ listen_ipv6_addr }}]:{{ config.sslport }} {{ listen_params }} {{ listen_http2_param }} ssl deferred;
 {%- else %}
-    listen {{ config.sslport }} {{ listen_params }} {{ listen_http2_param }} ssl deferred;
+    listen {{ listen_ipv4_addr }}:{{ config.sslport }} {{ listen_params }} {{ listen_http2_param }} ssl deferred;
 {%- endif %}
     ssl_certificate {{ ssl_cert_dir | path_join('certs', ssl_cert_prefix ~ config.sslcertificateref ~ '.crt') }};
     ssl_certificate_key {{ ssl_cert_dir | path_join('private', ssl_cert_prefix ~ config.sslcertificateref ~ '.key') }};


### PR DESCRIPTION
When IPv6 is deactivated, the environment variable OMV_NGINX_SITE_WEBGUI_LISTEN_IPV4_ADDRESS isn't taken into account when deploying the nginx configuration.

Fixes: https://github.com/openmediavault/openmediavault/issues/1898


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
