### PR TITLE
Umount a file system via mountpoint

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,5 +1,7 @@
-openmediavault (7.6.1-1) stable; urgency=low
+openmediavault (7.7.0-1) stable; urgency=low
 
+  * Refactor the RPC to umnount file systems to be able to get
+    rid of non-existing file systems.
   * Issue #1912: Fix pinning of backports repository.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Thu, 30 Jan 2025 18:07:22 +0100

--- a/deb/openmediavault/debian/openmediavault.postinst
+++ b/deb/openmediavault/debian/openmediavault.postinst
@@ -579,7 +579,7 @@ case "$1" in
 			omv_module_set_dirty apt
 			rm -rf /etc/apt/apt.conf.d/98openmediavault-unattended-upgrades-mail
 		fi
-		if dpkg --compare-versions "$2" lt-nl "7.6.1"; then
+		if dpkg --compare-versions "$2" lt-nl "7.7.0"; then
 			omv_module_set_dirty apt
 		fi
 

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.filesystemmgmt.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.filesystemmgmt.json
@@ -96,11 +96,11 @@
 	}
 },{
 	"type": "rpc",
-	"id": "rpc.filesystemmgmt.umount",
+	"id": "rpc.filesystemmgmt.umountbyfsname",
 	"params": {
 		"type": "object",
 		"properties": {
-			"id": {
+			"fsname": {
 				"type": "string",
 				"oneOf": [{
 					"type": "string",
@@ -109,6 +109,19 @@
 					"type": "string",
 					"format": "devicefile"
 				}],
+				"required": true
+			}
+		}
+	}
+},{
+	"type": "rpc",
+	"id": "rpc.filesystemmgmt.umountbydir",
+	"params": {
+		"type": "object",
+		"properties": {
+			"dir": {
+				"type": "string",
+				"format": "dirpath",
 				"required": true
 			}
 		}

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.fstab.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.fstab.json
@@ -68,9 +68,6 @@
 				},{
 					"type": "string",
 					"format": "devicefile"
-				},{
-					"type": "string",
-					"format": "dirpath"
 				}],
 				"required": true
 			}
@@ -84,6 +81,7 @@
 		"properties": {
 			"dir": {
 				"type": "string",
+				"format": "dirpath",
 				"required": true
 			}
 		}

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/filesystemmgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/filesystemmgmt.inc
@@ -46,7 +46,8 @@ class OMVRpcServiceFileSystemMgmt extends \OMV\Rpc\ServiceAbstract {
 		$this->registerMethod("createBtrfs");
 		$this->registerMethod("grow");
 		$this->registerMethod("setMountPoint");
-		$this->registerMethod("umount");
+		$this->registerMethod("umountByFsName");
+		$this->registerMethod("umountByDir");
 		$this->registerMethod("hasFilesystem");
 		$this->registerMethod("getDetails");
 	}
@@ -888,33 +889,66 @@ class OMVRpcServiceFileSystemMgmt extends \OMV\Rpc\ServiceAbstract {
 	}
 
 	/**
-	 * Unmount a file system.
-	 * The file system will be unmounted and the mount point database
-	 * configuration object will be deleted.
+	 * Unmount a file system by the given file system name, which may be
+	 * an UUID or block special device. The file system will be unmounted
+	 * and the mount point database configuration object will be deleted.
 	 * @param params An array containing the following fields:
-	 *   \em id The UUID or block special device of the file system to release.
+	 *   \em fsname The UUID or block special device of the file system to release.
 	 * @param context The context of the caller.
 	 * @return void
 	 * @throw \OMV\Exception
 	 */
-	public function umount($params, $context) {
+	public function umountByFsName($params, $context) {
 		// Validate the RPC caller context.
 		$this->validateMethodContext($context, [
 			"role" => OMV_ROLE_ADMINISTRATOR
 		]);
 		// Validate the parameters of the RPC service method.
-		$this->validateMethodParams($params, "rpc.filesystemmgmt.umount");
+		$this->validateMethodParams($params, "rpc.filesystemmgmt.umountbyfsname");
 		// Try to obtain the mount point configuration object if this exists.
 		$meObject = \OMV\Rpc\Rpc::call("FsTab", "getByFsName", [
-			"fsname" => $params['id']
+			"fsname" => $params['fsname']
 		], $context);
 		if (FALSE === $meObject) {
 			throw new \OMV\Exception(
 				"No mount point database configuration object exists for the file system '%s'.",
-				$params['id']);
+				$params['fsname']);
 		}
+		self::umount($meObject, $context);
+	}
+
+	/**
+	 * Unmount a file system by the given mount point. The file system will
+	 * be unmounted and the mount point database configuration object will
+	 * be deleted.
+	 * @param params An array containing the following fields:
+	 *   \em dir The mount point of the file system to release.
+	 * @param context The context of the caller.
+	 * @return void
+	 * @throw \OMV\Exception
+	 */
+	public function umountByDir($params, $context) {
+		// Validate the RPC caller context.
+		$this->validateMethodContext($context, [
+			"role" => OMV_ROLE_ADMINISTRATOR
+		]);
+		// Validate the parameters of the RPC service method.
+		$this->validateMethodParams($params, "rpc.filesystemmgmt.umountbydir");
+		// Try to obtain the mount point configuration object if this exists.
+		$meObject = \OMV\Rpc\Rpc::call("FsTab", "getByDir", [
+			"dir" => $params['dir']
+		], $context);
+		if (FALSE === $meObject) {
+			throw new \OMV\Exception(
+				"No mount point database configuration object exists for the mount point '%s'.",
+				$params['dir']);
+		}
+		self::umount($meObject, $context);
+	}
+
+	private static function umount($meObject, $context): void {
 		// Get the file system and unmount it.
-		$fs = \OMV\System\Filesystem\Filesystem::getImpl($params['id']);
+		$fs = \OMV\System\Filesystem\Filesystem::getImpl($meObject['fsname']);
 		if (!is_null($fs) && $fs->exists()) {
 			if (TRUE === $fs->isMounted()) {
 				$fs->umount(TRUE);

--- a/deb/openmediavault/workbench/src/app/pages/storage/filesystems/filesystem-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/storage/filesystems/filesystem-datatable-page.component.ts
@@ -298,6 +298,7 @@ export class FilesystemDatatablePageComponent implements OnInit {
         tooltip: gettext('Unmount'),
         enabledConstraints: {
           constraint: [
+            { operator: 'n', arg0: { prop: 'mountpoint' } },
             // Disable button if file system is in use or read-only.
             {
               operator: 'if',
@@ -328,10 +329,9 @@ export class FilesystemDatatablePageComponent implements OnInit {
           type: 'request',
           request: {
             service: 'FileSystemMgmt',
-            method: 'umount',
+            method: 'umountByDir',
             params: {
-              id: '{{ devicefile }}',
-              fstab: true
+              dir: '{{ mountpoint }}'
             },
             progressMessage: gettext('Please wait, unmounting the file system ...')
           }


### PR DESCRIPTION
The mount point always exists in the response of the FileSystemMgmt::getListBg RPC which is used to populate the list of configured file systems in the UI. If a file system does not exist anymore, the mount point attribute still exists in the response data because it is fetched from the database. Because of that it makes sense to use this to unmount file systems from within the UI. Otherwise users can not get rid of those zombies.


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
