### PR TITLE
Use K3S v1.32.3+k3s1 by default

### DIFF
--- a/deb/openmediavault-k8s/debian/changelog
+++ b/deb/openmediavault-k8s/debian/changelog
@@ -1,3 +1,13 @@
+openmediavault-k8s (7.4.5-1) stable; urgency=medium
+
+  * Update locale files.
+  * Use K3S v1.32.3+k3s1 by default.
+    Existing installations won't be upgraded automatically. To force
+    an upgrade, create the file `/var/lib/openmediavault/upgrade_k3s`
+    and run `omv-salt deploy run k3s`.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Sat, 29 Mar 2025 12:05:08 +0100
+
 openmediavault-k8s (7.4.4-1) stable; urgency=low
 
   * Update the recipe ingredients.

--- a/deb/openmediavault-k8s/srv/salt/omv/deploy/k3s/10default.sls
+++ b/deb/openmediavault-k8s/srv/salt/omv/deploy/k3s/10default.sls
@@ -27,7 +27,7 @@
 # https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistent-volumes
 # https://docs.k3s.io/installation/requirements?os=pi
 
-{% set k3s_version = salt['pillar.get']('default:OMV_K8S_K3S_VERSION', 'v1.31.2+k3s1') %}
+{% set k3s_version = salt['pillar.get']('default:OMV_K8S_K3S_VERSION', 'v1.32.3+k3s1') %}
 {% set k8s_config = salt['omv_conf.get']('conf.service.k8s') %}
 {% set dns_config = salt['omv_conf.get']('conf.system.network.dns') %}
 # {% set email_config = salt['omv_conf.get']('conf.system.notification.email') %}
@@ -94,7 +94,7 @@ create_k3s_traefik_manifest:
                 tls:
                   enabled: true
         ---
-        apiVersion: traefik.containo.us/v1alpha1
+        apiVersion: traefik.io/v1alpha1
         kind: Middleware
         metadata:
           name: https-redirect
@@ -106,7 +106,7 @@ create_k3s_traefik_manifest:
             permanent: true
             port: "{{ k8s_config.websecureport }}"
         ---
-        apiVersion: traefik.containo.us/v1alpha1
+        apiVersion: traefik.io/v1alpha1
         kind: TLSStore
         metadata:
           name: default
@@ -243,7 +243,7 @@ create_k3s_k8s_dashboard_manifest:
               ingress:
                 enabled: false
         ---
-        apiVersion: traefik.containo.us/v1alpha1
+        apiVersion: traefik.io/v1alpha1
         kind: ServersTransport
         metadata:
           name: no-verify-tls
@@ -253,7 +253,7 @@ create_k3s_k8s_dashboard_manifest:
         spec:
           insecureSkipVerify: true
         ---
-        apiVersion: traefik.containo.us/v1alpha1
+        apiVersion: traefik.io/v1alpha1
         kind: IngressRoute
         metadata:
           name: kubernetes-dashboard


### PR DESCRIPTION
Adapt traefik API version because `traefik.containo.us` is deprectaed in Traefik v3 (https://doc.traefik.io/traefik/migration/v2/#kubernetes-crds) which is now part of K3s (https://github.com/k3s-io/k3s/releases/tag/v1.32.3%2Bk3s1).


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
