### PR TITLE
Add support to dynamically reload `select` form fields

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,7 @@
 openmediavault (7.7.4-1) stable; urgency=medium
 
-  *
+  * Issue #1170: Add support to dynamically reload `select` form
+    fields.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Sat, 05 Apr 2025 12:50:50 +0200
 

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-select/form-select.component.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-select/form-select.component.ts
@@ -24,6 +24,7 @@ import { catchError } from 'rxjs/operators';
 import { AbstractFormFieldComponent } from '~/app/core/components/intuition/form/components/abstract-form-field-component';
 import { formatFormFieldConfig } from '~/app/core/components/intuition/functions.helper';
 import { Unsubscribe } from '~/app/decorators';
+import { DataStore } from '~/app/shared/models/data-store.type';
 import { DataStoreService } from '~/app/shared/services/data-store.service';
 
 @Component({
@@ -43,9 +44,12 @@ export class FormSelectComponent extends AbstractFormFieldComponent implements O
 
   override ngOnInit(): void {
     super.ngOnInit();
-    this.doLoadStore();
 
     const control = this.formGroup.get(this.config.name);
+    _.set(control, 'reload', this.doReloadStore.bind(this));
+
+    this.doLoadStore();
+
     this.subscriptions.add(
       control.valueChanges.subscribe((value) => {
         this.config.value = value;
@@ -84,5 +88,23 @@ export class FormSelectComponent extends AbstractFormFieldComponent implements O
           this.config.store.data.unshift(item);
         }
       });
+  }
+
+  private doReloadStore(store: DataStore): void {
+    const control = this.formGroup.get(this.config.name);
+    _.assign(
+      this.config.store,
+      // Reset several fields to make sure, the new store configuration is
+      // used and not falsified by old data.
+      {
+        data: undefined,
+        url: undefined,
+        proxy: undefined
+      },
+      // Assign the new store config that is used to reload the data.
+      store
+    );
+    control.setValue(null);
+    this.doLoadStore();
   }
 }

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/form.component.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/form.component.ts
@@ -43,6 +43,7 @@ import { PageContextService } from '~/app/core/services/page-context.service';
 import { Unsubscribe } from '~/app/decorators';
 import { formatDeep, isFormatable } from '~/app/functions.helper';
 import { CustomValidators } from '~/app/shared/forms/custom-validators';
+import { DataStore } from '~/app/shared/models/data-store.type';
 import { ConstraintService } from '~/app/shared/services/constraint.service';
 
 let nextUniqueId = 0;
@@ -431,6 +432,16 @@ export class FormComponent implements AfterViewInit, OnInit {
         if (fulfilled) {
           const value = formatDeep(modifier.typeConfig, values);
           control.setValue(value);
+        }
+        break;
+      case 'reload':
+        if (fulfilled) {
+          // eslint-disable-next-line @typescript-eslint/ban-types
+          const reloadFn: Function = _.get(control, 'reload');
+          if (_.isFunction(reloadFn)) {
+            const store: DataStore = formatDeep(modifier.typeConfig, values);
+            reloadFn.call(control, store);
+          }
         }
         break;
     }

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/models/form-field-config.type.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/models/form-field-config.type.ts
@@ -380,10 +380,17 @@ export type FormFieldModifier = {
     | 'focused'
     | 'visible'
     | 'hidden'
-    | 'value';
-  // Optional configuration used by modifiers. This is required by
-  // the 'value' modifier, e.g. '{{ <NAME> }}' to set the value
-  // of the given field.
+    | 'value'
+    | 'reload';
+  // Optional configuration used by modifiers.
+  // Examples:
+  // - value:
+  //   Specify the new value of the form field. This can be a tokenized
+  //   string.
+  //   `{{ name | rstrip("/") }}/`
+  // - reload:
+  //   Specify the DataStore object that is used to reload the content
+  //   of the `select` form field.
   typeConfig?: any;
   // Apply the opposite type, e.g. `disabled` for `enabled`, if the
   // constraint is falsy. Defaults to `true`.

--- a/deb/openmediavault/workbench/src/app/shared/services/data-store.service.spec.ts
+++ b/deb/openmediavault/workbench/src/app/shared/services/data-store.service.spec.ts
@@ -128,6 +128,22 @@ describe('DataStoreService', () => {
     });
   });
 
+  it('should load inline data (8)', (done) => {
+    const store: DataStore = {
+      data: ['foo', 'bar']
+    };
+    service.load(store).subscribe((res) => {
+      expect(store.fields).toEqual(['key', 'value']);
+      expect(store.data).toEqual([
+        { key: 'foo', value: 'foo' },
+        { key: 'bar', value: 'bar' }
+      ]);
+      expect(_.has(res, 'data')).toBeTruthy();
+      expect(_.has(res, 'total')).toBeTruthy();
+      done();
+    });
+  });
+
   it('should assign additional sources', (done) => {
     const store: DataStore = {
       data: ['poweroff', 'hybrid', 'suspendhybrid'],

--- a/deb/openmediavault/workbench/src/app/shared/services/data-store.service.ts
+++ b/deb/openmediavault/workbench/src/app/shared/services/data-store.service.ts
@@ -132,11 +132,11 @@ export class DataStoreService {
     // We need to create a new array, otherwise Angular won't
     // detect changes if we modify the original one only.
     let data = [];
+    if (_.isUndefined(store.fields) || !_.isArray(store.fields)) {
+      store.fields = ['key', 'value'];
+    }
     if (_.isPlainObject(store.data)) {
       // Convert simple objects to an array.
-      if (_.isUndefined(store.fields) || !_.isArray(store.fields)) {
-        store.fields = ['key', 'value'];
-      }
       _.forEach(store.data, (value, key) => {
         const newItem = {};
         _.set(newItem, store.fields[0], key);


### PR DESCRIPTION
A reload is triggered when the `constraint` of a modifier is true or the form fields specified in `deps` have been modified. The specified request parameters (DataStore) are used to reload the content via RPC.

The following code will trigger a `reload` when the field `disallowusermod` is modifed. Instead of `deps` you can also use `constraint`.
```
{
        type: 'select',
        name: 'shell',
        label: gettext('Shell'),
        placeholder: gettext('Select a shell ...'),
        value: '/usr/bin/sh',
        store: {
          proxy: {
            service: 'System',
            get: {
              method: 'getShells'
            }
          },
          sorters: [
            {
              dir: 'asc',
              prop: 'text'
            }
          ]
        },
        modifiers: [
          {
            type: 'reload',
            typeConfig: {
              proxy: {
                service: 'System',
                get: {
                  method: 'getShells2'
                }
              },
              sorters: [
                {
                  dir: 'desc',
                  prop: 'text'
                }
              ]
            },
            deps: ['disallowusermod']
          }
        ]
      },
```

Replace the via RPC loaded options with static data.
```
{
        type: 'select',
        name: 'shell',
        label: gettext('Shell'),
        placeholder: gettext('Select a shell ...'),
        value: '/usr/bin/sh',
        store: {
          proxy: {
            service: 'System',
            get: {
              method: 'getShells'
            }
          },
          sorters: [
            {
              dir: 'asc',
              prop: 'text'
            }
          ]
        },
        modifiers: [
          {
            type: 'reload',
            typeConfig: {
              data: ['/usr/bin/foo']
            },
            deps: ['disallowusermod']
          }
        ]
      }
```

Fixes: https://github.com/openmediavault/openmediavault/issues/1170


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
