### PR TITLE
Add OMV_K8S_TRAEFIK_PORTS environemnt variable

### DIFF
--- a/deb/openmediavault-k8s/debian/changelog
+++ b/deb/openmediavault-k8s/debian/changelog
@@ -1,3 +1,14 @@
+openmediavault-k8s (7.4.6-1) stable; urgency=medium
+
+  * Update locale files.
+  * Issue #1940: Add `OMV_K8S_TRAEFIK_PORTS` environment variable to
+    append additional Traefik port configurations to the Helm chart.
+    The configuration must be specified in minified YAML format
+    Check the Traefik Helm chart documentation for more information
+    about the available port configuration properties.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Thu, 17 Apr 2025 21:16:51 +0200
+
 openmediavault-k8s (7.4.5-1) stable; urgency=medium
 
   * Update locale files.


### PR DESCRIPTION
... to be able to inject additional port configurations to the Traefik Helm chart.

The environemnt variable should contain minified yaml code.

Example:
```
OMV_K8S_TRAEFIK_PORTS="{foo: {exposedPort: 3456}}"
```

References:
- https://github.com/traefik/traefik-helm-chart/blob/master/traefik/VALUES.md
- https://github.com/traefik/traefik-helm-chart/blob/a76355d67f170ff779a7e4ea3b0e277f27739fc9/traefik/values.schema.json#L1189

Related to: https://github.com/openmediavault/openmediavault/issues/1940

<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
