### PR TITLE
Fix that omv-onedrive always starts the service regardless if it is enabled or not.

### DIFF
--- a/deb/openmediavault-onedrive/usr/sbin/omv-onedrive
+++ b/deb/openmediavault-onedrive/usr/sbin/omv-onedrive
@@ -23,14 +23,12 @@ enabled=$(systemctl is-enabled onedrive@onedrive.service)
 username=$(omv-confdbadm read 'conf.service.onedrive' | jq --raw-output '.username')
 
 stop_onedrive_service() {
-  if [ ${enabled} ]; then
-    echo "Please wait, stopping service ..."
-    systemctl stop onedrive@onedrive.service || true
-  fi
+  echo "Please wait, stopping service, if it is running ..."
+  systemctl stop onedrive@onedrive.service || true
 }
 
 start_onedrive_service() {
-  if [ ${enabled} ]; then
+  if [ "$enabled" = "enabled" ]; then
     echo "Please wait, starting service ..."
     systemctl start onedrive@onedrive.service || true
   fi


### PR DESCRIPTION
Removed condition for stopping the service, as it could run even it is disabled. 
Added a condition to check on the string "enabled", as previously both contitions where always `true`, even if they were `disabled` from line 22

https://github.com/openmediavault/openmediavault/issues/1955

Signed-off-by: StevusPrimus <dev@stevusprimus.net>

- [ ] References issue
- [X] Includes tests for new functionality or reproducer for bug

```
 ⚡ root@vault  /var/cache/onedrive  systemctl stop onedrive@onedrive.service
 ⚡ root@vault  /var/cache/onedrive  systemctl is-enabled onedrive@onedrive.service
disabled
 ✘ ⚡ root@vault  /var/cache/onedrive  systemctl enable onedrive@onedrive.service
Created symlink /etc/systemd/system/multi-user.target.wants/onedrive@onedrive.service → /lib/systemd/system/onedrive@.service.
 ⚡ root@vault  /var/cache/onedrive  systemctl is-enabled onedrive@onedrive.service
enabled
 ⚡ root@vault  /var/cache/onedrive  systemctl disable onedrive@onedrive.service
Removed "/etc/systemd/system/multi-user.target.wants/onedrive@onedrive.service".
 ⚡ root@vault  /var/cache/onedrive  systemctl is-enabled onedrive@onedrive.service
disabled
```

