### PR TITLE
Add OMV_K8S_DEFAULT_TLS_CERT_ISSUER and OMV_K8S_FQDN env vars.

### DIFF
--- a/deb/openmediavault-k8s/debian/changelog
+++ b/deb/openmediavault-k8s/debian/changelog
@@ -6,6 +6,14 @@ openmediavault-k8s (7.4.6-1) stable; urgency=medium
     The configuration must be specified in minified YAML format
     Check the Traefik Helm chart documentation for more information
     about the available port configuration properties.
+  * Add `OMV_K8S_DEFAULT_TLS_CERT_ISSUER` environment variable to
+    allow a custom certificate issuer instead of selfsigned.
+    Check the cert-manager documentation for more information on how
+    to create and configure ClusterIssuers to acquire certificates.
+  * Add `OMV_K8S_FQDN` environment variable to allow a custom domain
+    name different from the one configured in OMV Network config. It
+    may be used when using Traefik as an external-facing server with
+    a public domain name, e.g. with a LetsEncrypt certificate.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Thu, 17 Apr 2025 21:16:51 +0200
 

--- a/deb/openmediavault-k8s/usr/share/openmediavault/engined/rpc/k8s.inc
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/engined/rpc/k8s.inc
@@ -237,6 +237,10 @@ class OMVRpcServiceK8s extends \OMV\Rpc\ServiceAbstract {
 				return $obj->get("domainname");
 			},
 			"fqdn" => function() use($db) {
+				$result = \OMV\Environment::get("OMV_K8S_FQDN");
+				if (!empty($result)) {
+					return $result;
+				}
 				$obj = $db->get("conf.system.network.dns");
 				if (!$obj->isEmpty("domainname")) {
 					$result = sprintf("%s.%s", $obj->get("hostname"),


### PR DESCRIPTION
...to be able to acquire certificates differently than selfsigned.

Example:
```
OMV_K8S_DEFAULT_TLS_CERT_ISSUER=my-own-issuer
OMV_K8S_FQDN=my-registered-domain.example.org
```

References:
- https://forum.openmediavault.org/index.php?thread/56486-kubernetes-custom-certificate-management-e-g-letsencrypt/
- https://cert-manager.io/docs/configuration/

Fixes: https://github.com/openmediavault/openmediavault/issues/1957


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [x] Includes tests for new functionality or reproducer for bug
    - I've [posted](https://forum.openmediavault.org/index.php?thread/56486-kubernetes-custom-certificate-management-e-g-letsencrypt/) manual testing instructions to the forum and tried it on my own OMV box and it works.
    - Let me know if automated tests are desired. If so, please kindly give a few pointers on where to start.