### PR TITLE
Use parent directory when a file is passed to `omv-btrfs-dfree`

### DIFF
--- a/deb/openmediavault/usr/sbin/omv-btrfs-dfree
+++ b/deb/openmediavault/usr/sbin/omv-btrfs-dfree
@@ -33,6 +33,8 @@ import openmediavault.procutils
 
 def main():
     path = os.path.realpath(sys.argv[1] if len(sys.argv) > 0 else '.')
+    if os.path.isfile(path):
+        path = os.path.dirname(path)
     output = openmediavault.procutils.check_output(
         ['btrfs', 'filesystem', 'usage', '--raw', path],
         stderr=subprocess.DEVNULL


### PR DESCRIPTION
When a file is copied on the same share on windows 11, the `dfree` command is called with the file path and crash the script:
```
[2025/05/25 16:22:11.074992,  3] ../../source3/smbd/smb2_trans2.c:2164(smbd_do_qfsinfo)
  smbd_do_qfsinfo: level = 1001
[2025/05/25 16:22:11.075089,  3] ../../source3/smbd/smb2_trans2.c:2164(smbd_do_qfsinfo)
  smbd_do_qfsinfo: level = 1005
[2025/05/25 16:22:11.075541,  3] ../../source3/smbd/smb2_trans2.c:2164(smbd_do_qfsinfo)
  smbd_do_qfsinfo: level = 1003
[2025/05/25 16:22:11.075621,  3] ../../source3/smbd/dfree.c:90(sys_disk_free)
  sys_disk_free: Running command '/usr/sbin/omv-btrfs-dfree dfree_file_fix.patch'
Traceback (most recent call last):
  File "/usr/sbin/omv-btrfs-dfree", line 62, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/sbin/omv-btrfs-dfree", line 36, in main
    output = openmediavault.procutils.check_output(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/openmediavault/procutils.py", line 63, in check_output
    return subprocess.check_output(*popenargs, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['btrfs', 'filesystem', 'usage', '--raw', '/srv/dev-disk-by-uuid-e48746a1-ae0a-474d-9c34-d3252701ab1d/downloads/dfree_file_fix.patch']
' returned non-zero exit status 1.
[2025/05/25 16:22:11.186193,  0] ../../source3/smbd/dfree.c:125(sys_disk_free)
  sys_disk_free: file_lines_load() failed for command '/usr/sbin/omv-btrfs-dfree dfree_file_fix.patch'. Error was : No child processes
```

Taking the path of the directory if the argument is a file fix this.