### PR TITLE
FR: Add UDEV rule to fix the duplicate serial number issue for USB enclosure

### DIFF
--- a/deb/openmediavault/etc/udev/rules.d/61-openmediavault-dev-disk-by-id.rules
+++ b/deb/openmediavault/etc/udev/rules.d/61-openmediavault-dev-disk-by-id.rules
@@ -770,6 +770,78 @@ ENV{ID_VENDOR_ID}=="152d", \
   SYMLINK="disk/by-path/$env{ID_PATH}", \
   SYMLINK+="disk/by-id/$env{ID_BUS}-$env{ID_SERIAL}"
 
+# External SATA Hard Drive Adapter cable PA023U3
+# https://devicehunt.com/view/type/usb/vendor/7825/device/a2a4
+#
+# P: /devices/pci0000:00/0000:00:14.0/usb2/2-3/2-3:1.0/host0/target0:0:0/0:0:0:0/block/sdb
+# M: sdb
+# U: block
+# T: disk
+# D: b 8:16
+# N: sdb
+# L: 0
+# S: disk/by-diskseq/3
+# S: disk/by-label/disk
+# S: disk/by-uuid/7067644550817850007
+# S: disk/by-id/usb-ST2000DM_008-2FR102_235678C218CA-0:0
+# S: disk/by-path/pci-0000:00:14.0-usb-0:3:1.0-scsi-0:0:0:0
+# Q: 3
+# E: DEVPATH=/devices/pci0000:00/0000:00:14.0/usb2/2-3/2-3:1.0/host0/target0:0:0/0:0:0:0/block/sdb
+# E: DEVNAME=/dev/sdb
+# E: DEVTYPE=disk
+# E: DISKSEQ=3
+# E: MAJOR=8
+# E: MINOR=16
+# E: SUBSYSTEM=block
+# E: USEC_INITIALIZED=3298176
+# E: ID_BUS=usb
+# E: ID_MODEL=008-2FR102
+# E: ID_MODEL_ENC=008-2FR102\x20\x20\x20\x20\x20\x20
+# E: ID_MODEL_ID=a2a4
+# E: ID_SERIAL=ST2000DM_008-2FR102_235678C218CA-0:0
+# E: ID_SERIAL_SHORT=235678C218CA
+# E: ID_VENDOR=ST2000DM
+# E: ID_VENDOR_ENC=ST2000DM
+# E: ID_VENDOR_ID=7825
+# E: ID_REVISION=4101
+# E: ID_TYPE=disk
+# E: ID_INSTANCE=0:0
+# E: ID_USB_MODEL=008-2FR102
+# E: ID_USB_MODEL_ENC=008-2FR102\x20\x20\x20\x20\x20\x20
+# E: ID_USB_MODEL_ID=a2a4
+# E: ID_USB_SERIAL=ST2000DM_008-2FR102_235678C218CA-0:0
+# E: ID_USB_SERIAL_SHORT=235678C218CA
+# E: ID_USB_VENDOR=ST2000DM
+# E: ID_USB_VENDOR_ENC=ST2000DM
+# E: ID_USB_VENDOR_ID=7825
+# E: ID_USB_REVISION=4101
+# E: ID_USB_TYPE=disk
+# E: ID_USB_INSTANCE=0:0
+# E: ID_USB_INTERFACES=:080650:080662:
+# E: ID_USB_INTERFACE_NUM=00
+# E: ID_USB_DRIVER=uas
+# E: ID_PATH=pci-0000:00:14.0-usb-0:3:1.0-scsi-0:0:0:0
+# E: ID_PATH_TAG=pci-0000_00_14_0-usb-0_3_1_0-scsi-0_0_0_0
+# E: ID_FS_VERSION=5000
+# E: ID_FS_LABEL=disk
+# E: ID_FS_LABEL_ENC=disk
+# E: ID_FS_UUID=7067644550817850007
+# E: ID_FS_UUID_ENC=7067644550817850007
+# E: ID_FS_UUID_SUB=9552983788758719893
+# E: ID_FS_UUID_SUB_ENC=9552983788758719893
+# E: ID_FS_TYPE=zfs_member
+# E: ID_FS_USAGE=filesystem
+# E: NVME_HOST_IFACE=none
+# E: DEVLINKS=/dev/disk/by-diskseq/3 /dev/disk/by-label/disk /dev/disk/by-uuid/7067644550817850007
+# E: TAGS=:systemd:
+# E: CURRENT_TAGS=:systemd:
+ENV{ID_VENDOR_ID}=="7825", \
+  ENV{ID_MODEL_ID}=="a2a4", \
+  IMPORT{program}="serial_id %N", \
+  ENV{ID_SERIAL}="$env{ID_VENDOR}_$env{ID_MODEL}_$env{ID_SERIAL_SHORT}-$env{ID_INSTANCE}", \
+  SYMLINK="disk/by-path/$env{ID_PATH}", \
+  SYMLINK+="disk/by-id/$env{ID_BUS}-$env{ID_SERIAL}"
+
 # by-uuid links (filesystem metadata)
 # Skip bcache backing devices, handled in `/lib/udev/rules.d/69-bcache.rules`.
 ENV{ID_FS_TYPE}=="bcache", GOTO="omv_skip_by_uuid"


### PR DESCRIPTION
Add UDEV rule to fix the duplicate serial number issue for External SATA Hard Drive Adapter cable PA023U3.

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
