### PR TITLE
fix: k8s certificates assigned through settings are overwritten by cert-manager

### DIFF
--- a/deb/openmediavault-k8s/debian/changelog
+++ b/deb/openmediavault-k8s/debian/changelog
@@ -4,6 +4,7 @@ openmediavault-k8s (7.4.10-1) stable; urgency=medium
   * Fix the file mode bits of the systemd unit file k3s.service to prevent
     "is marked world-writable" warnings.
   * Disable Kong admin UI which is part of the Kubernetes Dashboard.
+  * Issue #1972: Fix bug when using user defined SSL certificates.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Mon, 09 Jun 2025 15:04:01 +0200
 

--- a/deb/openmediavault-k8s/srv/salt/omv/deploy/k3s/10default.sls
+++ b/deb/openmediavault-k8s/srv/salt/omv/deploy/k3s/10default.sls
@@ -106,10 +106,18 @@ create_k3s_traefik_manifest:
           labels:
             app.kubernetes.io/part-of: openmediavault
         spec:
+{%- if k8s_config.sslcertificateref | length < 1 %}
           certificates:
             - secretName: default-tls-cert
           defaultCertificate:
             secretName: default-tls-cert
+{%- endif %}
+{%- if k8s_config.sslcertificateref | length > 0 %}
+          certificates:
+            - secretName: openmediavault-tls-cert
+          defaultCertificate:
+            secretName: openmediavault-tls-cert
+{%- endif %}
     - user: root
     - group: root
     - mode: 600
@@ -318,7 +326,7 @@ create_k3s_misc_manifest:
         apiVersion: v1
         kind: Secret
         metadata:
-          name: default-tls-cert
+          name: openmediavault-tls-cert
           namespace: kube-system
           labels:
             app.kubernetes.io/part-of: openmediavault

--- a/deb/openmediavault-k8s/srv/salt/omv/deploy/k3s/10default.sls
+++ b/deb/openmediavault-k8s/srv/salt/omv/deploy/k3s/10default.sls
@@ -106,17 +106,16 @@ create_k3s_traefik_manifest:
           labels:
             app.kubernetes.io/part-of: openmediavault
         spec:
-{%- if k8s_config.sslcertificateref | length < 1 %}
+{%- if k8s_config.sslcertificateref | length > 0 %}
+          certificates:
+            - secretName: userdefined-tls-cert
+          defaultCertificate:
+            secretName: userdefined-tls-cert
+{%- else %}
           certificates:
             - secretName: default-tls-cert
           defaultCertificate:
             secretName: default-tls-cert
-{%- endif %}
-{%- if k8s_config.sslcertificateref | length > 0 %}
-          certificates:
-            - secretName: openmediavault-tls-cert
-          defaultCertificate:
-            secretName: openmediavault-tls-cert
 {%- endif %}
     - user: root
     - group: root
@@ -326,7 +325,7 @@ create_k3s_misc_manifest:
         apiVersion: v1
         kind: Secret
         metadata:
-          name: openmediavault-tls-cert
+          name: userdefined-tls-cert
           namespace: kube-system
           labels:
             app.kubernetes.io/part-of: openmediavault


### PR DESCRIPTION
Fixes: #1972

- [X] References issue
- [X] Includes tests for new functionality or reproducer for bug

**To Reproduce**

Steps to reproduce the behavior:

1. Generate certificates to use with Open Media Vault (I used OpenSSL)
2. Add the certificates to Open Media Vault
2.1. Open System, Certificates, SSL
2.2. Add the certificate with the + button, uploading the PEM and KEY files
3. Install the Kubernetes plugin
4. Open Services, Kubernetes, Settings
5. Configure the Certificate option, with the certificates added in 2.2 above
6. Save the settings, and deploy
7. Wait for Kubernetes to be installed and configured
8. Click on the Open UI button
9. See certificate that is self generated by Kubernetes

This change uses a kubernetes secret openmediavault-tls-cert when a certificate is provided in the k8s settings certificate option for the traefik TLSStore.  Otherwise it uses the default-tls-cert (current behaviour).
The secret is created within the existing file /var/lib/rancher/k3s/server/manifests/openmediavault-misc.yaml instead of the default-tls-cert.