### PR TITLE
Resolve MD linting warnings in readme/security files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # openmediavault
-openmediavault is the next generation network attached storage (NAS) solution based on Debian Linux. It contains services like SSH, (S)FTP, SMB/CIFS, RSync and many more. Thanks to the modular design of the framework it can be enhanced via plugins. openmediavault is primarily designed to be used in home environments or small home offices, but is not limited to those scenarios. It is a simple and easy to use out-of-the-box solution that will allow everyone to install and administrate a Network Attached Storage without deeper knowledge.
+
+openmediavault is the next generation network attached storage (NAS) solution based on Debian Linux. It contains services like SSH, (S)FTP, SMB/CIFS, rsync and many more. Thanks to the modular design of the framework it can be enhanced via plugins. openmediavault is primarily designed to be used in home environments or small home offices, but is not limited to those scenarios. It is a simple and easy to use out-of-the-box solution that will allow everyone to install and administrate a Network Attached Storage without deeper knowledge.
 
 **Note: openmediavault (like other NAS solutions) expects to have full, exclusive control over OS configuration and cannot be used within a container. Also, no graphical desktop user interface can be installed in parallel.**
 
 ## Installation
-A detailed instruction about how to install openmediavault can be found [here](https://docs.openmediavault.org/en/stable/installation/index.html). 
+
+A detailed instruction about how to install openmediavault can be found [here](https://docs.openmediavault.org/en/stable/installation/index.html).
 
 ## Resources
+
 - [Documentation](https://docs.openmediavault.org)
 - [Forum](https://forum.openmediavault.org)
 - [Blog](https://blog.openmediavault.org)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ If you believe you have found a security issue in the openmediavault software, p
 
 When reporting a potential security problem, please bear this in mind:
 
-*   Make sure to provide as many details as possible about the vulnerability.
-*   Please do not disclose publicly any security issues until we fix them and publish security releases.
+* Make sure to provide as many details as possible about the vulnerability.
+* Please do not disclose publicly any security issues until we fix them and publish security releases.
 
 Contact the security team at security@openmediavault.org.


### PR DESCRIPTION
Resolve 2 markdown lint warnings in the readme and security files:

- Leave an empty line before lists
- Don't include empty spaces on list bullets