### PR TITLE
Wrap fields in a form container

### DIFF
--- a/deb/openmediavault-bcache/usr/share/openmediavault/workbench/component.d/omv-storage-bcache-backing-configuration-form-page.yaml
+++ b/deb/openmediavault-bcache/usr/share/openmediavault/workbench/component.d/omv-storage-bcache-backing-configuration-form-page.yaml
@@ -42,7 +42,6 @@ data:
               min: 0
               patternType: "float"
               required: true
-            flex: 75
           - type: select
             name: sequentialcutoffunit
             label: _("Unit")
@@ -54,7 +53,6 @@ data:
                 - ['GiB', 'GiB']
             validators:
               required: true
-            flex: 25
       - type: numberInput
         name: writebackdelay
         label: _("Writeback Delay")

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/form.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/form.component.html
@@ -146,10 +146,9 @@
     </ng-template>
 
     <ng-template [ngSwitchCase]="'container'">
-      <div class="omv-form-container omv-box-border omv-display-flex omv-flex-row omv-gap-3 omv-align-items-stretch">
+      <div class="omv-form-container omv-box-border omv-display-flex omv-flex-row omv-flex-wrap omv-gap-3 omv-align-items-stretch">
         <div *ngFor="let innerField of field.fields"
-             class="omv-form-container-item omv-max-w-{{ innerField.flex ?? 'none' }}"
-             [ngClass]="{'omv-flex-grow': innerField.flex, 'omv-flex-1': !innerField.flex }">
+             class="omv-form-container-item omv-flex-1">
           <ng-container [ngTemplateOutlet]="renderFormField"
                         [ngTemplateOutletContext]="{ $implicit: innerField }">
           </ng-container>

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/models/form-field-config.type.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/models/form-field-config.type.ts
@@ -176,9 +176,6 @@ export type FormFieldConfig = {
 
   // --- container ---
   fields?: Array<FormFieldConfig>;
-  // Fields in a container will respect the 'flex' configuration.
-  // Specifies the size of the field in percent.
-  flex?: 10 | 20 | 25 | 33 | 45 | 50 | 66 | 75 | 80 | 90 | 100;
 
   // --- button | card | hint ---
   text?: string;

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-bond-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-bond-form-page.component.ts
@@ -377,8 +377,7 @@ export class InterfaceBondFormPageComponent extends BaseFormPageComponent {
                 type: 'disabled',
                 constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
               }
-            ],
-            flex: 75
+            ]
           },
           {
             type: 'numberInput',
@@ -470,8 +469,7 @@ export class InterfaceBondFormPageComponent extends BaseFormPageComponent {
                 type: 'disabled',
                 constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
               }
-            ],
-            flex: 75
+            ]
           },
           {
             type: 'numberInput',

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-bridge-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-bridge-form-page.component.ts
@@ -178,8 +178,7 @@ export class InterfaceBridgeFormPageComponent extends BaseFormPageComponent {
                 type: 'disabled',
                 constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
               }
-            ],
-            flex: 75
+            ]
           },
           {
             type: 'numberInput',
@@ -271,8 +270,7 @@ export class InterfaceBridgeFormPageComponent extends BaseFormPageComponent {
                 type: 'disabled',
                 constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
               }
-            ],
-            flex: 75
+            ]
           },
           {
             type: 'numberInput',

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-ethernet-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-ethernet-form-page.component.ts
@@ -161,8 +161,7 @@ export class InterfaceEthernetFormPageComponent extends BaseFormPageComponent {
                 type: 'disabled',
                 constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
               }
-            ],
-            flex: 75
+            ]
           },
           {
             type: 'numberInput',
@@ -254,8 +253,7 @@ export class InterfaceEthernetFormPageComponent extends BaseFormPageComponent {
                 type: 'disabled',
                 constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
               }
-            ],
-            flex: 75
+            ]
           },
           {
             type: 'numberInput',

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-vlan-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-vlan-form-page.component.ts
@@ -189,8 +189,7 @@ export class InterfaceVlanFormPageComponent extends BaseFormPageComponent {
                 type: 'disabled',
                 constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
               }
-            ],
-            flex: 75
+            ]
           },
           {
             type: 'numberInput',
@@ -282,8 +281,7 @@ export class InterfaceVlanFormPageComponent extends BaseFormPageComponent {
                 type: 'disabled',
                 constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
               }
-            ],
-            flex: 75
+            ]
           },
           {
             type: 'numberInput',

--- a/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-wifi-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/network/interfaces/interface-wifi-form-page.component.ts
@@ -218,8 +218,7 @@ export class InterfaceWifiFormPageComponent extends BaseFormPageComponent {
                 type: 'disabled',
                 constraint: { operator: 'ne', arg0: { prop: 'method' }, arg1: 'static' }
               }
-            ],
-            flex: 75
+            ]
           },
           {
             type: 'numberInput',
@@ -311,8 +310,7 @@ export class InterfaceWifiFormPageComponent extends BaseFormPageComponent {
                 type: 'disabled',
                 constraint: { operator: 'ne', arg0: { prop: 'method6' }, arg1: 'static' }
               }
-            ],
-            flex: 75
+            ]
           },
           {
             type: 'numberInput',

--- a/deb/openmediavault/workbench/src/app/pages/services/smb/smb-share-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/smb/smb-share-form-page.component.ts
@@ -185,8 +185,7 @@ export class SmbShareFormPageComponent extends BaseFormPageComponent {
               min: 0,
               patternType: 'integer',
               required: true
-            },
-            flex: 45
+            }
           },
           {
             type: 'numberInput',
@@ -206,8 +205,7 @@ export class SmbShareFormPageComponent extends BaseFormPageComponent {
               min: 0,
               patternType: 'integer',
               required: true
-            },
-            flex: 45
+            }
           },
           {
             type: 'iconButton',

--- a/deb/openmediavault/workbench/src/app/pages/storage/filesystems/filesystem-quota-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/storage/filesystems/filesystem-quota-form-page.component.ts
@@ -75,8 +75,7 @@ export class FilesystemQuotaFormPageComponent extends BaseFormPageComponent {
               min: 0,
               patternType: 'integer',
               required: true
-            },
-            flex: 75
+            }
           },
           {
             type: 'select',
@@ -93,8 +92,7 @@ export class FilesystemQuotaFormPageComponent extends BaseFormPageComponent {
             },
             validators: {
               required: true
-            },
-            flex: 25
+            }
           }
         ]
       }


### PR DESCRIPTION
- Remove `flex` property from form fields.
- The width of the individual fields in a container is automatically adjusted to the number of form fields it contains. All fields have the same width.
- Fields are wrapped to the next line if the width of the browser window is not wide enough to display all fields in one line. The display on small screens such as tablets benefits from this.

Plugins do not have to adapt their code; the `flex` form field property is simply ignored.

### Wide viewport
<img width="1063" height="491" alt="grafik" src="https://github.com/user-attachments/assets/8605855c-7dec-4bae-9330-8c7989e555e3" />

### Small viewport
<img width="776" height="796" alt="grafik" src="https://github.com/user-attachments/assets/a7a49650-fe7a-4c8e-8f7e-0068d3f13da4" />

### Other
<img width="776" height="796" alt="grafik" src="https://github.com/user-attachments/assets/51e1524f-f38e-4394-8c2e-cddede279ab6" />

<img width="776" height="796" alt="grafik" src="https://github.com/user-attachments/assets/4f5b5be0-531c-44ce-979f-7ea99050b302" />
