### PR TITLE
Improve chrony systemd service configuration

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -2,6 +2,7 @@ openmediavault (7.7.14-1) stable; urgency=medium
 
   * Make sure specific domain names, e.g. `local` or `test`, can't be
     applied via RPC.
+  * Improve chrony systemd service configuration.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Fri, 01 Aug 2025 12:40:01 +0200
 

--- a/deb/openmediavault/debian/openmediavault.postinst
+++ b/deb/openmediavault/debian/openmediavault.postinst
@@ -587,6 +587,7 @@ case "$1" in
 			udevadm trigger || :
 		fi
 		if dpkg --compare-versions "$2" lt-nl "7.7.14"; then
+			deb-systemd-invoke restart chrony.service || :
 			salt-call --local --retcode-passthrough --no-color state.orchestrate \
 				omv.setup.shell >/dev/null || :
 		fi

--- a/deb/openmediavault/etc/systemd/system/chrony.service.d/openmediavault.conf
+++ b/deb/openmediavault/etc/systemd/system/chrony.service.d/openmediavault.conf
@@ -1,0 +1,13 @@
+[Unit]
+# openmediavault always retrieves the time information from an external time
+# server, so we need to make sure that chrony is started after the network is
+# online.
+# References:
+# - https://salsa.debian.org/debian/chrony/-/commit/6974494213d1bb2f4b979a9e21ea2c4f886f15c5
+# - https://salsa.debian.org/debian/chrony/-/commit/f573be255e18f42733a220e7219741abbc8cf2e6
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Restart=on-failure
+RestartSec=5


### PR DESCRIPTION
Make sure that chrony is started after the network is online. References:
- https://forum.openmediavault.org/index.php?thread/57076-chrony-service-control-process-exited-code-exited-status-226-namespace/
- https://salsa.debian.org/debian/chrony/-/commit/6974494213d1bb2f4b979a9e21ea2c4f886f15c5
- https://salsa.debian.org/debian/chrony/-/commit/f573be255e18f42733a220e7219741abbc8cf2e6


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
