### PR TITLE
Fixed network statistics #2001

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/system/net/networkinterface.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/net/networkinterface.inc
@@ -421,7 +421,7 @@ class NetworkInterface {
 		//   lan2:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
 		//   ext1:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
 		//   ext2:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
-		$regex = sprintf('/^\s*%s:(.*)$/im', $this->getDeviceName());
+		$regex = sprintf('/^\s*%s:[\s]?(.*)$/im', $this->getDeviceName());
 		if (1 !== preg_match($regex, file_get_contents("/proc/net/dev"),
 				$matches)) {
 			return FALSE;


### PR DESCRIPTION
Fix for the shifted network statistics

In case the /proc/net/dev output line has a space between the iface name and the rx bytes, the existing regex does not match properly. This pull request should fix the issue #2001 .

Fixes: #2001 

Signed-off-by: Tobias Link <ranger81@dsuclan.de>