### PR TITLE
Issue #2013: ACLs aren't loaded correctly when changing the relative path

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,6 @@
 openmediavault (7.7.17-1) stable; urgency=medium
 
-  *
+  * Issue #2013: ACLs aren't loaded correctly when changing the relative path.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Wed, 10 Sep 2025 06:37:39 +0200
 

--- a/deb/openmediavault/workbench/src/app/pages/storage/shared-folders/shared-folder-acl-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/storage/shared-folders/shared-folder-acl-form-page.component.ts
@@ -321,7 +321,7 @@ export class SharedFolderAclFormPageComponent extends BaseFormPageComponent impl
       self.afterViewInitEvent.subscribe(() => {
         const control: AbstractControl = self.form.formGroup.get('file');
         control?.valueChanges.pipe(distinctUntilChanged()).subscribe((value) => {
-          this.doLoadData(value).subscribe();
+          this.doLoadData(value).subscribe((res: RpcObjectResponse) => this.onLoadData(res));
         });
       })
     );


### PR DESCRIPTION
This is a regression introduced by https://github.com/openmediavault/openmediavault/pull/1987.

Fixes: https://github.com/openmediavault/openmediavault/issues/2013


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
