### PR TITLE
Using smartctl to get hdd temps values relied on the related smart IDs

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/smartinformation.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/smartinformation.inc
@@ -451,22 +451,44 @@ class SmartInformation {
 			return FALSE;
 		$result = 0;
 		$found = FALSE;
-		// Process the attributes to get the temperature value.
+
+		//
+		// Examples of the smartctl result structure on the possible
+		// IDs (#190, #194, #231) that are representing temperature values
+		//
+		// ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
+		// 190 Airflow_Temperature_Cel 0x0022   040   039   045    Old_age   Always   FAILING_NOW 60 (0 209 61 41)
+		//
+		// ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
+		// 190 Airflow_Temperature_Cel -O---K   065   044   045    Past 35 (0 3 35 35 0)
+		// ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
+		// 194 Temperature_Celsius     0x0002   214   214   000    Old_age   Always       -       28 (Lifetime Min/Max 21/32)
+		// 194 Temperature_Celsius     0x0022   060   061   000    Old_age   Always       -       60 (0 20 0 0)
+		// 194 Temperature_Celsius     0x0022   030   055   000    Old_age   Always       -       30 (Min/Max 17/55)
+		//
+		// ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
+		// 194 Temperature_Celsius     -O---K   076   037   ---    -    24 (Min/Max 19/37)
+		// ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
+		// 231 Temperature_Celsius     0x0013   100   100   010    Pre-fail  Always       -       0
+
+
+		// Looping through the attributes to get the temperature value by
+		// analyzing IDs (ID#) and attribute names (ATTRIBUTE_NAME)
 		foreach ($attributes as $attrk => $attrv) {
 			if (
 				in_array( (int) $attrv['id'], [190,194,231] )
 				&&
-				stripos( strtolower($attrv['attrname']), 'temperature')
+				stripos( $attrv['attrname'], 'temperature') !== false
 			) {
 				$regex = '/^(\d+)(\s+(.+))*$/';
 				if (1 !== preg_match($regex, $attrv['rawvalue'], $matches))
-					break;
+					continue;
 				$temp = intval($matches[1]);
 				if ((-15 > $temp) || (100 < $temp))
-					break;
-				if (!$found || ($temp > $result))
-					$result = $temp;
+					continue;
+
 				$found = TRUE;
+				$result = $temp;
 				break;
 			}
 		}


### PR DESCRIPTION
Usually the IDs 190, 194 and 231 where used for temperature values. Some SandForce or Phison controlled SSDs, like the Corsair Force LS SSD, don't have any temparature sensors at all. In this case you could find the value for "SSD_LIFE_LEFT" in the line with the ID 231.

getTemperature() used to solely check for one of the three IDs. As, as far as I my researches were correct, the attribute_name is always a string containing the substring "Temperature", including a check for this substring should do the trick.


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
