### PR TITLE
Fixing cases of wrongly assumed temperature values. 

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/smartinformation.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/smartinformation.inc
@@ -451,41 +451,46 @@ class SmartInformation {
 			return FALSE;
 		$result = 0;
 		$found = FALSE;
-		// Process the attributes to get the temperature value.
+
+		// Examples of the smartctl result structure of the possible
+		// IDs (#190, #194, #231) that are representing temperature values
+		//
+		// ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
+		// 190 Airflow_Temperature_Cel 0x0022   040   039   045    Old_age   Always   FAILING_NOW 60 (0 209 61 41)
+		//
+		// ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
+		// 190 Airflow_Temperature_Cel -O---K   065   044   045    Past 35 (0 3 35 35 0)
+		// ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
+		// 194 Temperature_Celsius     0x0002   214   214   000    Old_age   Always       -       28 (Lifetime Min/Max 21/32)
+		// 194 Temperature_Celsius     0x0022   060   061   000    Old_age   Always       -       60 (0 20 0 0)
+		// 194 Temperature_Celsius     0x0022   030   055   000    Old_age   Always       -       30 (Min/Max 17/55)
+		//
+		// ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
+		// 194 Temperature_Celsius     -O---K   076   037   ---    -    24 (Min/Max 19/37)
+		// ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
+		// 231 Temperature_Celsius     0x0013   100   100   010    Pre-fail  Always       -       0
+
+		// Looping through the attributes to get the temperature value by
+		// analyzing IDs (ID#) and attribute names (ATTRIBUTE_NAME)
 		foreach ($attributes as $attrk => $attrv) {
-			switch ($attrv['id']) {
-			case 190:
-				// ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
-				// 190 Airflow_Temperature_Cel 0x0022   040   039   045    Old_age   Always   FAILING_NOW 60 (0 209 61 41)
-				//
-				// ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
-				// 190 Airflow_Temperature_Cel -O---K   065   044   045    Past 35 (0 3 35 35 0)
-			case 194:
-				// ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
-				// 194 Temperature_Celsius     0x0002   214   214   000    Old_age   Always       -       28 (Lifetime Min/Max 21/32)
-				// 194 Temperature_Celsius     0x0022   060   061   000    Old_age   Always       -       60 (0 20 0 0)
-				// 194 Temperature_Celsius     0x0022   030   055   000    Old_age   Always       -       30 (Min/Max 17/55)
-				//
-				// ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
-				// 194 Temperature_Celsius     -O---K   076   037   ---    -    24 (Min/Max 19/37)
-			case 231: // temperature-celsius
-				// ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
-				// 231 Temperature_Celsius     0x0013   100   100   010    Pre-fail  Always       -       0
+			if (
+				in_array( (int) $attrv['id'], [190,194,231] )
+				&&
+				stripos( $attrv['attrname'], 'temperature') !== false
+			) {
 				$regex = '/^(\d+)(\s+(.+))*$/';
 				if (1 !== preg_match($regex, $attrv['rawvalue'], $matches))
-					break;
-				// Verify temperature.
+					continue;
 				$temp = intval($matches[1]);
 				if ((-15 > $temp) || (100 < $temp))
-					break;
-				if (!$found || ($temp > $result))
-					$result = $temp;
+					continue;
+
 				$found = TRUE;
+				$result = $temp;
 				break;
 			}
-			if (TRUE === $found)
-				break;
 		}
+
 		// If the SMART attributes are not present then it may be a SAS
 		// or older SCSI device. Then the command output looks like:
 		//


### PR DESCRIPTION
This fixes a failure using smartctl to get hdd temperature values relied on the related smart IDs.

Usually the IDs 190, 194 and 231 where used for temperature values. Some SandForce or Phison controlled SSDs, like the Corsair Force LS SSD, don't have any temperature sensors at all. This can lead to finding a wrong attribute at ID 231, like "SSD_LIFE_LEFT", giving the maintainer slight heart attacks.

getTemperature() used to solely check for one of the three IDs. As, as far as my researches were correct, the attribute_name is always a string containing the substring "Temperature". Including a check for this substring should do the trick. 

Fixes: 
There are two blocks inside the getTemperature() method to find the right temperature value. One for smart devices and one for non-smart devices. This fixes the smart-device-block.
 - ditching the switch case for a short in_array()
 - adding a second comparison to check if the attribute name does include the substring "temperature" (case insensitive)
 - moving the comment blocks inside the switch cases to an area right before the foreach-loop.


Signed-off-by: robNice <robnice@downlord.net>