### PR TITLE
Add functionality to execute a function to populate an environment variable

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/engined/inc/10rootdevicefile.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/inc/10rootdevicefile.inc
@@ -19,8 +19,12 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenMediaVault. If not, see <https://www.gnu.org/licenses/>.
  */
-// Initialize the root device file. The value is cached by the method
-// to avoid further useless process calls. The code below is executed by
-// the omv-engined parent process, so all forked child processes can
-// access the static value.
-\OMV\System\System::getRootDeviceFile();
+// Make the root device file a environment variable. The root device file
+// should not change under normal circumstances.
+\OMV\Environment::set("OMV_ROOT_DEVICE_FILE", function() {
+	// Note, the returned value is cached by the method `getRootDeviceFile`
+	// itself to avoid further useless process calls. The code below is
+	// executed by the omv-engined parent process, so all forked child
+	// processes can access the static value as well.
+	return \OMV\System\System::getRootDeviceFile();
+});

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/diskmgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/diskmgmt.inc
@@ -59,9 +59,6 @@ class DiskMgmt extends \OMV\Rpc\ServiceAbstract {
 		$this->validateMethodContext($context, [
 			"role" => OMV_ROLE_ADMINISTRATOR
 		]);
-		// Get the device containing the operating system. Mark it as
-		// read-only to deny wiping this device.
-		$rootDeviceFile = \OMV\System\System::getRootDeviceFile();
 		// Get all existing devices except software RAID devices.
 		if (FALSE === ($devs = \OMV\System\Storage\StorageDevice::enumerate(
 		  OMV_STORAGE_DEVICE_TYPE_DISK))) {

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/filesystemmgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/filesystemmgmt.inc
@@ -266,7 +266,8 @@ class OMVRpcServiceFileSystemMgmt extends \OMV\Rpc\ServiceAbstract {
 		) {
 			$rootObject = new \OMV\Config\ConfigObject(
 				"conf.system.filesystem.mountpoint");
-			$rootObject->set("fsname", \OMV\System\System::getRootDeviceFile());
+			$rootObject->set("fsname", \OMV\Environment::get(
+				"OMV_ROOT_DEVICE_FILE"));
 			$rootObject->set("dir", "/");
 			$rootObject->set("comment", "");
 			$rootObject->set("usagewarnthreshold", \OMV\Environment::get(

--- a/deb/openmediavault/usr/share/php/openmediavault/environment.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/environment.inc
@@ -50,7 +50,17 @@ class Environment {
 		return $default;
 	}
 
+	/**
+	 * Set the specified environment variable.
+	 * @param string $name The name of the environment variable.
+	 * @param any $value The value of the environment variable. If this
+	 *   variable is a callable function, then it is executed. The
+	 *   function has to return a value.
+	 */
 	public static function set($name, $value) {
+		if (is_callable($value)) {
+			$value = call_user_func($value);
+		}
 		$GLOBALS[$name] = $value;
 	}
 

--- a/deb/openmediavault/usr/share/php/openmediavault/system/system.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/system.inc
@@ -41,8 +41,9 @@ class System {
 		// Cache the root device file. If this should change during the
 		// meantime something strange has been happened to the system.
 		static $rootDeviceFile = NULL;
-		if (!is_null($rootDeviceFile))
+		if (!is_null($rootDeviceFile)) {
 			return $rootDeviceFile;
+		}
 		// Do not use /dev/root anymore because Debian has removed this
 		// symlink in Jessie. The OMV workaround to create this symlink
 		// during the boot process via an udev rule does not work reliable.
@@ -65,8 +66,9 @@ class System {
 	public static function isRootDeviceFile($deviceFile, $exact = TRUE) {
 		// '/dev/root' is obsolete, but we still keep it (maybe we will
 		// need it sometime).
-		if ("/dev/root" == $deviceFile)
+		if ("/dev/root" == $deviceFile) {
 			return TRUE;
+		}
 		$rootDeviceFile = static::getRootDeviceFile();
 		if (TRUE === $exact) {
 			return (($rootDeviceFile == $deviceFile) ||


### PR DESCRIPTION
Note, the `OMV_ROOT_DEVICE_FILE` is not really necessary because `\OMV\System\System::getRootDeviceFile()` is already caching the result, but it is a nice example how the new feature works.


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
