### PR TITLE
Display old versions of upgradable packages on the update page

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -10,6 +10,7 @@ openmediavault (8.0-10) stable; urgency=medium
     response times dramatically.
   * Display updated modules in notification after configuration changes have
     been applied.
+  * Display old versions of upgradable packages on the update page.
   * Issue #1737 && #1866: Add support for WPA3 (SAE) authentication for
     wireless connections.
 

--- a/deb/openmediavault/workbench/src/app/pages/system/updates/update-datatable-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/system/updates/update-datatable-page.component.ts
@@ -34,7 +34,7 @@ export class UpdateDatatablePageComponent {
         cellTemplateConfig:
           '<div>' +
           '  <div class="omv-display-flex omv-flex-column">' +
-          '    <div class="omv-font-weight-title omv-font-size-title">{{ name }} {{ version }}</div>' +
+          '    <div><span class="omv-font-weight-title omv-font-size-title">{{ name }} {{ version }}</span> ({{ "from" | translate }} {{ oldversion | notavailable | translate }})</div>' +
           '    <div class="omv-font-size-subheading-2">{{ summary }}</div>' +
           '  </div>' +
           '  <br>' +
@@ -48,6 +48,13 @@ export class UpdateDatatablePageComponent {
       },
       { name: gettext('Name'), prop: 'name', flexGrow: 1, sortable: true, hidden: true },
       { name: gettext('Version'), prop: 'version', flexGrow: 1, sortable: true, hidden: true },
+      {
+        name: gettext('Old Version'),
+        prop: 'oldversion',
+        flexGrow: 1,
+        sortable: true,
+        hidden: true
+      },
       {
         name: gettext('Repository'),
         prop: 'repository',


### PR DESCRIPTION
Related to: https://forum.openmediavault.org/index.php?thread/57716-suggestion-show-current-version-next-to-package-updates/

<img width="1555" height="696" alt="grafik" src="https://github.com/user-attachments/assets/36bad57a-4235-40d2-af5e-7eba8726bb26" />

<img width="1555" height="696" alt="grafik" src="https://github.com/user-attachments/assets/11c8598b-f990-4f08-a637-4f84c23d911b" />

<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
