### PR TITLE
Add IPv6 detection when installing OMV over Debian

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/confdb/populate.d/40interfaces.sh
+++ b/deb/openmediavault/usr/share/openmediavault/confdb/populate.d/40interfaces.sh
@@ -38,18 +38,21 @@ for dnsnameserver in $(grep -iP "^\s*dns-nameservers\s+.*$" ${OMV_INTERFACES_CON
 done
 
 # Configure ethernet network interfaces.
-# Understanding systemd’s predictable network device names:
+# Understanding systemd's predictable network device names:
 # https://github.com/systemd/systemd/blob/master/src/udev/udev-builtin-net_id.c
-grep -iP "^\s*iface\s+(eth[0-9]+|en[a-z0-9]+)\s+(inet|inet6)\s+(static|dhcp)" ${OMV_INTERFACES_CONFIG} |
+grep -iP "^\s*iface\s+(eth[0-9]+|en[a-z0-9]+)\s+(inet6?)\s+(static|dhcp|auto)" ${OMV_INTERFACES_CONFIG} |
     while read type devname family method; do
-        # Skip IPv6 for now. Should be fixed in a future version.
-        [ "inet6" = "${family}" ] && continue
-        # Add interface if it does not already exist.
-        if ! omv-confdbadm exists --filter "{\"operator\":\"and\", \
+        # Skip if interface already exists (handles interfaces with both inet and inet6 lines).
+        if omv-confdbadm exists --filter "{\"operator\":\"and\", \
                 \"arg0\":{\"operator\":\"stringEquals\",\"arg0\":\"type\", \
                 \"arg1\":\"ethernet\"},\"arg1\":{\"operator\":\"stringEquals\", \
                 \"arg0\":\"devicename\",\"arg1\":\"${devname}\"}}" \
                 "conf.system.network.interface"; then
+            continue
+        fi
+
+        # IPv4 configuration.
+        if [ "inet" = "${family}" ]; then
             address=""
             netmask=""
             gateway=""
@@ -61,19 +64,67 @@ grep -iP "^\s*iface\s+(eth[0-9]+|en[a-z0-9]+)\s+(inet|inet6)\s+(static|dhcp)" ${
                 netmask=$(echo ${data} | jq --raw-output '.netmask // empty')
                 gateway=$(salt-call --local --retcode-passthrough --no-color \
                     --out=json network.routes inet | \
-                    jq --raw-output ".[] | map(select((.interface == \"${devname}\") and \
-                    (.flags == \"UG\"))) | first | .gateway // empty")
+                    jq --raw-output ".[] | map(select((.interface == \
+                    \"${devname}\") and (.flags == \"UG\"))) | first | \
+                    .gateway // empty")
             fi
-            jq --null-input --compact-output "{uuid: \"${OMV_CONFIGOBJECT_NEW_UUID}\", \
-                devicename: \"${devname}\", type: \"ethernet\", method6: \"manual\", \
-                address6: \"\", netmask6: 64, gateway6: \"\", routemetric6: 1, \
-                dnsnameservers: \"${dnsnameservers}\", dnssearch: \"\", \
-                wol: false, mtu: 0, \
-                comment: \"\", method: \"${method}\", \
-                address: \"${address}\", netmask: \"${netmask}\", \
-                gateway: \"${gateway}\", routemetric: 0}" |
-                omv-confdbadm update "conf.system.network.interface" -
+        else
+            # IPv6-only interface: disable IPv4.
+            method="manual"
+            address=""
+            netmask=""
+            gateway=""
         fi
+
+        # IPv6 configuration.
+        method6="manual"
+        address6=""
+        netmask6=64
+        gateway6=""
+
+        if [ "inet6" = "${family}" ]; then
+            # Matched line is inet6, use its method directly.
+            method6="${method}"
+            # Reset method for IPv4 (already set to manual above).
+            method="manual"
+        else
+            # Matched line is inet, check for secondary inet6 configuration.
+            ipv6Config=$(grep -iP \
+                "^\s*iface\s+${devname}\s+inet6\s+(auto|dhcp|static)" \
+                ${OMV_INTERFACES_CONFIG} || true)
+            if [ -n "${ipv6Config}" ]; then
+                method6=$(echo "${ipv6Config}" | \
+                    grep -oP 'inet6\s+\K(auto|dhcp|static)')
+            fi
+        fi
+
+        # Get static IPv6 address/gateway from runtime state.
+        if [ "static" = "${method6}" ]; then
+            ipv6Data=$(ip -6 -o addr show dev "${devname}" \
+                scope global 2>/dev/null | head -1)
+            if [ -n "${ipv6Data}" ]; then
+                addr6Cidr=$(echo "${ipv6Data}" | \
+                    grep -oP 'inet6\s+\K[a-fA-F0-9:]+/\d+')
+                if [ -n "${addr6Cidr}" ]; then
+                    address6=$(echo "${addr6Cidr}" | cut -d'/' -f1)
+                    netmask6=$(echo "${addr6Cidr}" | cut -d'/' -f2)
+                fi
+            fi
+            gateway6=$(ip -6 route show dev "${devname}" 2>/dev/null | \
+                grep -oP '^default via \K[a-fA-F0-9:]+' | head -1)
+        fi
+
+        jq --null-input --compact-output \
+            "{uuid: \"${OMV_CONFIGOBJECT_NEW_UUID}\", \
+            devicename: \"${devname}\", type: \"ethernet\", \
+            method: \"${method}\", address: \"${address}\", \
+            netmask: \"${netmask}\", gateway: \"${gateway}\", \
+            routemetric: 0, method6: \"${method6}\", \
+            address6: \"${address6}\", netmask6: ${netmask6}, \
+            gateway6: \"${gateway6}\", routemetric6: 1, \
+            dnsnameservers: \"${dnsnameservers}\", dnssearch: \"\", \
+            mtu: 0, wol: false, comment: \"\"}" | \
+            omv-confdbadm update "conf.system.network.interface" -
     done
 
 # Create a backup of the original configuration file.


### PR DESCRIPTION
Added IPv6 support to [40interfaces.sh](https://github.com/openmediavault/openmediavault/blob/master/deb/openmediavault/usr/share/openmediavault/confdb/populate.d/40interfaces.sh).

Initial script skipped IPv6 detection.
It now detects IPv6.

Fixes: https://forum.openmediavault.org/index.php?thread/57706-providing-help-and-getting-eta-for-omv8/&postID=427168#post427168

First PR, signed and sent the OCA.
I hope everything is in place, please tell me if not.

Signed-off-by: Robin LABADIE - LRob <git@lrob.fr>