### PR TITLE
Issue #1555: Add ability to SMB shares to limit the reported disk size for Time Machine

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,3 +1,10 @@
+openmediavault (8.0.1-1) stable; urgency=medium
+
+  * Issue #1555: Add ability to SMB shares to limit the reported disk size
+    for Time Machine.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Sun, 21 Dec 2025 16:32:03 +0100
+
 openmediavault (8.0-13) stable; urgency=medium
 
   * Upgrade to Debian 13 (Trixie).

--- a/deb/openmediavault/srv/salt/omv/deploy/samba/files/shares.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/samba/files/shares.j2
@@ -72,6 +72,9 @@ fruit:veto_appledouble = {{ fruit_veto_appledouble }}
 fruit:wipe_intentionally_left_blank_rfork = {{ fruit_wipe_intentionally_left_blank_rfork }}
 fruit:delete_empty_adfiles = {{ fruit_delete_empty_adfiles }}
 fruit:time machine = yes
+{%- if share.timemachinemaxsize | length > 0 %}
+fruit:time machine max size = {{ share.timemachinemaxsize }}
+{%- endif %}
 {%- endif %}
 {%- if share.recyclebin | to_bool %}
 {%- set _ = vfs_objects.append('recycle') %}

--- a/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_8.0.1.sh
+++ b/deb/openmediavault/usr/share/openmediavault/confdb/migrations.d/conf_8.0.1.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env dash
+#
+# This file is part of OpenMediaVault.
+#
+# @license   https://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2025 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <https://www.gnu.org/licenses/>.
+
+set -e
+
+. /usr/share/openmediavault/scripts/helper-functions
+
+omv_config_add_key "/config/services/smb/shares/share" "timemachinemaxsize" ""
+
+exit 0

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smb.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smb.json
@@ -172,6 +172,11 @@
 								"type": "boolean",
 								"default": false
 							},
+							"timemachinemaxsize": {
+								"type": "string",
+								"pattern": "^(\\d+[KMGTP]?)?$",
+								"default": ""
+							},
 							"transportencryption": {
 								"type": "boolean",
 								"default": false

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smb.share.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.service.smb.share.json
@@ -82,6 +82,11 @@
 			"type": "boolean",
 			"default": false
 		},
+		"timemachinemaxsize": {
+			"type": "string",
+			"pattern": "^(\\d+[KMGTP]?)?$",
+			"default": ""
+		},
 		"transportencryption": {
 			"type": "boolean",
 			"default": false

--- a/deb/openmediavault/usr/share/openmediavault/locale/openmediavault.pot
+++ b/deb/openmediavault/usr/share/openmediavault/locale/openmediavault.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-30 11:37+0100\n"
+"POT-Creation-Date: 2025-12-21 21:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1721,6 +1721,9 @@ msgstr ""
 msgid "Limit monthly"
 msgstr ""
 
+msgid "Limit the reported disk size, thus preventing Time Machine from using the whole real disk space for backup."
+msgstr ""
+
 msgid "Limit weekly"
 msgstr ""
 
@@ -1848,6 +1851,9 @@ msgid "Max. connections"
 msgstr ""
 
 msgid "Maximum"
+msgstr ""
+
+msgid "Maximum disk size"
 msgstr ""
 
 msgid "Maximum file size"
@@ -3348,6 +3354,9 @@ msgid "This field is required."
 msgstr ""
 
 msgid "This field must have the format <hh:mm:ss>."
+msgstr ""
+
+msgid "This field must match the format SIZE[K|M|G|T|P]."
 msgstr ""
 
 msgid "This field should be a IP network address in CIDR notation."

--- a/deb/openmediavault/workbench/src/app/pages/services/smb/smb-share-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/services/smb/smb-share-form-page.component.ts
@@ -112,6 +112,27 @@ export class SmbShareFormPageComponent extends BaseFormPageComponent {
         value: false
       },
       {
+        type: 'textInput',
+        name: 'timemachinemaxsize',
+        label: gettext('Maximum disk size'),
+        hint: gettext(
+          'Limit the reported disk size, thus preventing Time Machine from using the whole real disk space for backup.'
+        ),
+        value: '',
+        validators: {
+          pattern: {
+            pattern: '^\\d+[KMGTP]?$',
+            errorData: gettext('This field must match the format SIZE[K|M|G|T|P].')
+          }
+        },
+        modifiers: [
+          {
+            type: 'hidden',
+            constraint: { operator: 'falsy', arg0: { prop: 'timemachine' } }
+          }
+        ]
+      },
+      {
         type: 'checkbox',
         name: 'transportencryption',
         label: gettext('Transport encryption'),


### PR DESCRIPTION
Fixes: https://github.com/openmediavault/openmediavault/issues/1555

References:
- https://www.samba.org/samba/docs/current/man-html/vfs_fruit.8.html


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
