### PR TITLE
Add email notification batching for scheduled power operations

### DIFF
--- a/deb/openmediavault/debian/openmediavault.postinst
+++ b/deb/openmediavault/debian/openmediavault.postinst
@@ -201,6 +201,7 @@ case "$1" in
 		deb-systemd-helper enable openmediavault-cleanup-php.service
 		deb-systemd-helper enable openmediavault-engined.service
 		deb-systemd-helper enable openmediavault-issue.service
+		deb-systemd-helper enable openmediavault-powermgmt-postreboot.service
 
 		########################################################################
 		# Activate trigger to rebuild workbench configuration files.

--- a/deb/openmediavault/etc/systemd/system/openmediavault-powermgmt-postreboot.service
+++ b/deb/openmediavault/etc/systemd/system/openmediavault-powermgmt-postreboot.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Send consolidated power management notifications after reboot
+After=network-online.target monit.service openmediavault-engined.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/bash -c 'if [ -f /var/lib/openmediavault/powermgmt-operation.state ]; then \
+    AGE=$(($(date +%%s) - $(stat -c %%Y /var/lib/openmediavault/powermgmt-operation.state))); \
+    if [ $AGE -gt 600 ]; then \
+        logger "Stale power management marker detected, cleaning up"; \
+        rm -f /var/lib/openmediavault/powermgmt-operation.state /var/lib/openmediavault/powermgmt-events.log; \
+        exit 1; \
+    fi; \
+fi'
+ExecStart=/usr/sbin/omv-powermgmt-sendemail reboot
+ExecStartPost=/usr/sbin/omv-powermgmt-restore-monit
+RemainAfterExit=no
+
+[Install]
+WantedBy=multi-user.target

--- a/deb/openmediavault/srv/salt/omv/deploy/cron/files/powermanagement.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/cron/files/powermanagement.j2
@@ -12,5 +12,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 {%- else -%}
 @{{ job.execution }}
 {%- endif -%}
-{{ separator }}{{ job.username }}{{ separator }}{{ 'systemctl ' + (job.type | replace('shutdown', 'poweroff') | replace('standby', config.standbymode) | replace('suspendhybrid', 'hybrid-sleep')) }} >/dev/null 2>&1
+{{ separator }}{{ job.username }}{{ separator }}{{ '/usr/sbin/omv-powermgmt-wrapper ' + (job.type | replace('shutdown', 'poweroff') | replace('standby', config.standbymode) | replace('suspendhybrid', 'hybrid-sleep')) }} >/dev/null 2>&1
 {%- endfor -%}

--- a/deb/openmediavault/srv/salt/omv/deploy/monit/alertprogram.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/monit/alertprogram.sls
@@ -1,0 +1,42 @@
+# This file is part of OpenMediaVault.
+#
+# @license   https://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2025 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <https://www.gnu.org/licenses/>.
+
+# Deploy Monit configuration with alert program for email batching during
+# power management operations. This is called explicitly by omv-powermgmt-wrapper
+# when batching mode is activated via: omv-salt deploy run monit.alertprogram
+
+{% set email_config = salt['omv_conf.get']('conf.system.notification.email') %}
+
+configure_monit_alertprogram:
+  file.managed:
+    - name: "/etc/monit/monitrc"
+    - source:
+      - salt://{{ tpldir }}/files/etc-monit-monitrc-alertprogram.j2
+    - template: jinja
+    - context:
+        email_config: {{ email_config | json }}
+    - user: root
+    - group: root
+    - mode: 700
+
+reload_monit_alertprogram:
+  cmd.run:
+    - name: "systemctl reload monit"
+    - require:
+      - file: configure_monit_alertprogram

--- a/deb/openmediavault/srv/salt/omv/deploy/monit/files/etc-monit-monitrc-alertprogram.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/monit/files/etc-monit-monitrc-alertprogram.j2
@@ -1,0 +1,50 @@
+{%- set check_interval = salt['pillar.get']('default:OMV_MONIT_CHECK_INTERVAL', '30') -%}
+{%- set check_start_delay = salt['pillar.get']('default:OMV_MONIT_CHECK_START_DELAY', '30') -%}
+{%- set logfile = salt['pillar.get']('default:OMV_MONIT_LOGFILE', 'syslog facility log_daemon') -%}
+{%- set idfile = salt['pillar.get']('default:OMV_MONIT_IDFILE', '/var/lib/monit/id') -%}
+{%- set statefile = salt['pillar.get']('default:OMV_MONIT_STATEFILE', '/var/lib/monit/state') -%}
+{%- set unixsocket = salt['pillar.get']('default:OMV_MONIT_UNIXSOCKET', '/run/monit.sock') -%}
+{%- set eventqueue_basedir = salt['pillar.get']('default:OMV_MONIT_EVENTQUEUE_BASEDIR', '/var/lib/monit/events') -%}
+{%- set eventqueue_slots = salt['pillar.get']('default:OMV_MONIT_EVENTQUEUE_SLOTS', '100') -%}
+{%- set include_dir = salt['pillar.get']('default:OMV_MONIT_CONFIG_INCLUDE_DIR', '/etc/monit/conf.d') -%}
+{%- set email_timeout = salt['pillar.get']('default:OMV_MONIT_EMAIL_TIMEOUT', '5') -%}
+{%- set email_alert_noevents = salt['pillar.get']('default:OMV_MONIT_EMAIL_ALERT_NOTEVENTS', 'action, instance') -%}
+{{ pillar['headers']['multiline'] }}
+set daemon {{ check_interval }} with start delay {{ check_start_delay }}
+set logfile {{ logfile }}
+set idfile {{ idfile }}
+set statefile {{ statefile }}
+
+set httpd unixsocket {{ unixsocket }}
+    allow localhost
+
+set eventqueue
+    basedir {{ eventqueue_basedir }}
+    slots {{ eventqueue_slots }}
+
+{%- if email_config.enable | to_bool  %}
+set mailserver 127.0.0.1
+    with timeout {{ email_timeout }} seconds
+set mail-format {
+    from: {{ email_config.sender }}
+    subject: Monitoring $ACTION -- $EVENT $SERVICE
+    message:
+The system monitoring needs your attention.
+
+Host:        $HOST
+Date:        $DATE
+Service:     $SERVICE
+Event:       $EVENT
+Description: $DESCRIPTION
+
+This triggered the monitoring system to: $ACTION
+
+—
+You have received this notification because you have enabled the system monitoring on this host.
+To change your notification preferences, please go to the 'System | Notification' or 'System | Monitoring' page in the web interface.
+}
+# Power management batching mode: Use alert program instead of direct SMTP
+set alert {{ email_config.primaryemail }} not reminder on { {{ email_alert_noevents }} } with mail-format { from: {{ email_config.sender }} }  mail-format { subject: $EVENT -- $SERVICE } PROGRAM /usr/sbin/omv-powermgmt-alert-handler
+{% endif %}
+
+include {{ include_dir }}/*

--- a/deb/openmediavault/usr/sbin/omv-powermgmt-alert-handler
+++ b/deb/openmediavault/usr/sbin/omv-powermgmt-alert-handler
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# This file is part of OpenMediaVault.
+#
+# @license   https://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2025 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <https://www.gnu.org/licenses/>.
+
+set -e
+
+# Alert handler for Monit notifications during power management batching
+# When batching is active, this script logs events to a file instead of sending emails
+# When not in batching mode, sends email normally via PHP
+
+MARKER_FILE="/var/lib/openmediavault/powermgmt-operation.state"
+EVENT_LOG="/var/lib/openmediavault/powermgmt-events.log"
+EMAIL_CONFIG_XPATH=".//system/email"
+
+# Monit sets these environment variables:
+# MONIT_SERVICE - service name
+# MONIT_EVENT - event type (e.g., "Restart", "Stop", "Start")
+# MONIT_ACTION - action taken (e.g., "restart", "alert")
+# MONIT_DESCRIPTION - detailed description
+# MONIT_HOST - hostname
+# MONIT_DATE - date/time
+
+# Check if we're in batching mode
+if [ ! -f "${MARKER_FILE}" ]; then
+	# Not in batching mode, send email normally via PHP
+	SENDER=$(omv-confdbadm read "${EMAIL_CONFIG_XPATH}/sender" 2>/dev/null || echo "root@localhost")
+	PRIMARY_EMAIL=$(omv-confdbadm read "${EMAIL_CONFIG_XPATH}/primaryemail" 2>/dev/null || echo "root@localhost")
+	SECONDARY_EMAIL=$(omv-confdbadm read "${EMAIL_CONFIG_XPATH}/secondaryemail" 2>/dev/null || echo "")
+
+	# Build recipient list
+	TO="${PRIMARY_EMAIL}"
+	if [ -n "${SECONDARY_EMAIL}" ]; then
+		TO="${TO},${SECONDARY_EMAIL}"
+	fi
+
+	# Build subject
+	SUBJECT="${MONIT_EVENT} - ${MONIT_SERVICE}"
+
+	# Build message body
+	MESSAGE="The system monitoring needs your attention.
+
+Host:        ${MONIT_HOST}
+Date:        ${MONIT_DATE}
+Service:     ${MONIT_SERVICE}
+Event:       ${MONIT_EVENT}
+Description: ${MONIT_DESCRIPTION}
+
+This triggered the monitoring system to: ${MONIT_ACTION}
+
+—
+You have received this notification because you have enabled the system monitoring on this host.
+To change your notification preferences, please go to the 'System | Notification' or 'System | Monitoring' page in the web interface."
+
+	# Use PHP to send email via OMV\Email class
+	php -r "
+	require_once '/usr/share/php/openmediavault/autoloader.inc';
+	\$mail = new \OMV\Email('${SENDER}', '${TO}', '${SUBJECT}', '${MESSAGE}');
+	\$mail->send();
+	" 2>/dev/null || true
+
+	exit 0
+fi
+
+# Batching mode: Log event to file
+# Format: timestamp|service|event|action|description
+cat >> "${EVENT_LOG}" <<EOF
+$(date --iso-8601=seconds)|${MONIT_SERVICE:-unknown}|${MONIT_EVENT:-unknown}|${MONIT_ACTION:-unknown}|${MONIT_DESCRIPTION:-No description}
+EOF

--- a/deb/openmediavault/usr/sbin/omv-powermgmt-restore-monit
+++ b/deb/openmediavault/usr/sbin/omv-powermgmt-restore-monit
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# This file is part of OpenMediaVault.
+#
+# @license   https://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2025 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <https://www.gnu.org/licenses/>.
+
+set -e
+
+# Restore normal Monit configuration after power management operation
+# This script is called after reboot to ensure Monit is back to normal mode
+
+# Deploy normal Monit configuration
+/usr/sbin/omv-salt deploy run monit >/dev/null 2>&1
+
+exit 0

--- a/deb/openmediavault/usr/sbin/omv-powermgmt-sendemail
+++ b/deb/openmediavault/usr/sbin/omv-powermgmt-sendemail
@@ -1,0 +1,173 @@
+#!/bin/bash
+#
+# This file is part of OpenMediaVault.
+#
+# @license   https://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2025 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <https://www.gnu.org/licenses/>.
+
+set -e
+
+# Consolidated email sender for power management events
+# Reads collected events from log file and sends a single consolidated email
+
+OPERATION="$1"
+MARKER_FILE="/var/lib/openmediavault/powermgmt-operation.state"
+EVENT_LOG="/var/lib/openmediavault/powermgmt-events.log"
+
+# Check if marker file exists
+if [ ! -f "${MARKER_FILE}" ]; then
+	# No marker file, nothing to do
+	exit 0
+fi
+
+# Check if event log exists and has content
+if [ ! -f "${EVENT_LOG}" ] || [ ! -s "${EVENT_LOG}" ]; then
+	# No events logged, cleanup and exit
+	rm -f "${MARKER_FILE}" "${EVENT_LOG}"
+	exit 0
+fi
+
+# Build and send consolidated email using PHP
+php <<'PHPCODE'
+<?php
+require_once '/usr/share/php/openmediavault/autoloader.inc';
+
+$markerFile = '/var/lib/openmediavault/powermgmt-operation.state';
+$eventLog = '/var/lib/openmediavault/powermgmt-events.log';
+
+// Check if files exist
+if (!file_exists($markerFile) || !file_exists($eventLog)) {
+    exit(0);
+}
+
+// Parse marker file
+$markerContent = file_get_contents($markerFile);
+preg_match('/operation=(\w+)/', $markerContent, $matches);
+$operation = $matches[1] ?? 'unknown';
+
+// Read events from log file
+$events = [];
+if (file_exists($eventLog)) {
+    $lines = file($eventLog, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    foreach ($lines as $line) {
+        $parts = explode('|', $line, 5);
+        if (count($parts) === 5) {
+            $events[] = [
+                'timestamp' => $parts[0],
+                'service' => $parts[1],
+                'event' => $parts[2],
+                'action' => $parts[3],
+                'description' => $parts[4]
+            ];
+        }
+    }
+}
+
+// If no events, cleanup and exit
+if (empty($events)) {
+    @unlink($markerFile);
+    @unlink($eventLog);
+    exit(0);
+}
+
+// Get email configuration from database
+try {
+    $db = \OMV\Config\Database::getInstance();
+    $emailConfig = $db->getAssoc("conf.system.notification.email");
+} catch (\Exception $e) {
+    // Cannot get email config, cleanup and exit
+    @unlink($markerFile);
+    @unlink($eventLog);
+    exit(1);
+}
+
+// Check if email notifications are enabled
+if (!$emailConfig['enable']) {
+    @unlink($markerFile);
+    @unlink($eventLog);
+    exit(0);
+}
+
+// Build subject
+$hostname = php_uname('n');
+$eventCount = count($events);
+$subject = sprintf("Scheduled %s - %d service event%s on %s",
+    strtoupper($operation),
+    $eventCount,
+    $eventCount === 1 ? '' : 's',
+    $hostname
+);
+
+// Build message
+$message = sprintf("A scheduled %s operation on %s generated the following service event%s:\n\n",
+    $operation,
+    $hostname,
+    $eventCount === 1 ? '' : 's'
+);
+
+$message .= "Summary:\n";
+$message .= str_repeat("-", 80) . "\n";
+foreach ($events as $event) {
+    $message .= sprintf("[%s] %s: %s (%s)\n",
+        $event['timestamp'],
+        $event['service'],
+        $event['event'],
+        $event['action']
+    );
+}
+
+$message .= "\nDetailed Events:\n";
+$message .= str_repeat("=", 80) . "\n";
+foreach ($events as $event) {
+    $message .= sprintf(
+        "Time:        %s\n" .
+        "Service:     %s\n" .
+        "Event:       %s\n" .
+        "Action:      %s\n" .
+        "Description: %s\n\n",
+        $event['timestamp'],
+        $event['service'],
+        $event['event'],
+        $event['action'],
+        $event['description']
+    );
+    $message .= str_repeat("-", 80) . "\n";
+}
+
+$message .= "\n—\n";
+$message .= "This is a consolidated notification for scheduled power management.\n";
+$message .= "To change settings, go to 'System | Power Management' in the web interface.";
+
+// Build recipient list
+$to = $emailConfig['primaryemail'];
+if (!empty($emailConfig['secondaryemail'])) {
+    $to .= ',' . $emailConfig['secondaryemail'];
+}
+
+// Send email
+try {
+    $mail = new \OMV\Email($emailConfig['sender'], $to, $subject, $message);
+    $mail->send();
+} catch (\Exception $e) {
+    // Log error but don't fail
+    syslog(LOG_ERR, sprintf("Failed to send power management consolidated email: %s", $e->getMessage()));
+}
+
+// Cleanup
+@unlink($markerFile);
+@unlink($eventLog);
+PHPCODE

--- a/deb/openmediavault/usr/sbin/omv-powermgmt-wrapper
+++ b/deb/openmediavault/usr/sbin/omv-powermgmt-wrapper
@@ -1,0 +1,109 @@
+#!/bin/bash
+#
+# This file is part of OpenMediaVault.
+#
+# @license   https://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2025 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <https://www.gnu.org/licenses/>.
+
+set -e
+
+# Wrapper script for power management operations to enable email batching
+# This script intercepts scheduled power management tasks and consolidates
+# service event notifications into a single email.
+
+OPERATION="$1"
+MARKER_FILE="/var/lib/openmediavault/powermgmt-operation.state"
+EVENT_LOG="/var/lib/openmediavault/powermgmt-events.log"
+CONFIG_DB_XPATH=".//system/powermanagement/emailbatching"
+
+# Cleanup function to restore normal Monit configuration on error
+cleanup() {
+	if [ -f "${MARKER_FILE}" ]; then
+		# Operation cancelled/failed, restore normal Monit
+		/usr/sbin/omv-salt deploy run monit >/dev/null 2>&1 || true
+		rm -f "${MARKER_FILE}" "${EVENT_LOG}"
+	fi
+}
+trap cleanup EXIT TERM INT
+
+# Validate operation argument
+if [ -z "${OPERATION}" ]; then
+	echo "Usage: $0 <reboot|poweroff|suspend|hibernate|hybrid-sleep>" >&2
+	exit 1
+fi
+
+# Check if batching is enabled in database
+BATCHING_ENABLED=$(omv-confdbadm read --defaults "${CONFIG_DB_XPATH}/enable" 2>/dev/null || echo "0")
+
+if [ "${BATCHING_ENABLED}" != "1" ]; then
+	# Batching disabled, execute directly
+	exec systemctl "${OPERATION}"
+fi
+
+# Batching enabled - create marker file with metadata
+cat > "${MARKER_FILE}" <<EOF
+operation=${OPERATION}
+timestamp=$(date +%s)
+scheduled=true
+EOF
+
+# Ensure correct permissions for marker file
+chmod 644 "${MARKER_FILE}"
+
+# Clear previous event log
+> "${EVENT_LOG}"
+chmod 644 "${EVENT_LOG}"
+
+# Reconfigure Monit to use alert program instead of SMTP
+# This will redirect all alerts to our custom handler
+/usr/sbin/omv-salt deploy run monit.alertprogram >/dev/null 2>&1
+
+# Wait for Monit to reload with new configuration
+sleep 2
+
+# Handle different operation types
+case "${OPERATION}" in
+	reboot)
+		# For reboot, systemd service handles email after boot
+		# Execute reboot immediately
+		systemctl "${OPERATION}"
+		;;
+	poweroff|suspend|hibernate|hybrid-sleep)
+		# For shutdown/standby, wait for collection window
+		BATCH_WINDOW=$(omv-confdbadm read --defaults "${CONFIG_DB_XPATH}/batchwindow" 2>/dev/null || echo "60")
+
+		# Ensure batch window is within valid range
+		if [ "${BATCH_WINDOW}" -lt 30 ]; then
+			BATCH_WINDOW=30
+		elif [ "${BATCH_WINDOW}" -gt 300 ]; then
+			BATCH_WINDOW=300
+		fi
+
+		# Wait for events to be collected
+		sleep "${BATCH_WINDOW}"
+
+		# Send consolidated email
+		/usr/sbin/omv-powermgmt-sendemail "${OPERATION}"
+
+		# Execute power operation
+		systemctl "${OPERATION}"
+		;;
+	*)
+		echo "Unknown operation: ${OPERATION}" >&2
+		exit 1
+		;;
+esac

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.system.powermngmnt.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.system.powermngmnt.json
@@ -20,6 +20,21 @@
 			"type": "string",
 			"enum": [ "poweroff", "suspend", "hibernate", "suspendhybrid" ],
 			"default": "suspend"
+		},
+		"emailbatching": {
+			"type": "object",
+			"properties": {
+				"enable": {
+					"type": "boolean",
+					"default": false
+				},
+				"batchwindow": {
+					"type": "integer",
+					"minimum": 30,
+					"maximum": 300,
+					"default": 60
+				}
+			}
 		}
 	}
 }

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.powermgmt.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.powermgmt.json
@@ -12,6 +12,19 @@
 				"type": "string",
 				"required": true,
 				"enum": [ "nothing", "shutdown", "standby" ]
+			},
+			"emailbatching": {
+				"type": "object",
+				"properties": {
+					"enable": {
+						"type": "boolean"
+					},
+					"batchwindow": {
+						"type": "integer",
+						"minimum": 30,
+						"maximum": 300
+					}
+				}
 			}
 		}
 	}

--- a/deb/openmediavault/workbench/src/app/pages/system/powermgmt/powermgmt-settings-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/system/powermgmt/powermgmt-settings-form-page.component.ts
@@ -87,6 +87,39 @@ export class PowermgmtSettingsFormPageComponent extends BaseFormPageComponent {
             }
           }
         }
+      },
+      {
+        type: 'divider',
+        title: gettext('Email Notification Batching')
+      },
+      {
+        type: 'checkbox',
+        name: 'emailbatching.enable',
+        label: gettext('Enable batching'),
+        hint: gettext(
+          'Consolidate service notifications during scheduled power operations into a single email.'
+        ),
+        value: false
+      },
+      {
+        type: 'numberInput',
+        name: 'emailbatching.batchwindow',
+        label: gettext('Batch window (seconds)'),
+        hint: gettext(
+          'Time to collect events before sending email (for shutdown/standby). Reboot sends after system restarts.'
+        ),
+        value: 60,
+        validators: {
+          min: 30,
+          max: 300,
+          requiredIf: { operator: 'truthy', arg0: { prop: 'emailbatching.enable' } }
+        },
+        modifiers: [
+          {
+            type: 'disabled',
+            constraint: { operator: 'falsy', arg0: { prop: 'emailbatching.enable' } }
+          }
+        ]
       }
     ],
     buttons: [


### PR DESCRIPTION
  Add email notification batching for scheduled power operations

  Consolidates multiple service event notifications during scheduled
  reboot/shutdown/standby into a single email. Configurable via
  System > Power Management > Settings. Disabled by default.

  - Wrapper script intercepts scheduled tasks
  - Monit alert program logs events during batching window
  - Post-reboot systemd service for reboot scenarios
  - Web UI configuration with enable toggle and time window
  
  Closes #2084

