### PR TITLE
Update regex matching for statistics in btrfs.inc

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/btrfs.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/btrfs.inc
@@ -170,20 +170,13 @@ class Btrfs extends Filesystem {
 		// Metadata, DUP: total=171048960, used=1458176
 		// GlobalReserve, single: total=3407872, used=0
 		//
-		// Related to: https://forum.openmediavault.org/index.php?thread/57958-bug-btrfs-drives-shows-incorrect-usage-value-in-file-systems
-		// In the examples above, it asssumes that every line ends with used=[number]
-		// However it shows up as below in Example 3, potentially due to changes in the btrfs fi df -b command, or HM-SMR drive info
-		//
 		// Example 3:
 		// Data, single: total=8858370048, used=8799649792, zone_unusable=0
 		// System, DUP: total=268435456, used=16384, zone_unusable=131072
 		// Metadata, DUP: total=268435456, used=11829248, zone_unusable=3440640
 		// GlobalReserve, single: total=8863744, used=16384
-		// 
-		// Regex needs to be able to match trailing text after used. 
-		// Changed from $ to .* to match any text
 		$regex = "/^([\w\+]+), (single|mixed|dup|raid0|raid1|raid10|raid5|".
-		  "raid6|raid1c3|raid1c4): total=([0-9]+), used=([0-9]+).*/i";
+		  "raid6|raid1c3|raid1c4): total=([\d]+), used=([\d]+)(?:, [\w_]+=\d+)*$/i";
 		foreach (preg_filter($regex, "$1 $2 $3 $4", $output) as $rowv) {
 			list($type, $profile, $t, $u) = explode(" ", $rowv);
 			switch (mb_strtoupper($profile)) {


### PR DESCRIPTION
Regex matching for getStatistics is not matching Data, System and Metadata, as the matching captures non-integer values in used, due to zone_unusable existing on the fields.

E.g. of btrfs fi df -b
Data, single: total=8858370048, used=8799649792, zone_unusable=0 System, DUP: total=268435456, used=16384, zone_unusable=131072 Metadata, DUP: total=268435456, used=11829248, zone_unusable=3440640 GlobalReserve, single: total=8863744, used=16384

As the first 3 lines are not matched, only the Global Reserve value is captured and displayed on the GUI. By changing the modifier from end of line $ to match anything .*, it fixes this issue.

<img width="1570" height="152" alt="Before" src="https://github.com/user-attachments/assets/0346d689-c8ff-4215-94d0-33d171b8a606" />
<img width="1572" height="160" alt="After" src="https://github.com/user-attachments/assets/82d237dd-f5d9-4b1c-835d-bd2178445d47" />
