### PR TITLE
Add support for network interfaces connected via USB bus

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,7 @@
 openmediavault (8.0.6-1) stable; urgency=medium
 
   * Various improvements.
+  * Add support for network interfaces connected via USB bus.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Tue, 06 Jan 2026 10:41:24 +0100
 

--- a/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/net/utils.py
+++ b/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/net/utils.py
@@ -35,12 +35,13 @@ def is_ethernet(name):
     # Examples:
     # - eth0
     # - enp2s0
-    # - enp2s0f0, enp5165p0s0
+    # - enp2s0f0, enp5165p0s0, enp1s0u1u2
     # - enx00259025963a
     # - ens1
     # - eno16777736
     # - encf5f0, enx026d3c00000a
     # - end0
+    # - enu1u3
     #
     # Predictable network interface device name types:
     # - BCMA bus core number
@@ -56,7 +57,7 @@ def is_ethernet(name):
     # - PCI geographical location
     #   [P<domain>]p<bus>s<slot>[f<function>][n<phys_port_name>|d<dev_port>]
     # - USB port number chain
-    #   [P<domain>]p<bus>s<slot>[f<function>][u<port>][..][c<config>][i<interface>]
+    #   [P<domain>][p<bus>s<slot>][f<function>][u<port>][..][c<config>][i<interface>]
     # - Device tree
     #   d<number>
     #
@@ -67,7 +68,7 @@ def is_ethernet(name):
             r'^eth[0-9]+|'
             r'en(b\d+|c\d+|d\d+|o\d+(n\S+|d\d+)?|s\d+(f\d+)?(n\S+|d\d+)?|'
             r'x[\da-f]{12}|(P\d+)?p\d+s\d+(f\d+)?(n\S+|d\d+)?|'
-            r'(P\d+)?p\d+s\d+(f\d+)?(u\d+)*(c\d+)?(i\d+)?)$',
+            r'(P\d+)?(p\d+s\d+)?(f\d+)?(u\d+)*(c\d+)?(i\d+)?)$',
             name
         )
     )
@@ -87,6 +88,8 @@ def is_wifi(name):
     # Examples:
     # - wlan1
     # - wlp3s0
+    # - wlx984827050421
+    # - wlu1u3
     #
     # Predictable network interface device name types:
     # - BCMA bus core number
@@ -102,7 +105,7 @@ def is_wifi(name):
     # - PCI geographical location
     #   [P<domain>]p<bus>s<slot>[f<function>][n<phys_port_name>|d<dev_port>]
     # - USB port number chain
-    #   [P<domain>]p<bus>s<slot>[f<function>][u<port>][..][c<config>][i<interface>]
+    #   [P<domain>][p<bus>s<slot>][f<function>][u<port>][..][c<config>][i<interface>]
     #
     # Understanding systemd’s predictable network device names:
     # https://github.com/systemd/systemd/blob/master/src/udev/udev-builtin-net_id.c
@@ -111,7 +114,7 @@ def is_wifi(name):
             r'^wlan[0-9]+|wl(b\d+|c\d+|o\d+(n\S+|d\d+)?|'
             r's\d+(f\d+)?(n\S+|d\d+)?|'
             r'x[\da-f]{12}|(P\d+)?p\d+s\d+(f\d+)?(n\S+|d\d+)?|'
-            r'(P\d+)?p\d+s\d+(f\d+)?(u\d+)*(c\d+)?(i\d+)?)$',
+            r'(P\d+)?(p\d+s\d+)?(f\d+)?(u\d+)*(c\d+)?(i\d+)?)$',
             name
         )
     )

--- a/deb/openmediavault/usr/share/openmediavault/scripts/helper-functions
+++ b/deb/openmediavault/usr/share/openmediavault/scripts/helper-functions
@@ -794,7 +794,7 @@ omv_is_ipv6_enabled() {
 # Check if the given device is a wireless network interface.
 # @return 0 if wireless, otherwise 1.
 omv_is_wlan() {
-	if echo "$1" | grep -Pq "^wlan[0-9]+|wl(b\d+|c\d+|o\d+(n\S+|d\d+)?|s\d+(f\d+)?(n\S+|d\d+)?|x[\da-f]{12}|(P\d+)?p\d+s\d+(f\d+)?(n\S+|d\d+)?|(P\d+)?p\d+s\d+(f\d+)?(u\d+)*(c\d+)?(i\d+)?)$"; then
+	if echo "$1" | grep -Pq "^wlan[0-9]+|wl(b\d+|c\d+|o\d+(n\S+|d\d+)?|s\d+(f\d+)?(n\S+|d\d+)?|x[\da-f]{12}|(P\d+)?p\d+s\d+(f\d+)?(n\S+|d\d+)?|(P\d+)?(p\d+s\d+)?(f\d+)?(u\d+)*(c\d+)?(i\d+)?)$"; then
 	  return 0
 	fi
 	return 1

--- a/deb/openmediavault/usr/share/php/openmediavault/system/net/networkinterfacebackend/ethernet.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/net/networkinterfacebackend/ethernet.inc
@@ -31,13 +31,14 @@ class Ethernet extends BackendAbstract {
 	// Examples:
 	// - eth0
 	// - enp2s0
-	// - enp2s0f0, enp5165p0s0
+	// - enp2s0f0, enp5165p0s0, enp1s0u1u2
 	// - enx00259025963a
 	// - ens1
 	// - eno16777736
 	// - encf5f0, enx026d3c00000a
 	// - end0
 	// - enX0
+	// - enu1u3
 	//
 	// Predictable network interface device name types:
 	// - BCMA bus core number
@@ -53,7 +54,7 @@ class Ethernet extends BackendAbstract {
 	// - PCI geographical location
 	//   [P<domain>]p<bus>s<slot>[f<function>][n<phys_port_name>|d<dev_port>]
 	// - USB port number chain
-	//   [P<domain>]p<bus>s<slot>[f<function>][u<port>][..][c<config>][i<interface>]
+	//   [P<domain>][p<bus>s<slot>][f<function>][u<port>][..][c<config>][i<interface>]
 	// - Device tree
 	//   d<number>
 	// - VIF interface number (Xen)
@@ -67,7 +68,7 @@ class Ethernet extends BackendAbstract {
 	protected $regex = "/^eth[0-9]+|".
 		"en(b\d+|c\d+|d\d+|o\d+(n\S+|d\d+)?|s\d+(f\d+)?(n\S+|d\d+)?|".
 		"x[\da-f]{12}|(P\d+)?p\d+s\d+(f\d+)?(n\S+|d\d+)?|".
-		"(P\d+)?p\d+s\d+(f\d+)?(u\d+)*(c\d+)?(i\d+)?|X\d+)$/i";
+		"(P\d+)?(p\d+s\d+)?(f\d+)?(u\d+)*(c\d+)?(i\d+)?|X\d+)$/i";
 
 	// Distributed Switch Architecture (DSA)
 	//

--- a/deb/openmediavault/usr/share/php/openmediavault/system/net/networkinterfacebackend/wifi.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/net/networkinterfacebackend/wifi.inc
@@ -30,6 +30,7 @@ class Wifi extends BackendAbstract {
 	// - wlan1
 	// - wlp3s0
 	// - wlx984827050421
+	// - wlu1u3
 	//
 	// Predictable network interface device name types:
 	// - BCMA bus core number
@@ -45,7 +46,7 @@ class Wifi extends BackendAbstract {
 	// - PCI geographical location
 	//   [P<domain>]p<bus>s<slot>[f<function>][n<phys_port_name>|d<dev_port>]
 	// - USB port number chain
-	//   [P<domain>]p<bus>s<slot>[f<function>][u<port>][..][c<config>][i<interface>]
+	//   [P<domain>][p<bus>s<slot>][f<function>][u<port>][..][c<config>][i<interface>]
 	//
 	// Understanding systemd’s predictable network device names:
 	// - https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames
@@ -53,7 +54,7 @@ class Wifi extends BackendAbstract {
 	protected $regex = "/^wlan[0-9]+|wl(b\d+|c\d+|o\d+(n\S+|d\d+)?|".
 		"s\d+(f\d+)?(n\S+|d\d+)?|".
 		"x[\da-f]{12}|(P\d+)?p\d+s\d+(f\d+)?(n\S+|d\d+)?|".
-		"(P\d+)?p\d+s\d+(f\d+)?(u\d+)*(c\d+)?(i\d+)?)$/i";
+		"(P\d+)?(p\d+s\d+)?(f\d+)?(u\d+)*(c\d+)?(i\d+)?)$/i";
 
 	function getType() {
 		return OMV_NETWORK_INTERFACE_TYPE_WIFI;


### PR DESCRIPTION
..., e.g. `enu1u3` or `wlu1u3`.

Related to: https://forum.openmediavault.org/index.php?thread/57780-2-5gb-interface-not-detected


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
