### PR TITLE
Use more secure permissions for the sshd config file

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/ssh/20sshd_config.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/ssh/20sshd_config.sls
@@ -33,7 +33,7 @@ configure_sshd_config:
         config: {{ config | json }}
     - user: root
     - group: root
-    - mode: 644
+    - mode: 600
 
 divert_sshd_config:
   omv_dpkg.divert_add:


### PR DESCRIPTION
Using the CIS benchmark recommendation that sshd should be 600. No need for anyone but root to be reading this.

Signed-off-by: Tim Smith <tsmith84@gmail.com>