### PR TITLE
Improve alert panel accessibility

### DIFF
--- a/deb/openmediavault/workbench/src/app/shared/components/alert-panel/alert-panel.component.html
+++ b/deb/openmediavault/workbench/src/app/shared/components/alert-panel/alert-panel.component.html
@@ -14,18 +14,16 @@
     </div>
     <mat-card-actions *ngIf="buttons.length"
                       class="omv-display-flex omv-flex-row omv-flex-column-reverse-lt-sm omv-justify-content-end omv-align-items-start">
-      <div *ngFor="let button of buttons"
-           class="alert-action-button omv-ml-q"
-           [class]="button.class"
-           mat-ripple
-           [attr.aria-label]="button.tooltip | transloco"
-           [matTooltip]="button.tooltip | transloco"
-           tabindex="0"
-           (keyup.space)="button.click && button.click(button)"
-           (keyup.enter)="button.click && button.click(button)"
-           (click)="button.click && button.click(button)">
+      <button *ngFor="let button of buttons"
+              class="alert-action-button omv-ml-q"
+              [class]="button.class"
+              mat-icon-button
+              [attr.aria-label]="button.tooltip | transloco"
+              matTooltip="{{ button.tooltip | transloco }}"
+              tabindex="0"
+              (click)="button.click && button.click(button)">
         <mat-icon svgIcon="{{ button.icon }}"></mat-icon>
-      </div>
+      </button>
     </mat-card-actions>
   </div>
 </mat-card>

--- a/deb/openmediavault/workbench/src/app/shared/components/alert-panel/alert-panel.component.scss
+++ b/deb/openmediavault/workbench/src/app/shared/components/alert-panel/alert-panel.component.scss
@@ -44,14 +44,7 @@
     padding: 0;
 
     .alert-action-button {
-      cursor: pointer;
-      width: 1.5rem;
-      height: 1.5rem;
       margin: 0;
-
-      &:not(:last-child) {
-        margin-right: 0.5rem;
-      }
     }
   }
 }


### PR DESCRIPTION
Replaced divs with buttons in alert panel to make them accessible by screen readers. This fixes the issue from this [thread](https://forum.openmediavault.org/index.php?thread/46139-calling-omv-developers-for-accessibility-improvement/) and relates to https://github.com/openmediavault/openmediavault/issues/1520.

The spacing between buttons has been increased to make ripple effect look appropriate. Also this makes buttons easier to click on mobile. @votdev feel free to adjust styles as needed.

<img width="1341" height="475" alt="alert-panel-buttons" src="https://github.com/user-attachments/assets/24729926-e475-4919-90d6-908df5c6a3d5" />


