### PR TITLE
Add UI support to configure additional Traefik ports

### DIFF
--- a/deb/openmediavault-k8s/debian/changelog
+++ b/deb/openmediavault-k8s/debian/changelog
@@ -1,6 +1,10 @@
-openmediavault-k8s (8.0.1-1) stable; urgency=medium
+openmediavault-k8s (8.1.0-1) stable; urgency=medium
 
-  *
+  * Issue #1940: Add UI support to configure additional Traefik ports.
+  * The following environment variables have been removed:
+    - OMV_K8S_TRAEFIK_PORTS
+    - OMV_K8S_TRAEFIK_ENTRYPOINT_TRANSPORT_RESPONDINGTIMEOUTS_READTIMEOUT
+    Please use the new UI functionality instead.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Fri, 23 Jan 2026 08:46:23 +0100
 

--- a/deb/openmediavault-k8s/debian/control
+++ b/deb/openmediavault-k8s/debian/control
@@ -9,7 +9,7 @@ Homepage: https://www.openmediavault.org
 
 Package: openmediavault-k8s
 Architecture: all
-Depends: openmediavault (>= 8.0), bash, git, tar, xz-utils
+Depends: openmediavault (>= 8.0.8), bash, git, tar, xz-utils
 Priority: optional
 Description: openmediavault Kubernetes plugin
  Kubernetes is an open-source platform for orchestrating and

--- a/deb/openmediavault-k8s/usr/share/openmediavault/confdb/create.d/conf.service.k8s.sh
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/confdb/create.d/conf.service.k8s.sh
@@ -32,15 +32,43 @@ set -e
 #     	<datastore>etcd|sqlite</datastore>
 #     	<webport>8080</webport>
 #     	<websecureport>8443</websecureport>
-#     	<dashboardport>4443</dashboardport>
-#       <sslcertificateref></sslcertificateref>
+#       <lbports>
+#         <lbport>
+#           <name>xxx</name>
+#           <port>1-65535</port>
+#           <exposedport>1-65535</exposedport>
+#           <protocol>udp|tcp</protocol>
+#           <expose>0|1</expose>
+#           <comment>xxx</comment>
+#           <extravalues>xxx</extravalues>
+#         </lbport>
+#       </ports>
 #       <snapshots_sharedfolderref></snapshots_sharedfolderref>
+#       <sslcertificateref></sslcertificateref>
 #     </k8s>
 #   </services>
 # </config>
 ########################################################################
 if ! omv_config_exists "/config/services/k8s"; then
     omv-confdbadm read --defaults "conf.service.k8s" | omv-confdbadm update "conf.service.k8s" -
+	if ! omv-confdbadm exists --filter '{"operator":"stringEquals","arg0":"name","arg1":"web"}' \
+			"conf.service.k8s.lbport"; then
+		omv-confdbadm read --defaults "conf.service.k8s.lbport" | \
+			jq '.name = "web" | .port = 8080 | .exposedport = 8080 | .protocol = "tcp" | .expose = true | .comment = "HTTP" | .extravalues="transport:\n  respondingTimeouts:\n    readTimeout: 60"' | \
+			omv-confdbadm update "conf.service.k8s.lbport" -
+	fi
+	if ! omv-confdbadm exists --filter '{"operator":"stringEquals","arg0":"name","arg1":"websecure"}' \
+			"conf.service.k8s.lbport"; then
+		omv-confdbadm read --defaults "conf.service.k8s.lbport" | \
+			jq '.name = "websecure" | .port = 8443 | .exposedport = 8443 | .protocol = "tcp" | .expose = true | .comment = "HTTPS" | .extravalues="transport:\n  respondingTimeouts:\n    readTimeout: 60"' | \
+			omv-confdbadm update "conf.service.k8s.lbport" -
+	fi
+	if ! omv-confdbadm exists --filter '{"operator":"stringEquals","arg0":"name","arg1":"dashboard"}' \
+			"conf.service.k8s.lbport"; then
+		omv-confdbadm read --defaults "conf.service.k8s.lbport" | \
+			jq '.name = "dashboard" | .port = 4443 | .exposedport = 4443 | .protocol = "tcp" | .expose = true | .comment = "Dashboard" | .extravalues= "tls:\n  enabled: true"' | \
+			omv-confdbadm update "conf.service.k8s.lbport" -
+	fi
 fi
 
 exit 0

--- a/deb/openmediavault-k8s/usr/share/openmediavault/confdb/migrations.d/conf.service.k8s_8.1.0.sh
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/confdb/migrations.d/conf.service.k8s_8.1.0.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# This file is part of OpenMediaVault.
+#
+# @license   https://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @copyright Copyright (c) 2009-2026 Volker Theile
+#
+# OpenMediaVault is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# OpenMediaVault is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenMediaVault. If not, see <https://www.gnu.org/licenses/>.
+
+set -e
+
+. /usr/share/openmediavault/scripts/helper-functions
+
+omv_config_add_node "/config/services/k8s" "lbports"
+
+if ! omv-confdbadm exists --filter '{"operator":"stringEquals","arg0":"name","arg1":"web"}' \
+		"conf.service.k8s.lbport"; then
+	webport=$(omv_config_get "/config/services/k8s/webport")
+	omv-confdbadm read --defaults "conf.service.k8s.lbport" | \
+		jq ".name = \"web\" | .port = ${webport} | .exposedport = ${webport} | .protocol = \"tcp\" | .expose = true | .comment = \"HTTP\" | .extravalues=\"transport:\\n  respondingTimeouts:\\n    readTimeout: 60\"" | \
+		omv-confdbadm update "conf.service.k8s.lbport" -
+fi
+if ! omv-confdbadm exists --filter '{"operator":"stringEquals","arg0":"name","arg1":"websecure"}' \
+		"conf.service.k8s.lbport"; then
+	websecureport=$(omv_config_get "/config/services/k8s/websecureport")
+	omv-confdbadm read --defaults "conf.service.k8s.lbport" | \
+		jq ".name = \"websecure\" | .port = ${websecureport} | .exposedport = ${websecureport} | .protocol = \"tcp\" | .expose = true | .comment = \"HTTPS\" | .extravalues=\"transport:\\n  respondingTimeouts:\\n    readTimeout: 60\"" | \
+		omv-confdbadm update "conf.service.k8s.lbport" -
+fi
+if ! omv-confdbadm exists --filter '{"operator":"stringEquals","arg0":"name","arg1":"dashboard"}' \
+		"conf.service.k8s.lbport"; then
+	dashboardport=$(omv_config_get "/config/services/k8s/dashboardport")
+	omv-confdbadm read --defaults "conf.service.k8s.lbport" | \
+		jq ".name = \"dashboard\" | .port = ${dashboardport} | .exposedport = ${dashboardport} | .protocol = \"tcp\" | .expose = true | .comment = \"Dashboard\" | .extravalues= \"tls:\\n  enabled: true\"" | \
+		omv-confdbadm update "conf.service.k8s.lbport" -
+fi
+
+omv_config_delete "/config/services/k8s/webport"
+omv_config_delete "/config/services/k8s/websecureport"
+omv_config_delete "/config/services/k8s/dashboardport"
+
+exit 0

--- a/deb/openmediavault-k8s/usr/share/openmediavault/datamodels/conf.service.k8s.json
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/datamodels/conf.service.k8s.json
@@ -16,23 +16,48 @@
 			"enum": [ "etcd", "sqlite" ],
 			"default": "sqlite"
 		},
-		"webport": {
-			"type": "integer",
-			"minimum": 1,
-			"maximum": 65535,
-			"default": 8080
-		},
-		"websecureport": {
-			"type": "integer",
-			"minimum": 1,
-			"maximum": 65535,
-			"default": 8443
-		},
-		"dashboardport": {
-			"type": "integer",
-			"minimum": 1,
-			"maximum": 65535,
-			"default": 4443
+		"lbports": {
+			"type": "object",
+			"properties": {
+				"item": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"uuid": {
+								"type": "string",
+								"format": "uuidv4"
+							},
+							"name": {
+								"type": "string"
+							},
+							"port": {
+								"type": "integer",
+								"minimum": 1,
+								"maximum": 65535
+							},
+							"exposedport": {
+								"type": "integer",
+								"minimum": 1,
+								"maximum": 65535
+							},
+							"protocol": {
+								"type": "string",
+								"enum": ["udp", "tcp"]
+							},
+							"expose": {
+								"type": "boolean"
+							},
+							"comment": {
+								"type": "string"
+							},
+							"extravalues": {
+								"type": "string"
+							}
+						}
+					}
+				}
+			}
 		},
 		"snapshots_sharedfolderref": {
 			"type": "string",

--- a/deb/openmediavault-k8s/usr/share/openmediavault/datamodels/conf.service.k8s.lbport.json
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/datamodels/conf.service.k8s.lbport.json
@@ -1,0 +1,42 @@
+{
+	"type": "config",
+	"id": "conf.service.k8s.lbport",
+	"title": "Load Balancer port",
+	"queryinfo": {
+		"xpath": ".//services/k8s/lbports/item",
+		"iterable": true,
+		"idproperty": "uuid"
+	},
+	"properties": {
+		"uuid": {
+			"type": "string",
+			"format": "uuidv4"
+		},
+		"name": {
+			"type": "string"
+		},
+		"port": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 65535
+		},
+		"exposedport": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 65535
+		},
+		"protocol": {
+			"type": "string",
+			"enum": ["udp", "tcp"]
+		},
+		"expose": {
+			"type": "boolean"
+		},
+		"comment": {
+			"type": "string"
+		},
+		"extravalues": {
+			"type": "string"
+		}
+	}
+}

--- a/deb/openmediavault-k8s/usr/share/openmediavault/engined/rpc/k8s.inc
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/engined/rpc/k8s.inc
@@ -82,6 +82,14 @@ class OMVRpcServiceK8s extends \OMV\Rpc\ServiceAbstract {
 		$response = \OMV\Rpc\Rpc::call("Config", "get", [
 			"id" => "conf.service.k8s"
 		], $context);
+		// Override the `lbports` configuration. Unfortunately, we have to do
+		// this strange acrobatics here because otherwise it becomes somewhat
+		// difficult to convert the XML structure of the database into JSON
+		// format.
+		$response['lbports'] = \OMV\Rpc\Rpc::call("Config", "get", [
+			"id" => "conf.service.k8s.lbport"
+		], $context);
+		// Append additional information.
 		$response['installed'] = $this->isK3sInstalled();
 		return $response;
 	}
@@ -93,10 +101,34 @@ class OMVRpcServiceK8s extends \OMV\Rpc\ServiceAbstract {
 	 * @return The stored configuration object.
 	 */
 	function set($params, $context) {
-		return \OMV\Rpc\Rpc::call("Config", "set", [
-			"id" => "conf.service.k8s",
-			"data" => $params
-		], $context);
+		// Do some validation:
+		// - Make sure that the port names are unique.
+		// - Validate the port configuration and make sure new added
+		//   port configurations get a new/unique identifier.
+		$lbPorts = [];
+		$lbPortNames = [];
+		foreach($params['lbports'] as $lbPortk => $lbPortv) {
+			$lbPortName = $lbPortv['name'];
+			if (isset($lbPortNames[$lbPortName])) {
+				throw new \OMV\Exception("Duplicate port configuration '%s' found.",
+					$lbPortName);
+			}
+			$lbPortObject = new \OMV\Config\ConfigObject("conf.service.k8s.lbport");
+			$lbPortObject->setAssoc($lbPortv);
+			if ($lbPortObject->isNew()) {
+				$lbPortObject->createIdentifier();
+			}
+			$lbPorts[] = $lbPortObject->getAssoc();
+			$lbPortNames[$lbPortName] = TRUE;
+		}
+		$object = new \OMV\Config\ConfigObject("conf.service.k8s");
+		$object->setAssoc(array_omit_keys($params, ["lbports"]));
+		$object->set("lbports", [
+			"item" => $lbPorts
+		]);
+		$db = \OMV\Config\Database::getInstance();
+		$db->set($object);
+		return $object->getAssoc();
 	}
 
 	function getToken($params, $context) {

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/ar_SA/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/ar_SA/openmediavault-k8s.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: omv nas <myomv100@gmail.com>, 2025\n"
 "Language-Team: Arabic (Saudi Arabia) (https://app.transifex.com/openmediavault/teams/14254/ar_SA/)\n"
@@ -119,7 +119,19 @@ msgstr ""
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
+msgstr ""
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
 msgstr ""
 
 msgid "Failed"
@@ -132,12 +144,6 @@ msgid "GID"
 msgstr ""
 
 msgid "Groups"
-msgstr ""
-
-msgid "HTTP port"
-msgstr ""
-
-msgid "HTTPS port"
 msgstr ""
 
 msgid "Helm Charts"
@@ -254,6 +260,9 @@ msgstr ""
 msgid "Ports"
 msgstr ""
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -273,6 +282,11 @@ msgid "Recipes"
 msgstr ""
 
 msgid "Reclaim policy"
+msgstr ""
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
 msgstr ""
 
 msgid "Repository"
@@ -345,8 +359,8 @@ msgid "Target Namespace"
 msgstr ""
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
 
 msgid ""
@@ -371,12 +385,6 @@ msgstr ""
 msgid "The manifest to apply."
 msgstr ""
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr ""
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr ""
-
 msgid "The snapshot was created successfully."
 msgstr ""
 
@@ -390,6 +398,9 @@ msgid "Type"
 msgstr ""
 
 msgid "UID"
+msgstr ""
+
+msgid "UUID"
 msgstr ""
 
 msgid "Unknown"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/bg_BG/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/bg_BG/openmediavault-k8s.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: Plamen Vasilev <p.vasileff@gmail.com>, 2025\n"
 "Language-Team: Bulgarian (Bulgaria) (https://app.transifex.com/openmediavault/teams/14254/bg_BG/)\n"
@@ -119,7 +119,19 @@ msgstr ""
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
+msgstr ""
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
 msgstr ""
 
 msgid "Failed"
@@ -132,12 +144,6 @@ msgid "GID"
 msgstr ""
 
 msgid "Groups"
-msgstr ""
-
-msgid "HTTP port"
-msgstr ""
-
-msgid "HTTPS port"
 msgstr ""
 
 msgid "Helm Charts"
@@ -254,6 +260,9 @@ msgstr ""
 msgid "Ports"
 msgstr ""
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -273,6 +282,11 @@ msgid "Recipes"
 msgstr ""
 
 msgid "Reclaim policy"
+msgstr ""
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
 msgstr ""
 
 msgid "Repository"
@@ -345,8 +359,8 @@ msgid "Target Namespace"
 msgstr ""
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
 
 msgid ""
@@ -371,12 +385,6 @@ msgstr ""
 msgid "The manifest to apply."
 msgstr ""
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr ""
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr ""
-
 msgid "The snapshot was created successfully."
 msgstr ""
 
@@ -390,6 +398,9 @@ msgid "Type"
 msgstr ""
 
 msgid "UID"
+msgstr ""
+
+msgid "UUID"
 msgstr ""
 
 msgid "Unknown"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/ca_ES/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/ca_ES/openmediavault-k8s.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: Quim Farriol <qfarriol@valette.cat>, 2025\n"
 "Language-Team: Catalan (Spain) (https://app.transifex.com/openmediavault/teams/14254/ca_ES/)\n"
@@ -122,8 +122,20 @@ msgstr "Activat"
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
 msgstr "IP externa"
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
+msgstr ""
 
 msgid "Failed"
 msgstr "Fallat"
@@ -136,12 +148,6 @@ msgstr "GID"
 
 msgid "Groups"
 msgstr "Grups"
-
-msgid "HTTP port"
-msgstr "Port HTTP"
-
-msgid "HTTPS port"
-msgstr "Port HTTPS"
 
 msgid "Helm Charts"
 msgstr "Gràfics Helm"
@@ -257,6 +263,9 @@ msgstr "Port"
 msgid "Ports"
 msgstr "Ports"
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr "LLEGEIX-ME"
 
@@ -277,6 +286,11 @@ msgstr "Receptes"
 
 msgid "Reclaim policy"
 msgstr "Política de reclamació"
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
+msgstr ""
 
 msgid "Repository"
 msgstr "Repository"
@@ -348,11 +362,9 @@ msgid "Target Namespace"
 msgstr "Espai de noms de destinació"
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
-"El certificat SSL utilitzat pel Dashboard i el servei LoadBalancer. Si no "
-"s'estableix, s'utilitza un certificat autofirmat de cert-manager."
 
 msgid ""
 "The datastore used by the Kubernetes cluster. SQLite is recommended for "
@@ -387,12 +399,6 @@ msgstr "La ubicació on s'emmagatzemen les instantànies sota demanda etcd."
 msgid "The manifest to apply."
 msgstr "El manifest a aplicar."
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr "El port on escolta el tauler de control de Kubernetes."
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr "El port on està escoltant el servei LoadBalancer."
-
 msgid "The snapshot was created successfully."
 msgstr "La instantània s'ha creat correctament."
 
@@ -407,6 +413,9 @@ msgstr "Tipus"
 
 msgid "UID"
 msgstr "UID"
+
+msgid "UUID"
+msgstr ""
 
 msgid "Unknown"
 msgstr "Desconegut"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/cs_CZ/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/cs_CZ/openmediavault-k8s.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>, 2025\n"
 "Language-Team: Czech (Czech Republic) (https://app.transifex.com/openmediavault/teams/14254/cs_CZ/)\n"
@@ -120,8 +120,20 @@ msgstr "Povoleno"
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
 msgstr "Externí IP"
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
+msgstr ""
 
 msgid "Failed"
 msgstr ""
@@ -134,12 +146,6 @@ msgstr "GID"
 
 msgid "Groups"
 msgstr "Skupiny"
-
-msgid "HTTP port"
-msgstr "Port HTTP"
-
-msgid "HTTPS port"
-msgstr "Port HTTPS"
 
 msgid "Helm Charts"
 msgstr ""
@@ -255,6 +261,9 @@ msgstr "Port"
 msgid "Ports"
 msgstr "Porty"
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -274,6 +283,11 @@ msgid "Recipes"
 msgstr "Předpisy"
 
 msgid "Reclaim policy"
+msgstr ""
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
 msgstr ""
 
 msgid "Repository"
@@ -346,8 +360,8 @@ msgid "Target Namespace"
 msgstr "Cílový jmenný prostor"
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
 
 msgid ""
@@ -372,12 +386,6 @@ msgstr ""
 msgid "The manifest to apply."
 msgstr "Použitý manifest."
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr ""
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr ""
-
 msgid "The snapshot was created successfully."
 msgstr ""
 
@@ -392,6 +400,9 @@ msgstr "Typ"
 
 msgid "UID"
 msgstr "UID"
+
+msgid "UUID"
+msgstr ""
 
 msgid "Unknown"
 msgstr ""

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/da_DA/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/da_DA/openmediavault-k8s.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: Stefan Thrane Overby <stoverby@gmail.com>, 2025\n"
 "Language-Team: Danish (https://app.transifex.com/openmediavault/teams/14254/da/)\n"
@@ -119,7 +119,19 @@ msgstr ""
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
+msgstr ""
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
 msgstr ""
 
 msgid "Failed"
@@ -132,12 +144,6 @@ msgid "GID"
 msgstr ""
 
 msgid "Groups"
-msgstr ""
-
-msgid "HTTP port"
-msgstr ""
-
-msgid "HTTPS port"
 msgstr ""
 
 msgid "Helm Charts"
@@ -254,6 +260,9 @@ msgstr ""
 msgid "Ports"
 msgstr ""
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -273,6 +282,11 @@ msgid "Recipes"
 msgstr ""
 
 msgid "Reclaim policy"
+msgstr ""
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
 msgstr ""
 
 msgid "Repository"
@@ -345,8 +359,8 @@ msgid "Target Namespace"
 msgstr ""
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
 
 msgid ""
@@ -371,12 +385,6 @@ msgstr ""
 msgid "The manifest to apply."
 msgstr ""
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr ""
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr ""
-
 msgid "The snapshot was created successfully."
 msgstr ""
 
@@ -390,6 +398,9 @@ msgid "Type"
 msgstr ""
 
 msgid "UID"
+msgstr ""
+
+msgid "UUID"
 msgstr ""
 
 msgid "Unknown"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/de_DE/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/de_DE/openmediavault-k8s.po
@@ -4,16 +4,16 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Volker Theile <votdev@gmx.de>, 2025
+# Volker Theile <votdev@gmx.de>, 2026
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-19 21:22+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
-"Last-Translator: Volker Theile <votdev@gmx.de>, 2025\n"
+"Last-Translator: Volker Theile <votdev@gmx.de>, 2026\n"
 "Language-Team: German (https://app.transifex.com/openmediavault/teams/14254/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -122,8 +122,20 @@ msgstr "Aktiviert"
 msgid "Events"
 msgstr "Ereignisse"
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
 msgstr "External IP"
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
+msgstr ""
 
 msgid "Failed"
 msgstr "Fehlgeschlagen"
@@ -136,12 +148,6 @@ msgstr "GID"
 
 msgid "Groups"
 msgstr "Gruppen"
-
-msgid "HTTP port"
-msgstr "HTTP Port"
-
-msgid "HTTPS port"
-msgstr "HTTPS Port"
 
 msgid "Helm Charts"
 msgstr "Helm Charts"
@@ -257,6 +263,9 @@ msgstr "Port"
 msgid "Ports"
 msgstr "Ports"
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr "README"
 
@@ -277,6 +286,13 @@ msgstr "Rezepte"
 
 msgid "Reclaim policy"
 msgstr ""
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
+msgstr ""
+"Die verfügbaren Konfigurationsoptionen finden Sie in der Datei values.yaml "
+"im Traefik-Helm-Chart."
 
 msgid "Repository"
 msgstr "Repository"
@@ -348,12 +364,11 @@ msgid "Target Namespace"
 msgstr ""
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
-"Das vom Dashboard und dem LoadBalancer-Dienst verwendete SSL-Zertifikat. "
-"Wenn es nicht gesetzt ist, wird ein selbstsigniertes Zertifikat von cert-"
-"manager verwendet."
+"Das vom LoadBalancer-Dienst verwendete SSL-Zertifikat. Falls nicht "
+"angegeben, wird ein selbstsigniertes Zertifikat von cert-manager verwendet."
 
 msgid ""
 "The datastore used by the Kubernetes cluster. SQLite is recommended for "
@@ -381,12 +396,6 @@ msgstr ""
 msgid "The manifest to apply."
 msgstr "Das anzuwendende Manifest."
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr "Der Port, auf dem das Kubernetes Dashboard lauscht."
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr "Der Port, an dem der LoadBalancer-Dienst lauscht."
-
 msgid "The snapshot was created successfully."
 msgstr "Der Schnappschuss wurde erfolgreich erstellt."
 
@@ -401,6 +410,9 @@ msgstr "Typ"
 
 msgid "UID"
 msgstr "UID"
+
+msgid "UUID"
+msgstr ""
 
 msgid "Unknown"
 msgstr ""

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/el_GR/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/el_GR/openmediavault-k8s.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-19 21:22+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: Kostas Moho, 2025\n"
 "Language-Team: Greek (Greece) (https://app.transifex.com/openmediavault/teams/14254/el_GR/)\n"
@@ -122,8 +122,20 @@ msgstr "Ενεργό"
 msgid "Events"
 msgstr "Συμβάντα"
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
 msgstr "Εξωτερική ΙΡ"
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
+msgstr ""
 
 msgid "Failed"
 msgstr "Απέτυχε"
@@ -136,12 +148,6 @@ msgstr "GID"
 
 msgid "Groups"
 msgstr "Ομάδες"
-
-msgid "HTTP port"
-msgstr "Θύρα HTTP"
-
-msgid "HTTPS port"
-msgstr "Θύρα HTTPS"
 
 msgid "Helm Charts"
 msgstr "Διαγράμματα Πλοήγησης"
@@ -257,6 +263,9 @@ msgstr "Θύρα"
 msgid "Ports"
 msgstr "Θύρες"
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr "README"
 
@@ -277,6 +286,11 @@ msgstr "Συνταγές"
 
 msgid "Reclaim policy"
 msgstr "Πολιτική επανάκτησης"
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
+msgstr ""
 
 msgid "Repository"
 msgstr "Αποθετήριο"
@@ -348,12 +362,9 @@ msgid "Target Namespace"
 msgstr "Σκοπούμενος Χώρος Ονομάτων"
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
-"Το πιστοποιητικό SSL που χρησιμοποιείται από το Ταμπλώ και την υπηρεσία του "
-"Εξισορροπητή Φόρτου. Αν δεν οριστεί, τότε θα χρησιμοποιείται ένα αυτοσχέδιο "
-"πιστοποιητικό από τον cert-manager."
 
 msgid ""
 "The datastore used by the Kubernetes cluster. SQLite is recommended for "
@@ -387,12 +398,6 @@ msgstr "Η θέση αποθήκευσης των αιτούμενων στιγ�
 msgid "The manifest to apply."
 msgstr "Η δήλωση προς εφαρμογή."
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr "Η θύρα στην οποία ακούει το Ταμπλό του Kubernetes."
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr "Η θύρα στην οποία ακούει η υπηρεσία του Εξισορροπητή Φόρτου."
-
 msgid "The snapshot was created successfully."
 msgstr "Το στιγμιότυπο δημιουργήθηκε επιτυχώς"
 
@@ -407,6 +412,9 @@ msgstr "Τύπος"
 
 msgid "UID"
 msgstr "UID"
+
+msgid "UUID"
+msgstr ""
 
 msgid "Unknown"
 msgstr "Άγνωστο"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/es_ES/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/es_ES/openmediavault-k8s.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: Raul Fernandez Garcia <raulfg3@gmail.com>, 2024\n"
 "Language-Team: Spanish (Spain) (https://app.transifex.com/openmediavault/teams/14254/es_ES/)\n"
@@ -122,8 +122,20 @@ msgstr "Habilitado"
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
 msgstr "IP Externa"
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
+msgstr ""
 
 msgid "Failed"
 msgstr ""
@@ -136,12 +148,6 @@ msgstr "GID"
 
 msgid "Groups"
 msgstr "Grupos"
-
-msgid "HTTP port"
-msgstr "Puerto HTTP"
-
-msgid "HTTPS port"
-msgstr "puerto HTTPS"
 
 msgid "Helm Charts"
 msgstr "Helm Charts"
@@ -257,6 +263,9 @@ msgstr "Puerto"
 msgid "Ports"
 msgstr "Puertos"
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -277,6 +286,11 @@ msgstr "Recetas"
 
 msgid "Reclaim policy"
 msgstr "Política de reclamaciones"
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
+msgstr ""
 
 msgid "Repository"
 msgstr "Repositorio"
@@ -348,11 +362,9 @@ msgid "Target Namespace"
 msgstr "Espacio de nombres de destino"
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
-"El certificado SSL utilizado por el Panel y el servicio LoadBalancer. Si no "
-"se establece, se utiliza un certificado autofirmado de cert-manager."
 
 msgid ""
 "The datastore used by the Kubernetes cluster. SQLite is recommended for "
@@ -380,12 +392,6 @@ msgstr "La ubicación donde almacenar instantáneas bajo demanda de etcd."
 msgid "The manifest to apply."
 msgstr "El manifiesto a aplicar"
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr "El puerto en el que escucha el panel de Kubernetes."
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr "El puerto en el que escucha el servicio LoadBalancer."
-
 msgid "The snapshot was created successfully."
 msgstr "La instantánea ha sido creada satisfactoriamente."
 
@@ -401,6 +407,9 @@ msgstr "Tipo"
 
 msgid "UID"
 msgstr "UID"
+
+msgid "UUID"
+msgstr ""
 
 msgid "Unknown"
 msgstr ""

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/eu_ES/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/eu_ES/openmediavault-k8s.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Language-Team: Basque (Spain) (https://app.transifex.com/openmediavault/teams/14254/eu_ES/)\n"
 "MIME-Version: 1.0\n"
@@ -115,7 +115,19 @@ msgstr ""
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
+msgstr ""
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
 msgstr ""
 
 msgid "Failed"
@@ -128,12 +140,6 @@ msgid "GID"
 msgstr ""
 
 msgid "Groups"
-msgstr ""
-
-msgid "HTTP port"
-msgstr ""
-
-msgid "HTTPS port"
 msgstr ""
 
 msgid "Helm Charts"
@@ -250,6 +256,9 @@ msgstr ""
 msgid "Ports"
 msgstr ""
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -269,6 +278,11 @@ msgid "Recipes"
 msgstr ""
 
 msgid "Reclaim policy"
+msgstr ""
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
 msgstr ""
 
 msgid "Repository"
@@ -341,8 +355,8 @@ msgid "Target Namespace"
 msgstr ""
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
 
 msgid ""
@@ -367,12 +381,6 @@ msgstr ""
 msgid "The manifest to apply."
 msgstr ""
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr ""
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr ""
-
 msgid "The snapshot was created successfully."
 msgstr ""
 
@@ -386,6 +394,9 @@ msgid "Type"
 msgstr ""
 
 msgid "UID"
+msgstr ""
+
+msgid "UUID"
 msgstr ""
 
 msgid "Unknown"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/fr_FR/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/fr_FR/openmediavault-k8s.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: Axel Cantenys, 2025\n"
 "Language-Team: French (France) (https://app.transifex.com/openmediavault/teams/14254/fr_FR/)\n"
@@ -121,7 +121,19 @@ msgstr "Activé"
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
+msgstr ""
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
 msgstr ""
 
 msgid "Failed"
@@ -135,12 +147,6 @@ msgstr "GID"
 
 msgid "Groups"
 msgstr "Groupes"
-
-msgid "HTTP port"
-msgstr "Port HTTP"
-
-msgid "HTTPS port"
-msgstr "Port HTTPS"
 
 msgid "Helm Charts"
 msgstr ""
@@ -256,6 +262,9 @@ msgstr "Port"
 msgid "Ports"
 msgstr "Ports"
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -275,6 +284,11 @@ msgid "Recipes"
 msgstr ""
 
 msgid "Reclaim policy"
+msgstr ""
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
 msgstr ""
 
 msgid "Repository"
@@ -347,8 +361,8 @@ msgid "Target Namespace"
 msgstr ""
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
 
 msgid ""
@@ -373,12 +387,6 @@ msgstr ""
 msgid "The manifest to apply."
 msgstr ""
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr ""
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr ""
-
 msgid "The snapshot was created successfully."
 msgstr "Instantané créé avec succès."
 
@@ -393,6 +401,9 @@ msgstr "Type"
 
 msgid "UID"
 msgstr "UID"
+
+msgid "UUID"
+msgstr ""
 
 msgid "Unknown"
 msgstr ""

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/gl_ES/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/gl_ES/openmediavault-k8s.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: Miguel Anxo Bouzada <mbouzada@gmail.com>, 2025\n"
 "Language-Team: Galician (Spain) (https://app.transifex.com/openmediavault/teams/14254/gl_ES/)\n"
@@ -120,7 +120,19 @@ msgstr ""
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
+msgstr ""
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
 msgstr ""
 
 msgid "Failed"
@@ -133,12 +145,6 @@ msgid "GID"
 msgstr ""
 
 msgid "Groups"
-msgstr ""
-
-msgid "HTTP port"
-msgstr ""
-
-msgid "HTTPS port"
 msgstr ""
 
 msgid "Helm Charts"
@@ -255,6 +261,9 @@ msgstr "Port"
 msgid "Ports"
 msgstr ""
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -274,6 +283,11 @@ msgid "Recipes"
 msgstr ""
 
 msgid "Reclaim policy"
+msgstr ""
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
 msgstr ""
 
 msgid "Repository"
@@ -346,8 +360,8 @@ msgid "Target Namespace"
 msgstr ""
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
 
 msgid ""
@@ -372,12 +386,6 @@ msgstr ""
 msgid "The manifest to apply."
 msgstr ""
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr ""
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr ""
-
 msgid "The snapshot was created successfully."
 msgstr ""
 
@@ -391,6 +399,9 @@ msgid "Type"
 msgstr ""
 
 msgid "UID"
+msgstr ""
+
+msgid "UUID"
 msgstr ""
 
 msgid "Unknown"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/hu_HU/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/hu_HU/openmediavault-k8s.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-19 21:22+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: Gyuris Gellért <jobel@ujevangelizacio.hu>, 2025\n"
 "Language-Team: Hungarian (Hungary) (https://app.transifex.com/openmediavault/teams/14254/hu_HU/)\n"
@@ -123,8 +123,20 @@ msgstr "Engedélyezve"
 msgid "Events"
 msgstr "Események"
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
 msgstr "Külső IP"
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
+msgstr ""
 
 msgid "Failed"
 msgstr "Sikertelen"
@@ -137,12 +149,6 @@ msgstr "GID"
 
 msgid "Groups"
 msgstr "Csoportok"
-
-msgid "HTTP port"
-msgstr "HTTP-port"
-
-msgid "HTTPS port"
-msgstr "HTTPS-port"
 
 msgid "Helm Charts"
 msgstr "Helm diagramok"
@@ -258,6 +264,9 @@ msgstr "Port"
 msgid "Ports"
 msgstr "Portok"
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr "OLVASSEL"
 
@@ -278,6 +287,11 @@ msgstr "Receptek"
 
 msgid "Reclaim policy"
 msgstr "Visszaigénylési irányelv"
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
+msgstr ""
 
 msgid "Repository"
 msgstr "Tároló"
@@ -349,12 +363,9 @@ msgid "Target Namespace"
 msgstr "Célnévtér"
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
-"A Műszerfal és a Terheléselosztó szolgáltatás által használt SSL-"
-"tanúsítvány. Ha nincs beállítva, akkor a tanúsítványkezelő saját aláírású "
-"tanúsítványát használja."
 
 msgid ""
 "The datastore used by the Kubernetes cluster. SQLite is recommended for "
@@ -390,12 +401,6 @@ msgstr "Az etcd igény szerinti pillanatképek tárolási helye."
 msgid "The manifest to apply."
 msgstr "Az alkalmazandó manifesztum. "
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr "A port, amelyen a Kubernetes Műszerfal hallgat."
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr "A port, amelyen a Terheléselosztó szolgáltatás hallgat."
-
 msgid "The snapshot was created successfully."
 msgstr "A pillanatfelvétel sikeresen létrejött."
 
@@ -411,6 +416,9 @@ msgstr "Típus"
 
 msgid "UID"
 msgstr "UID"
+
+msgid "UUID"
+msgstr ""
 
 msgid "Unknown"
 msgstr "Ismeretlen"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/it_IT/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/it_IT/openmediavault-k8s.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-19 21:22+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: Giovanni Scafora <scafora.giovanni@gmail.com>, 2025\n"
 "Language-Team: Italian (https://app.transifex.com/openmediavault/teams/14254/it/)\n"
@@ -123,8 +123,20 @@ msgstr "Abilitato"
 msgid "Events"
 msgstr "Eventi"
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
 msgstr "IP esterno"
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
+msgstr ""
 
 msgid "Failed"
 msgstr "Operazione non riuscita"
@@ -137,12 +149,6 @@ msgstr "GID"
 
 msgid "Groups"
 msgstr "Gruppi"
-
-msgid "HTTP port"
-msgstr "Porta HTTP"
-
-msgid "HTTPS port"
-msgstr "Porta HTTPS"
 
 msgid "Helm Charts"
 msgstr "Grafici Helm"
@@ -258,6 +264,9 @@ msgstr "Porta"
 msgid "Ports"
 msgstr "Porte"
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr "README"
 
@@ -278,6 +287,11 @@ msgstr "Ricette"
 
 msgid "Reclaim policy"
 msgstr "Politica di recupero"
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
+msgstr ""
 
 msgid "Repository"
 msgstr "Repository"
@@ -349,12 +363,9 @@ msgid "Target Namespace"
 msgstr "Namespace di destinazione"
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
-"Il certificato SSL utilizzato dalla dashboard e dal servizio LoadBalancer. "
-"Se non impostato, viene utilizzato un certificato autofirmato da cert-"
-"manager."
 
 msgid ""
 "The datastore used by the Kubernetes cluster. SQLite is recommended for "
@@ -388,12 +399,6 @@ msgstr "La posizione in cui archiviare gli snapshot etcd su richiesta."
 msgid "The manifest to apply."
 msgstr "Il manifesto da applicare."
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr "La porta su cui è in ascolto la dashboard di Kubernetes."
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr "La porta su cui è in ascolto il servizio LoadBalancer."
-
 msgid "The snapshot was created successfully."
 msgstr "Lo snapshot è stato creato correttamente."
 
@@ -409,6 +414,9 @@ msgstr "Tipo"
 
 msgid "UID"
 msgstr "UID"
+
+msgid "UUID"
+msgstr ""
 
 msgid "Unknown"
 msgstr "Sconosciuto"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/ja_JP/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/ja_JP/openmediavault-k8s.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: Toshihiro Kan <kansuke4649@gmail.com>, 2024\n"
 "Language-Team: Japanese (Japan) (https://app.transifex.com/openmediavault/teams/14254/ja_JP/)\n"
@@ -119,7 +119,19 @@ msgstr "有効化済み"
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
+msgstr ""
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
 msgstr ""
 
 msgid "Failed"
@@ -132,12 +144,6 @@ msgid "GID"
 msgstr ""
 
 msgid "Groups"
-msgstr ""
-
-msgid "HTTP port"
-msgstr ""
-
-msgid "HTTPS port"
 msgstr ""
 
 msgid "Helm Charts"
@@ -254,6 +260,9 @@ msgstr "ポート"
 msgid "Ports"
 msgstr ""
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -273,6 +282,11 @@ msgid "Recipes"
 msgstr ""
 
 msgid "Reclaim policy"
+msgstr ""
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
 msgstr ""
 
 msgid "Repository"
@@ -345,8 +359,8 @@ msgid "Target Namespace"
 msgstr ""
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
 
 msgid ""
@@ -371,12 +385,6 @@ msgstr ""
 msgid "The manifest to apply."
 msgstr ""
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr ""
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr ""
-
 msgid "The snapshot was created successfully."
 msgstr ""
 
@@ -390,6 +398,9 @@ msgid "Type"
 msgstr ""
 
 msgid "UID"
+msgstr ""
+
+msgid "UUID"
 msgstr ""
 
 msgid "Unknown"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/ko_KR/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/ko_KR/openmediavault-k8s.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: Ji-Hyeon Gim <potatogim@potatogim.net>, 2025\n"
 "Language-Team: Korean (Korea) (https://app.transifex.com/openmediavault/teams/14254/ko_KR/)\n"
@@ -119,7 +119,19 @@ msgstr ""
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
+msgstr ""
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
 msgstr ""
 
 msgid "Failed"
@@ -132,12 +144,6 @@ msgid "GID"
 msgstr ""
 
 msgid "Groups"
-msgstr ""
-
-msgid "HTTP port"
-msgstr ""
-
-msgid "HTTPS port"
 msgstr ""
 
 msgid "Helm Charts"
@@ -254,6 +260,9 @@ msgstr "포트"
 msgid "Ports"
 msgstr ""
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -273,6 +282,11 @@ msgid "Recipes"
 msgstr ""
 
 msgid "Reclaim policy"
+msgstr ""
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
 msgstr ""
 
 msgid "Repository"
@@ -345,8 +359,8 @@ msgid "Target Namespace"
 msgstr ""
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
 
 msgid ""
@@ -371,12 +385,6 @@ msgstr ""
 msgid "The manifest to apply."
 msgstr ""
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr ""
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr ""
-
 msgid "The snapshot was created successfully."
 msgstr ""
 
@@ -390,6 +398,9 @@ msgid "Type"
 msgstr ""
 
 msgid "UID"
+msgstr ""
+
+msgid "UUID"
 msgstr ""
 
 msgid "Unknown"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/nl_NL/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/nl_NL/openmediavault-k8s.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: Stephan Paternotte <stephan@paternottes.net>, 2025\n"
 "Language-Team: Dutch (Netherlands) (https://app.transifex.com/openmediavault/teams/14254/nl_NL/)\n"
@@ -123,8 +123,20 @@ msgstr "Ingeschakeld"
 msgid "Events"
 msgstr "Gebeurtenissen"
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
 msgstr "Externe IP"
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
+msgstr ""
 
 msgid "Failed"
 msgstr "Mislukt"
@@ -137,12 +149,6 @@ msgstr "GID"
 
 msgid "Groups"
 msgstr "Groepen"
-
-msgid "HTTP port"
-msgstr "HTTP-poort"
-
-msgid "HTTPS port"
-msgstr "HTTPS-poort"
 
 msgid "Helm Charts"
 msgstr "Helm-diagrammen"
@@ -258,6 +264,9 @@ msgstr "Poort"
 msgid "Ports"
 msgstr "Poorten"
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr "README"
 
@@ -278,6 +287,11 @@ msgstr "Recepten"
 
 msgid "Reclaim policy"
 msgstr "Terugvorderingsbeleid"
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
+msgstr ""
 
 msgid "Repository"
 msgstr "Opslagplaats"
@@ -349,12 +363,9 @@ msgid "Target Namespace"
 msgstr "Doel-naamruimte"
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
-"Het SSL-certificaat dat wordt gebruikt door het bedieningspaneel en de "
-"LoadBalancer-dienst. Indien niet ingesteld, wordt een zelfondertekend "
-"certificaat van cert-manager gebruikt."
 
 msgid ""
 "The datastore used by the Kubernetes cluster. SQLite is recommended for "
@@ -389,12 +400,6 @@ msgstr "De locatie waar etcd momentopnames op aanvraag worden opgeslagen."
 msgid "The manifest to apply."
 msgstr "Het manifest dat moet worden toegepast."
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr "De poort waarop het Kubernetes bedieningspaneel luistert."
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr "De poort waarop de LoadBalancer-dienst luistert."
-
 msgid "The snapshot was created successfully."
 msgstr "De momentopname is met succes aangemaakt."
 
@@ -409,6 +414,9 @@ msgstr "Type"
 
 msgid "UID"
 msgstr "UID"
+
+msgid "UUID"
+msgstr ""
 
 msgid "Unknown"
 msgstr "Onbekend"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/no_NO/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/no_NO/openmediavault-k8s.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: runesudden <runesudden@gmail.com>, 2025\n"
 "Language-Team: Norwegian (https://app.transifex.com/openmediavault/teams/14254/no/)\n"
@@ -119,7 +119,19 @@ msgstr ""
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
+msgstr ""
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
 msgstr ""
 
 msgid "Failed"
@@ -132,12 +144,6 @@ msgid "GID"
 msgstr ""
 
 msgid "Groups"
-msgstr ""
-
-msgid "HTTP port"
-msgstr ""
-
-msgid "HTTPS port"
 msgstr ""
 
 msgid "Helm Charts"
@@ -254,6 +260,9 @@ msgstr ""
 msgid "Ports"
 msgstr ""
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -273,6 +282,11 @@ msgid "Recipes"
 msgstr ""
 
 msgid "Reclaim policy"
+msgstr ""
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
 msgstr ""
 
 msgid "Repository"
@@ -345,8 +359,8 @@ msgid "Target Namespace"
 msgstr ""
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
 
 msgid ""
@@ -371,12 +385,6 @@ msgstr ""
 msgid "The manifest to apply."
 msgstr ""
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr ""
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr ""
-
 msgid "The snapshot was created successfully."
 msgstr ""
 
@@ -390,6 +398,9 @@ msgid "Type"
 msgstr ""
 
 msgid "UID"
+msgstr ""
+
+msgid "UUID"
 msgstr ""
 
 msgid "Unknown"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/openmediavault-k8s.pot
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/openmediavault-k8s.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -113,7 +113,19 @@ msgstr ""
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
+msgstr ""
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
 msgstr ""
 
 msgid "Failed"
@@ -126,12 +138,6 @@ msgid "GID"
 msgstr ""
 
 msgid "Groups"
-msgstr ""
-
-msgid "HTTP port"
-msgstr ""
-
-msgid "HTTPS port"
 msgstr ""
 
 msgid "Helm Charts"
@@ -248,6 +254,9 @@ msgstr ""
 msgid "Ports"
 msgstr ""
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -267,6 +276,9 @@ msgid "Recipes"
 msgstr ""
 
 msgid "Reclaim policy"
+msgstr ""
+
+msgid "Refer to the values.yaml file in the Traefik Helm chart to see what configuration options are available."
 msgstr ""
 
 msgid "Repository"
@@ -338,7 +350,7 @@ msgstr ""
 msgid "Target Namespace"
 msgstr ""
 
-msgid "The SSL certificate used by the Dashboard and the LoadBalancer service. If not set, a self-signed certificate from cert-manager is used."
+msgid "The SSL certificate used by the LoadBalancer service. If not set, a self-signed certificate from cert-manager is used."
 msgstr ""
 
 msgid "The datastore used by the Kubernetes cluster. SQLite is recommended for single-node setups and SBCs with slow disks, while etcd is recommended for high-availability setups with multiple nodes."
@@ -351,12 +363,6 @@ msgid "The location where to store etcd on-demand snapshots."
 msgstr ""
 
 msgid "The manifest to apply."
-msgstr ""
-
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr ""
-
-msgid "The port on which the LoadBalancer service is listening."
 msgstr ""
 
 msgid "The snapshot was created successfully."
@@ -372,6 +378,9 @@ msgid "Type"
 msgstr ""
 
 msgid "UID"
+msgstr ""
+
+msgid "UUID"
 msgstr ""
 
 msgid "Unknown"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/pl_PL/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/pl_PL/openmediavault-k8s.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: jacekniedziolka71 <lucas71@interia.pl>, 2025\n"
 "Language-Team: Polish (Poland) (https://app.transifex.com/openmediavault/teams/14254/pl_PL/)\n"
@@ -120,7 +120,19 @@ msgstr "Włączony"
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
+msgstr ""
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
 msgstr ""
 
 msgid "Failed"
@@ -133,12 +145,6 @@ msgid "GID"
 msgstr ""
 
 msgid "Groups"
-msgstr ""
-
-msgid "HTTP port"
-msgstr ""
-
-msgid "HTTPS port"
 msgstr ""
 
 msgid "Helm Charts"
@@ -255,6 +261,9 @@ msgstr ""
 msgid "Ports"
 msgstr "Porty"
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -274,6 +283,11 @@ msgid "Recipes"
 msgstr ""
 
 msgid "Reclaim policy"
+msgstr ""
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
 msgstr ""
 
 msgid "Repository"
@@ -346,8 +360,8 @@ msgid "Target Namespace"
 msgstr ""
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
 
 msgid ""
@@ -372,12 +386,6 @@ msgstr ""
 msgid "The manifest to apply."
 msgstr ""
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr ""
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr ""
-
 msgid "The snapshot was created successfully."
 msgstr ""
 
@@ -391,6 +399,9 @@ msgid "Type"
 msgstr ""
 
 msgid "UID"
+msgstr ""
+
+msgid "UUID"
 msgstr ""
 
 msgid "Unknown"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/pt_PT/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/pt_PT/openmediavault-k8s.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: Nelson Rosado <nelsontrosado@gmail.com>, 2025\n"
 "Language-Team: Portuguese (Portugal) (https://app.transifex.com/openmediavault/teams/14254/pt_PT/)\n"
@@ -120,7 +120,19 @@ msgstr ""
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
+msgstr ""
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
 msgstr ""
 
 msgid "Failed"
@@ -133,12 +145,6 @@ msgid "GID"
 msgstr ""
 
 msgid "Groups"
-msgstr ""
-
-msgid "HTTP port"
-msgstr ""
-
-msgid "HTTPS port"
 msgstr ""
 
 msgid "Helm Charts"
@@ -255,6 +261,9 @@ msgstr "Porta"
 msgid "Ports"
 msgstr ""
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -274,6 +283,11 @@ msgid "Recipes"
 msgstr ""
 
 msgid "Reclaim policy"
+msgstr ""
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
 msgstr ""
 
 msgid "Repository"
@@ -346,8 +360,8 @@ msgid "Target Namespace"
 msgstr ""
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
 
 msgid ""
@@ -372,12 +386,6 @@ msgstr ""
 msgid "The manifest to apply."
 msgstr ""
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr ""
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr ""
-
 msgid "The snapshot was created successfully."
 msgstr ""
 
@@ -391,6 +399,9 @@ msgid "Type"
 msgstr ""
 
 msgid "UID"
+msgstr ""
+
+msgid "UUID"
 msgstr ""
 
 msgid "Unknown"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/ru_RU/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/ru_RU/openmediavault-k8s.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Language-Team: Russian (Russia) (https://app.transifex.com/openmediavault/teams/14254/ru_RU/)\n"
 "MIME-Version: 1.0\n"
@@ -115,7 +115,19 @@ msgstr ""
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
+msgstr ""
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
 msgstr ""
 
 msgid "Failed"
@@ -128,12 +140,6 @@ msgid "GID"
 msgstr ""
 
 msgid "Groups"
-msgstr ""
-
-msgid "HTTP port"
-msgstr ""
-
-msgid "HTTPS port"
 msgstr ""
 
 msgid "Helm Charts"
@@ -250,6 +256,9 @@ msgstr ""
 msgid "Ports"
 msgstr ""
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -269,6 +278,11 @@ msgid "Recipes"
 msgstr ""
 
 msgid "Reclaim policy"
+msgstr ""
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
 msgstr ""
 
 msgid "Repository"
@@ -341,8 +355,8 @@ msgid "Target Namespace"
 msgstr ""
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
 
 msgid ""
@@ -367,12 +381,6 @@ msgstr ""
 msgid "The manifest to apply."
 msgstr ""
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr ""
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr ""
-
 msgid "The snapshot was created successfully."
 msgstr ""
 
@@ -386,6 +394,9 @@ msgid "Type"
 msgstr ""
 
 msgid "UID"
+msgstr ""
+
+msgid "UUID"
 msgstr ""
 
 msgid "Unknown"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/sl_SI/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/sl_SI/openmediavault-k8s.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: Valentin Korenjak <valentin@korenjak.si>, 2025\n"
 "Language-Team: Slovenian (Slovenia) (https://app.transifex.com/openmediavault/teams/14254/sl_SI/)\n"
@@ -119,7 +119,19 @@ msgstr ""
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
+msgstr ""
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
 msgstr ""
 
 msgid "Failed"
@@ -132,12 +144,6 @@ msgid "GID"
 msgstr ""
 
 msgid "Groups"
-msgstr ""
-
-msgid "HTTP port"
-msgstr ""
-
-msgid "HTTPS port"
 msgstr ""
 
 msgid "Helm Charts"
@@ -254,6 +260,9 @@ msgstr ""
 msgid "Ports"
 msgstr ""
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -273,6 +282,11 @@ msgid "Recipes"
 msgstr ""
 
 msgid "Reclaim policy"
+msgstr ""
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
 msgstr ""
 
 msgid "Repository"
@@ -345,8 +359,8 @@ msgid "Target Namespace"
 msgstr ""
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
 
 msgid ""
@@ -371,12 +385,6 @@ msgstr ""
 msgid "The manifest to apply."
 msgstr ""
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr ""
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr ""
-
 msgid "The snapshot was created successfully."
 msgstr ""
 
@@ -390,6 +398,9 @@ msgid "Type"
 msgstr ""
 
 msgid "UID"
+msgstr ""
+
+msgid "UUID"
 msgstr ""
 
 msgid "Unknown"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/sv_SE/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/sv_SE/openmediavault-k8s.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-19 21:22+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: Daniel, 2025\n"
 "Language-Team: Swedish (https://app.transifex.com/openmediavault/teams/14254/sv/)\n"
@@ -123,8 +123,20 @@ msgstr "Aktiverad"
 msgid "Events"
 msgstr "Händelser"
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
 msgstr "Extern IP"
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
+msgstr ""
 
 msgid "Failed"
 msgstr "Misslyckades"
@@ -137,12 +149,6 @@ msgstr "GID"
 
 msgid "Groups"
 msgstr "Grupper"
-
-msgid "HTTP port"
-msgstr "HTTP-port"
-
-msgid "HTTPS port"
-msgstr "HTTPS-port"
 
 msgid "Helm Charts"
 msgstr ""
@@ -258,6 +264,9 @@ msgstr "Port"
 msgid "Ports"
 msgstr "Portar"
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr "README"
 
@@ -278,6 +287,11 @@ msgstr "Recept"
 
 msgid "Reclaim policy"
 msgstr "Återkrävningspolicy "
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
+msgstr ""
 
 msgid "Repository"
 msgstr "Förråd"
@@ -349,11 +363,9 @@ msgid "Target Namespace"
 msgstr ""
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
-"SSL-certifikatet som används av instrumentpanelen och LoadBalancer-tjänsten."
-" Om inte inställt används ett självsignerat certifikat från cert-manager."
 
 msgid ""
 "The datastore used by the Kubernetes cluster. SQLite is recommended for "
@@ -387,12 +399,6 @@ msgstr "Platsen där man lagrar etcd-on-demand ögonblicksbilder."
 msgid "The manifest to apply."
 msgstr "Manifestet som ska verkställas."
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr "Porten som Kubernetes-instrumentpanel lyssnar på."
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr "Porten som LoadBalancer-tjänsten lyssnar på."
-
 msgid "The snapshot was created successfully."
 msgstr "Ögonblicksbilden skapades."
 
@@ -407,6 +413,9 @@ msgstr "Typ"
 
 msgid "UID"
 msgstr "UID"
+
+msgid "UUID"
+msgstr ""
 
 msgid "Unknown"
 msgstr "Okänd"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/tr_TR/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/tr_TR/openmediavault-k8s.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: Serhat SUT <serhat.sut@gmail.com>, 2025\n"
 "Language-Team: Turkish (Turkey) (https://app.transifex.com/openmediavault/teams/14254/tr_TR/)\n"
@@ -119,7 +119,19 @@ msgstr "Geçerli"
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
+msgstr ""
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
 msgstr ""
 
 msgid "Failed"
@@ -132,12 +144,6 @@ msgid "GID"
 msgstr ""
 
 msgid "Groups"
-msgstr ""
-
-msgid "HTTP port"
-msgstr ""
-
-msgid "HTTPS port"
 msgstr ""
 
 msgid "Helm Charts"
@@ -254,6 +260,9 @@ msgstr ""
 msgid "Ports"
 msgstr ""
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -273,6 +282,11 @@ msgid "Recipes"
 msgstr ""
 
 msgid "Reclaim policy"
+msgstr ""
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
 msgstr ""
 
 msgid "Repository"
@@ -345,8 +359,8 @@ msgid "Target Namespace"
 msgstr ""
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
 
 msgid ""
@@ -371,12 +385,6 @@ msgstr ""
 msgid "The manifest to apply."
 msgstr ""
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr ""
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr ""
-
 msgid "The snapshot was created successfully."
 msgstr ""
 
@@ -390,6 +398,9 @@ msgid "Type"
 msgstr ""
 
 msgid "UID"
+msgstr ""
+
+msgid "UUID"
 msgstr ""
 
 msgid "Unknown"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/uk_UK/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/uk_UK/openmediavault-k8s.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: zubr139, 2025\n"
 "Language-Team: Ukrainian (https://app.transifex.com/openmediavault/teams/14254/uk/)\n"
@@ -119,7 +119,19 @@ msgstr "Увімкнено"
 msgid "Events"
 msgstr ""
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
+msgstr ""
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
 msgstr ""
 
 msgid "Failed"
@@ -132,12 +144,6 @@ msgid "GID"
 msgstr ""
 
 msgid "Groups"
-msgstr ""
-
-msgid "HTTP port"
-msgstr ""
-
-msgid "HTTPS port"
 msgstr ""
 
 msgid "Helm Charts"
@@ -254,6 +260,9 @@ msgstr ""
 msgid "Ports"
 msgstr "Порти"
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr ""
 
@@ -273,6 +282,11 @@ msgid "Recipes"
 msgstr ""
 
 msgid "Reclaim policy"
+msgstr ""
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
 msgstr ""
 
 msgid "Repository"
@@ -345,8 +359,8 @@ msgid "Target Namespace"
 msgstr ""
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
 msgstr ""
 
 msgid ""
@@ -371,12 +385,6 @@ msgstr ""
 msgid "The manifest to apply."
 msgstr "Маніфест для застосування."
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr ""
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr ""
-
 msgid "The snapshot was created successfully."
 msgstr ""
 
@@ -390,6 +398,9 @@ msgid "Type"
 msgstr ""
 
 msgid "UID"
+msgstr ""
+
+msgid "UUID"
 msgstr ""
 
 msgid "Unknown"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/zh_CN/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/zh_CN/openmediavault-k8s.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: irrelevant91, 2025\n"
 "Language-Team: Chinese (China) (https://app.transifex.com/openmediavault/teams/14254/zh_CN/)\n"
@@ -123,8 +123,20 @@ msgstr "已启用"
 msgid "Events"
 msgstr "事件"
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
 msgstr "外部 IP"
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
+msgstr ""
 
 msgid "Failed"
 msgstr "失败"
@@ -137,12 +149,6 @@ msgstr "GID"
 
 msgid "Groups"
 msgstr "组"
-
-msgid "HTTP port"
-msgstr "HTTP 端口"
-
-msgid "HTTPS port"
-msgstr "HTTPS 端口"
 
 msgid "Helm Charts"
 msgstr "Helm Charts"
@@ -258,6 +264,9 @@ msgstr "端口"
 msgid "Ports"
 msgstr "端口"
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr "README"
 
@@ -278,6 +287,11 @@ msgstr "Recipes"
 
 msgid "Reclaim policy"
 msgstr "回收策略"
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
+msgstr ""
 
 msgid "Repository"
 msgstr "源"
@@ -349,9 +363,9 @@ msgid "Target Namespace"
 msgstr "目标命名空间"
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
-msgstr "仪表板与负载均衡服务使用的 SSL 证书。若未设定，则使用来自 cert-manager 的自签名证书。"
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
+msgstr ""
 
 msgid ""
 "The datastore used by the Kubernetes cluster. SQLite is recommended for "
@@ -380,12 +394,6 @@ msgstr "存储 etcd 按需快照的位置。"
 msgid "The manifest to apply."
 msgstr "要应用的 manifest。"
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr "Kubernetes 仪表板监听的端口。"
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr "负载均衡服务监听的端口。"
-
 msgid "The snapshot was created successfully."
 msgstr "快照创建成功。"
 
@@ -400,6 +408,9 @@ msgstr "类型"
 
 msgid "UID"
 msgstr "UID"
+
+msgid "UUID"
+msgstr ""
 
 msgid "Unknown"
 msgstr "未知"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/locale/zh_TW/openmediavault-k8s.po
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/locale/zh_TW/openmediavault-k8s.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: openmediavault-k8s\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-03 21:46+0100\n"
+"POT-Creation-Date: 2026-01-24 19:51+0100\n"
 "PO-Revision-Date: 2024-03-09 09:44+0000\n"
 "Last-Translator: kochin <kochinc@outlook.com>, 2025\n"
 "Language-Team: Chinese (Taiwan) (https://app.transifex.com/openmediavault/teams/14254/zh_TW/)\n"
@@ -122,8 +122,20 @@ msgstr "已啟用"
 msgid "Events"
 msgstr "事件"
 
+msgid "Expose"
+msgstr ""
+
+msgid "Exposed Port"
+msgstr ""
+
 msgid "External IP"
 msgstr "外部 IP"
+
+msgid "Extra Values"
+msgstr ""
+
+msgid "Extra configuration"
+msgstr ""
 
 msgid "Failed"
 msgstr "失敗"
@@ -136,12 +148,6 @@ msgstr "GID"
 
 msgid "Groups"
 msgstr "群組"
-
-msgid "HTTP port"
-msgstr "HTTP 通訊埠"
-
-msgid "HTTPS port"
-msgstr "HTTPS 通訊埠"
 
 msgid "Helm Charts"
 msgstr "Helm Charts"
@@ -257,6 +263,9 @@ msgstr "通訊埠"
 msgid "Ports"
 msgstr "通訊埠"
 
+msgid "Protocol"
+msgstr ""
+
 msgid "README"
 msgstr "讀我檔案"
 
@@ -277,6 +286,11 @@ msgstr "配方集"
 
 msgid "Reclaim policy"
 msgstr "回收政策"
+
+msgid ""
+"Refer to the values.yaml file in the Traefik Helm chart to see what "
+"configuration options are available."
+msgstr ""
 
 msgid "Repository"
 msgstr "鏡像庫"
@@ -348,9 +362,9 @@ msgid "Target Namespace"
 msgstr "目標命名空間"
 
 msgid ""
-"The SSL certificate used by the Dashboard and the LoadBalancer service. If "
-"not set, a self-signed certificate from cert-manager is used."
-msgstr "儀表板與負載平衡服務使用的 SSL 憑證。若未設定，則使用來自 cert-manager 的自行簽署憑證。"
+"The SSL certificate used by the LoadBalancer service. If not set, a self-"
+"signed certificate from cert-manager is used."
+msgstr ""
 
 msgid ""
 "The datastore used by the Kubernetes cluster. SQLite is recommended for "
@@ -380,12 +394,6 @@ msgstr "儲存 etcd 隨選快照的位置。"
 msgid "The manifest to apply."
 msgstr "要套用的 manifest。"
 
-msgid "The port on which the Kubernetes Dashboard is listening."
-msgstr "Kubernetes 儀表板正在監聽的連接埠。"
-
-msgid "The port on which the LoadBalancer service is listening."
-msgstr "負載平衡服務正在監聽的連接埠。"
-
 msgid "The snapshot was created successfully."
 msgstr "快照建立成功。"
 
@@ -400,6 +408,9 @@ msgstr "類型"
 
 msgid "UID"
 msgstr "UID"
+
+msgid "UUID"
+msgstr ""
 
 msgid "Unknown"
 msgstr "未知"

--- a/deb/openmediavault-k8s/usr/share/openmediavault/workbench/component.d/omv-services-k8s-settings-form-page.yaml
+++ b/deb/openmediavault-k8s/usr/share/openmediavault/workbench/component.d/omv-services-k8s-settings-form-page.yaml
@@ -51,46 +51,167 @@ data:
             operator: truthy
             arg0:
               prop: enable
+      - type: divider
+        title: _("Load Balancer")
+      - type: datatable
+        name: lbports
+        label: _("Ports")
+        hasFooter: false
+        columns:
+          - name: _("UUID")
+            prop: "uuid"
+            hidden: true
+          - name: _("Name")
+            prop: "name"
+            flexGrow: 1
+          - name: _("Port")
+            prop: "port"
+            flexGrow: 1
+          - name: _("Exposed Port")
+            prop: "exposedport"
+            flexGrow: 1
+          - name: _("Protocol")
+            prop: "protocol"
+            flexGrow: 1
+            cellTemplateName: "chip"
+            cellTemplateConfig:
+              map:
+                tcp:
+                  value: "TCP"
+                udp:
+                  value: "UDP"
+          - name: _("Expose")
+            prop: "expose"
+            cellTemplateName: "checkIcon"
+            flexGrow: 1
+          - name: _("Tags")
+            prop: "comment"
+            cellTemplateName: "chip"
+            cellTemplateConfig:
+              separator: ","
+            flexGrow: 1
+            sortable: true
+          - name: _("Extra Values")
+            prop: "extravalues"
+            hidden: true
+        sorters:
+          - dir: asc
+            prop: name
+        actions:
+          - template: add
+            formDialogConfig:
+              title: _("Port")
+              fields:
+                - type: confObjUuid
+                - type: textInput
+                  name: name
+                  label: _("Name")
+                  validators:
+                    required: true
+                - type: container
+                  fields:
+                    - type: numberInput
+                      name: port
+                      label: _("Port")
+                      validators:
+                        required: true
+                        min: 1
+                        max: 65535
+                      value: "{{ range(1024, 65535) | random }}"
+                    - type: numberInput
+                      name: exposedport
+                      label: _("Exposed Port")
+                      validators:
+                        required: true
+                        min: 1
+                        max: 65535
+                      value: "{{ range(1024, 65535) | random }}"
+                - type: select
+                  name: protocol
+                  label: _("Protocol")
+                  validators:
+                    required: true
+                  store:
+                    data:
+                      - ["udp", "UDP"]
+                      - ["tcp", "TCP"]
+                  value: "tcp"
+                - type: checkbox
+                  name: expose
+                  label: _("Expose")
+                  value: true
+                - type: codeEditor
+                  name: extravalues
+                  label: _("Extra configuration")
+                  hint: _("Refer to the values.yaml file in the Traefik Helm chart to see what configuration options are available.")
+                  language: yaml
+                  lineNumbers: true
+                  value: ""
+                - type: tagInput
+                  name: comment
+                  label: _("Tags")
+                  value: ""
+          - template: edit
+            formDialogConfig:
+              title: _("Port")
+              fields:
+                - type: confObjUuid
+                - type: textInput
+                  name: name
+                  label: _("Name")
+                  disabled: true
+                - type: container
+                  fields:
+                    - type: numberInput
+                      name: port
+                      label: _("Port")
+                      validators:
+                        required: true
+                        min: 1
+                        max: 65535
+                      value: "{{ range(1024, 65535) | random }}"
+                    - type: numberInput
+                      name: exposedport
+                      label: _("Exposed Port")
+                      validators:
+                        required: true
+                        min: 1
+                        max: 65535
+                      value: "{{ range(1024, 65535) | random }}"
+                - type: select
+                  name: protocol
+                  label: _("Protocol")
+                  validators:
+                    required: true
+                  store:
+                    data:
+                      - ["udp", "UDP"]
+                      - ["tcp", "TCP"]
+                  value: "tcp"
+                - type: checkbox
+                  name: expose
+                  label: _("Expose")
+                  value: true
+                - type: codeEditor
+                  name: extravalues
+                  label: _("Extra configuration")
+                  hint: _("Refer to the values.yaml file in the Traefik Helm chart to see what configuration options are available.")
+                  language: yaml
+                  lineNumbers: true
+                  value: ""
+                - type: tagInput
+                  name: comment
+                  label: _("Tags")
+                  value: ""
+          - template: delete
       - type: sslCertSelect
         name: sslcertificateref
         label: _("Certificate")
-        hint: _("The SSL certificate used by the Dashboard and the LoadBalancer service. If not set, a self-signed certificate from cert-manager is used.")
+        hint: _("The SSL certificate used by the LoadBalancer service. If not set, a self-signed certificate from cert-manager is used.")
         hasEmptyOption: true
         value: ""
       - type: divider
-        title: _("Load Balancer")
-      - type: numberInput
-        name: webport
-        label: _("HTTP port")
-        hint: _("The port on which the LoadBalancer service is listening.")
-        value: 8080
-        validators:
-          min: 1
-          max: 65535
-          patternType: port
-          required: true
-      - type: numberInput
-        name: websecureport
-        label: _("HTTPS port")
-        hint: _("The port on which the LoadBalancer service is listening.")
-        value: 8443
-        validators:
-          min: 1
-          max: 65535
-          patternType: port
-          required: true
-      - type: divider
         title: _("Dashboard")
-      - type: numberInput
-        name: dashboardport
-        label: _("Port")
-        hint: _("The port on which the Kubernetes Dashboard is listening.")
-        value: 4443
-        validators:
-          min: 1
-          max: 65535
-          patternType: port
-          required: true
       - type: button
         name: token
         text: _("Copy token")
@@ -132,7 +253,7 @@ data:
         request:
           service: K8s
           method: isConfigApplicable
-          successUrl: "/externalRedirect/https{{ ['://', location() | get('hostname'), ':', dashboardport] | join | encodeuricomponent }}"
+          successUrl: "/externalRedirect/https{{ ['://', location() | get('hostname'), ':', lbports | filter(['name','dashboard']) | first | get('exposedport') ] | join | encodeuricomponent }}"
       - type: divider
         title: _("Kubeconfig")
       - type: hint


### PR DESCRIPTION
The following environment variables have been removed:
- OMV_K8S_TRAEFIK_PORTS
- OMV_K8S_TRAEFIK_ENTRYPOINT_TRANSPORT_RESPONDINGTIMEOUTS_READTIMEOUT

Related to: https://github.com/openmediavault/openmediavault/issues/1940

<img width="1511" height="860" alt="Bildschirmfoto vom 2026-01-24 19-31-37" src="https://github.com/user-attachments/assets/eda438ad-bf86-4145-8450-4b17bd203016" />

<img width="1511" height="860" alt="Bildschirmfoto vom 2026-01-24 19-31-43" src="https://github.com/user-attachments/assets/e532ab93-4bf6-48e9-a863-4232317b90c7" />


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
