### PR TITLE
Sync HTML lang attribute with current locale

### DIFF
--- a/deb/openmediavault/workbench/src/app/app.component.ts
+++ b/deb/openmediavault/workbench/src/app/app.component.ts
@@ -45,12 +45,15 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.setHtmlLangAttributeFromLocale();
+    this.setLangAttribute();
   }
 
-  private setHtmlLangAttributeFromLocale(): void {
-    const locale = LocaleService.getCurrentLocale();
-    const lang = locale.substring(0, 2);
-    this.renderer2.setAttribute(document.documentElement, 'lang', lang);
+  /**
+   * Set the `lang` attribute of the HTML document element.
+   * @private
+   */
+  private setLangAttribute(): void {
+    const locale = LocaleService.getCurrentLocaleObject();
+    this.renderer2.setAttribute(document.documentElement, 'lang', locale.language);
   }
 }

--- a/deb/openmediavault/workbench/src/app/shared/services/locale.service.ts
+++ b/deb/openmediavault/workbench/src/app/shared/services/locale.service.ts
@@ -32,6 +32,14 @@ export class LocaleService {
   }
 
   /**
+   * Get the current locale as `Intl.Locale` object.
+   */
+  static getCurrentLocaleObject(): Intl.Locale {
+    const locale: Intl.BCP47LanguageTag = getCurrentLocale().replace('_', '-');
+    return new Intl.Locale(locale);
+  }
+
+  /**
    * Set the current locale.
    */
   static setCurrentLocale(locale: string): void {


### PR DESCRIPTION
Implement success criterion [3.1.1 Language of Page (Level A)](https://www.w3.org/TR/WCAG22/#language-of-page) from [WCAG 2.2](https://www.w3.org/TR/WCAG22/) by setting HTML lang attribute with current locale.

Refers to: #1520

<img width="1305" height="585" alt="lang" src="https://github.com/user-attachments/assets/332f6446-6367-42df-bb04-70440c1a5b0e" />
