### PR TITLE
Issue #2169: Make sure the symlink points to the canonical device file

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,6 @@
 openmediavault (8.2.4-1) stable; urgency=medium
 
-  *
+  * Issue #2169: Make sure device symlinks point to the canonical device file.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Fri, 10 Apr 2026 15:34:13 +0200
 

--- a/deb/openmediavault/usr/share/php/openmediavault/system/blockdevice.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/blockdevice.inc
@@ -226,13 +226,20 @@ class BlockDevice implements BlockDeviceInterface, UdevInterface {
 		// - /dev/mapper/omv--lvm--vg-root /dev/omv-lvm-vg/root /dev/disk/by-id/dm-name-omv--lvm--vg-root /dev/disk/by-id/dm-uuid-LVM-qrB1zl0Sshr0gzosPHD4NeJC7D2aLNF50m40r7lb7304SjsnCw6V0hOOeMmByPrq /dev/disk/by-uuid/4a1aa5db-980b-43ac-a62a-a2b9eadcb34f
 		$parts = array_map("trim", explode(" ", $property));
 		sort($parts, SORT_NATURAL);
+		$canonicalDeviceFile = $this->getCanonicalDeviceFile();
 		$result = [];
 		foreach ($parts as $partk => $partv) {
 			// Make sure that the device path is correct.
 			if (TRUE === is_devicefile($partv)) {
-				$result[] = $partv;
+				$deviceFile = $partv;
 			} else {
-				$result[] = sprintf("/dev/%s", $partv);
+				$deviceFile = sprintf("/dev/%s", $partv);
+			}
+			// Make sure the symlink points to the canonical device file.
+			// This prevents returning symlinks that have been "hijacked" by
+			// DM multipath devices or other layers.
+			if (realpath($deviceFile) === $canonicalDeviceFile) {
+				$result[] = $deviceFile;
 			}
 		}
 		return $result;


### PR DESCRIPTION
This prevents returning symlinks that have been "hijacked" by DM multipath devices or other layers.

<img width="1232" height="338" alt="grafik" src="https://github.com/user-attachments/assets/adb91602-9020-434c-852d-d4341f5116f6" />

<img width="1026" height="352" alt="grafik" src="https://github.com/user-attachments/assets/754db766-1517-456d-9dae-7357cdbb0a42" />

Fixes: https://github.com/openmediavault/openmediavault/issues/2169


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
