### PR TITLE
Update create.py error handling

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/confdbadm/commands.d/create.py
+++ b/deb/openmediavault/usr/share/openmediavault/confdbadm/commands.d/create.py
@@ -65,9 +65,9 @@ class Command(
             self.create_backup()
             # Test if the script exists and is executable.
             script_path = os.path.join(create_dir, script_name)
-            if not os.path.exists(script_path):
+            if not script_name:
                 raise RuntimeError(
-                    "The script '%s' does not exist" % script_name
+                    "No script was found for data-model ID '%s' in the data model directory '%s'" % (cmd_args.id, create_dir)
                 )
             if not os.access(script_path, os.X_OK):
                 raise RuntimeError(


### PR DESCRIPTION
"""
create.py error handling improved.

Fixed broken error handling. There was already a search for the name of the datamodel script in create_dir earlier in the code: If nothing was found in the create_dir folder, script_name passed on an EMPTY value and so created a script_path out of only create_dir. Which failed the previou error catching, and led to trying to execute the create_dir directory, causing a misleading Errno 13 Access Denied.

Fixes: the above unreported issue

Signed-off-by: Poofy Gummy <poofygummy@gmail.com>
"""
- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
