### PR TITLE
Fix Time Machine backups via SMB

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/avahi/services/smb.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/avahi/services/smb.sls
@@ -24,7 +24,7 @@
 
 {% set smb_config = salt['omv_conf.get']('conf.service.smb') %}
 {% set smb_zeroconf_enabled = salt['pillar.get']('default:OMV_SAMBA_ZEROCONF_ENABLED', 1) %}
-{% set smb_zeroconf_name = salt['pillar.get']('default:OMV_SAMBA_ZEROCONF_NAME', '%h') %}
+{% set smb_zeroconf_name = salt['pillar.get']('default:OMV_SAMBA_ZEROCONF_NAME', '%h - SMB/CIFS') %}
 
 {% if (smb_config.enable | to_bool) and (smb_zeroconf_enabled | to_bool) %}
 

--- a/deb/openmediavault/srv/salt/omv/deploy/samba/files/shares.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/samba/files/shares.j2
@@ -72,6 +72,10 @@ fruit:veto_appledouble = {{ fruit_veto_appledouble }}
 fruit:wipe_intentionally_left_blank_rfork = {{ fruit_wipe_intentionally_left_blank_rfork }}
 fruit:delete_empty_adfiles = {{ fruit_delete_empty_adfiles }}
 fruit:time machine = yes
+fruit:posix_rename = yes
+fruit:nfs_aces = no
+durable handles = yes
+smb2 leases = yes
 {%- if share.timemachinemaxsize | length > 0 %}
 fruit:time machine max size = {{ share.timemachinemaxsize }}
 {%- endif %}


### PR DESCRIPTION
Fix Time Machine backups via SMB

This PR addresses widespread compatibility issues with macOS Time Machine backups over SMB, particularly affecting clients running macOS Sequoia connected to Samba 4.22.

**Root Causes & Fixes:**
1. **Samba 4.22 Rename Bug:** Backups often fail during the renaming of temporary files. Setting `fruit:posix_rename = yes` bypasses this issue.
2. **macOS Credential/Permission Errors:** Newer macOS versions enforce stricter metadata handling. If `fruit:nfs_aces` is enabled or left to default behavior in certain contexts, it can trigger false "incorrect username/password" prompts on the client. Forcing `fruit:nfs_aces = no` on the share level resolves this.
3. **Connection Stability:** Adding `durable handles = yes` and `smb2 leases = yes` improves connection reliability and file locking mechanisms for long-running backup tasks.
4. **Service Discovery:** macOS Finder sometimes struggles to identify the SMB service correctly via mDNS. Appending ` - SMB/CIFS` to the Avahi zeroconf broadcast name (`OMV_SAMBA_ZEROCONF_NAME`) ensures stable discovery alongside other protocols like AFP.

These changes integrate community-tested workarounds directly into the `shares.j2` and `smb.sls` Salt templates, automatically applying them when a share is marked as a Time Machine target.

References: 
- Reddit Community Workaround: https://www.reddit.com/r/OpenMediaVault/comments/1sirfe7/time_machine_stopped_working/

Signed-off-by: InvalidPandaa <mail@invalidpanda.dev>