### PR TITLE
Fixed filebrowser not starting in OMV8

### DIFF
--- a/deb/openmediavault-filebrowser/debian/changelog
+++ b/deb/openmediavault-filebrowser/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-filebrowser (8.0.4-1) stable; urgency=medium
+
+  * Issue #2194: Changed ports and set correct UID and GID.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Tue, 05 May 2026 09:58:56 +0200
+
 openmediavault-filebrowser (8.0.3-1) stable; urgency=medium
 
   * Issue #2176: Increase mDNS/Zeroconf compatibility for MacOS.

--- a/deb/openmediavault-filebrowser/debian/openmediavault-filebrowser.postinst
+++ b/deb/openmediavault-filebrowser/debian/openmediavault-filebrowser.postinst
@@ -85,6 +85,9 @@ case "$1" in
 		if dpkg --compare-versions "$2" lt-nl "8.0.1"; then
 			omv_module_set_dirty filebrowser
 		fi
+		if dpkg --compare-versions "$2" lt-nl "8.0.4"; then
+			omv_module_set_dirty filebrowser
+		fi
 	;;
 
 	abort-upgrade|abort-remove|abort-deconfigure)

--- a/deb/openmediavault-filebrowser/srv/salt/omv/deploy/filebrowser/files/Caddyfile.j2
+++ b/deb/openmediavault-filebrowser/srv/salt/omv/deploy/filebrowser/files/Caddyfile.j2
@@ -2,12 +2,12 @@
   admin off
   auto_https off
 }
-:443 {
+:8443 {
   tls /data/cert.crt /data/cert.key
 
   # Public endpoints (no authentication)
   handle /public/* {
-    reverse_proxy filebrowser-app:80 {
+    reverse_proxy filebrowser-app:8080 {
       header_up Host {host}
       header_up X-Forwarded-For {remote_host}
       header_up X-Forwarded-Proto {scheme}
@@ -16,14 +16,14 @@
 
   # Private endpoints (with authentication)
   handle /* {
-    reverse_proxy filebrowser-app:80 {
+    reverse_proxy filebrowser-app:8080 {
       header_up Host {host}
       header_up X-Forwarded-For {remote_host}
       header_up X-Forwarded-Proto {scheme}
     }
   }
 
-  reverse_proxy filebrowser-app:80 {
+  reverse_proxy filebrowser-app:8080 {
     header_up Connection {>Connection}
     header_up Transfer-Encoding {>Transfer-Encoding}
   }

--- a/deb/openmediavault-filebrowser/srv/salt/omv/deploy/filebrowser/files/Caddyfile.j2
+++ b/deb/openmediavault-filebrowser/srv/salt/omv/deploy/filebrowser/files/Caddyfile.j2
@@ -4,7 +4,7 @@
 }
 :8443 {
   tls /data/cert.crt /data/cert.key
-
+  
   # Public endpoints (no authentication)
   handle /public/* {
     reverse_proxy filebrowser-app:8080 {

--- a/deb/openmediavault-filebrowser/srv/salt/omv/deploy/filebrowser/files/config.yaml.j2
+++ b/deb/openmediavault-filebrowser/srv/salt/omv/deploy/filebrowser/files/config.yaml.j2
@@ -4,7 +4,7 @@
 {%- set create_directory_permission = salt['pillar.get']('default:OMV_FILEBROWSER_APP_CREATEDIRECTORYPERMISSION', '775') -%}
 server:
   disableUpdateCheck: true
-  port: 80
+  port: 8080
   baseURL: "/"
   logging:
     - levels: "info|warning|error"

--- a/deb/openmediavault-filebrowser/srv/salt/omv/deploy/filebrowser/files/container-filebrowser-app.service.j2
+++ b/deb/openmediavault-filebrowser/srv/salt/omv/deploy/filebrowser/files/container-filebrowser-app.service.j2
@@ -20,7 +20,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/container-filebrowser-app.pid %t/container-filebrowser-app.ctr-id
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/container-filebrowser-app.pid --cidfile %t/container-filebrowser-app.ctr-id --cgroups=no-conmon --pod-id-file %t/pod-filebrowser.pod-id -d --replace --pull=never --name=filebrowser-app -v /var/lib/filebrowser/:/home/filebrowser/data/ -v "{{ sf_path }}":/srv/ {{ options }} {{ image }}
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/container-filebrowser-app.pid --cidfile %t/container-filebrowser-app.ctr-id --cgroups=no-conmon --pod-id-file %t/pod-filebrowser.pod-id -d --replace --pull=never --name=filebrowser-app -u {{ uid }}:{{ gid }} -v /var/lib/filebrowser/:/home/filebrowser/data/ -v "{{ sf_path }}":/srv/ {{ options }} {{ image }}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/container-filebrowser-app.ctr-id
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/container-filebrowser-app.ctr-id
 PIDFile=%t/container-filebrowser-app.pid

--- a/deb/openmediavault-filebrowser/srv/salt/omv/deploy/filebrowser/files/pod-filebrowser.service.j2
+++ b/deb/openmediavault-filebrowser/srv/salt/omv/deploy/filebrowser/files/pod-filebrowser.service.j2
@@ -12,7 +12,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/pod-filebrowser.pid %t/pod-filebrowser.pod-id
-ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/pod-filebrowser.pid --pod-id-file %t/pod-filebrowser.pod-id --name=filebrowser -p {{ config.port }}:{{ ssl_enabled | yesno('443,80') }} --replace
+ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/pod-filebrowser.pid --pod-id-file %t/pod-filebrowser.pod-id --name=filebrowser -p {{ config.port }}:{{ ssl_enabled | yesno('8443,8080') }} --replace
 ExecStart=/usr/bin/podman pod start --pod-id-file %t/pod-filebrowser.pod-id
 ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file %t/pod-filebrowser.pod-id
 ExecStopPost=/usr/bin/podman pod rm --ignore -f --pod-id-file %t/pod-filebrowser.pod-id


### PR DESCRIPTION
Issue described in the following forum post:
https://forum.openmediavault.org/index.php?thread/58753-omv8-file-browser-stopped-working/

Actions that fixed the issue:
Changed ports to prevent incompatibility
Added correct uid and gid so that the pod has the right privileges on monted volume

Signed-off-by: Jorge Frade <jamfrade@gmail.com>