### PR TITLE
Remove auth from config (fix admin pass reset)

### DIFF
--- a/deb/openmediavault-filebrowser/debian/changelog
+++ b/deb/openmediavault-filebrowser/debian/changelog
@@ -1,6 +1,6 @@
 openmediavault-filebrowser (8.0.5-1) stable; urgency=medium
 
-  *
+  * Issue #2198: Prevent admin password reset on container restart.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Thu, 07 May 2026 22:07:06 +0200
 

--- a/deb/openmediavault-filebrowser/debian/openmediavault-filebrowser.postinst
+++ b/deb/openmediavault-filebrowser/debian/openmediavault-filebrowser.postinst
@@ -88,6 +88,9 @@ case "$1" in
 		if dpkg --compare-versions "$2" lt-nl "8.0.4"; then
 			omv_module_set_dirty filebrowser
 		fi
+		if dpkg --compare-versions "$2" lt-nl "8.0.5"; then
+			omv_module_set_dirty filebrowser
+		fi
 	;;
 
 	abort-upgrade|abort-remove|abort-deconfigure)

--- a/deb/openmediavault-filebrowser/srv/salt/omv/deploy/filebrowser/files/config.yaml.j2
+++ b/deb/openmediavault-filebrowser/srv/salt/omv/deploy/filebrowser/files/config.yaml.j2
@@ -1,5 +1,3 @@
-{%- set admin_username = salt['pillar.get']('default:OMV_FILEBROWSER_APP_ADMIN_USERNAME', 'admin') -%}
-{%- set admin_password = salt['pillar.get']('default:OMV_FILEBROWSER_APP_ADMIN_PASSWORD', 'admin') -%}
 {%- set create_file_permission = salt['pillar.get']('default:OMV_FILEBROWSER_APP_CREATEFILEPERMISSION', '664') -%}
 {%- set create_directory_permission = salt['pillar.get']('default:OMV_FILEBROWSER_APP_CREATEDIRECTORYPERMISSION', '775') -%}
 server:
@@ -17,9 +15,6 @@ server:
   filesystem:
     createFilePermission: "{{ create_file_permission }}"
     createDirectoryPermission: "{{ create_directory_permission }}"
-auth:
-  adminUsername: {{ admin_username }}
-  adminPassword: {{ admin_password }}
 userDefaults:
   preview:
     image: true

--- a/deb/openmediavault-filebrowser/srv/salt/omv/deploy/filebrowser/files/config.yaml.j2
+++ b/deb/openmediavault-filebrowser/srv/salt/omv/deploy/filebrowser/files/config.yaml.j2
@@ -1,3 +1,4 @@
+{%- set admin_username = salt['pillar.get']('default:OMV_FILEBROWSER_APP_ADMIN_USERNAME', 'admin') -%}
 {%- set create_file_permission = salt['pillar.get']('default:OMV_FILEBROWSER_APP_CREATEFILEPERMISSION', '664') -%}
 {%- set create_directory_permission = salt['pillar.get']('default:OMV_FILEBROWSER_APP_CREATEDIRECTORYPERMISSION', '775') -%}
 server:
@@ -15,6 +16,8 @@ server:
   filesystem:
     createFilePermission: "{{ create_file_permission }}"
     createDirectoryPermission: "{{ create_directory_permission }}"
+auth:
+  adminUsername: {{ admin_username }}
 userDefaults:
   preview:
     image: true


### PR DESCRIPTION
Removed admin username and password configuration from config to prevent admin password reset on startup.

According documentation bellow if the admin password is set in the config file it is reset to the config value upon restart (even if changed by the user). https://filebrowserquantum.com/en/docs/configuration/authentication/password/#set-admin-password

Removed the auth part completely from the config file as it was redundant. Default user and pass are already admin:admin.

Signed-off-by: Jorge Frade jamfrade@gmail.com