### PR TITLE
Fix login notification cookie name encoding

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/unittests/php/test_openmediavault_functions.php
+++ b/deb/openmediavault/usr/share/openmediavault/unittests/php/test_openmediavault_functions.php
@@ -384,6 +384,15 @@ class test_openmediavault_functions extends \PHPUnit\Framework\TestCase {
 			"/srv/dev-disk-by-label-xx yy");
 	}
 
+	public function test_urlencode_cookie_name() {
+		$str = '$2y$10$OBTlQaTLcWfqXRoeceqdpeN5IWAoIKM.'.
+			'FUCab/36YhE5GaNzGs3Va';
+		$encoded = urlencode_cookie_name($str);
+		$cookieKey = str_replace(".", "_", $encoded);
+		$this->assertStringNotContainsString(".", $encoded);
+		$this->assertEquals($str, urldecode($cookieKey));
+	}
+
 	public function test_array_remove_key_exists() {
 		$d = ["a" => "xxx"];
 		$this->assertTrue(array_remove_key($d, "a"));

--- a/deb/openmediavault/usr/share/php/openmediavault/functions.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/functions.inc
@@ -998,6 +998,16 @@ function escape_percent($var) {
 }
 
 /**
+ * URL-encode a string so it can be used as a cookie name without being
+ * normalized by PHP's $_COOKIE handling.
+ * @param string $var The variable that will be encoded.
+ * @return string The encoded string.
+ */
+function urlencode_cookie_name($var): string {
+	return str_replace(".", "%2E", urlencode($var));
+}
+
+/**
  * Unescape a string. Various hexadecimal/octal characters will be replaced
  * with their ASCII representation, e.g. \x20 or \040 will be replaced by
  * a whitespace.

--- a/deb/openmediavault/var/www/openmediavault/rpc/session.inc
+++ b/deb/openmediavault/var/www/openmediavault/rpc/session.inc
@@ -151,7 +151,8 @@ class OMVRpcServiceSession extends \OMV\Rpc\ServiceAbstract {
 				// user name to meet RFC 2616.
 				$hashedUsername = password_hash($params['username'],
 					PASSWORD_DEFAULT);
-				$key = sprintf("%s-%s", $prefix, urlencode($hashedUsername));
+				$key = sprintf("%s-%s", $prefix,
+					urlencode_cookie_name($hashedUsername));
 				$value = array_rand_value(\OMV\Environment::get(
 					"OMV_DUNE_QUOTES"));
 				$expire = time() + 60 * 60 * 24 * 60;


### PR DESCRIPTION
# Fix login notification cookie names containing bcrypt dots

## Summary

- Add `urlencode_cookie_name()` to encode literal dots as `%2E`
- Use it when creating the web UI login notification marker cookie
- Add a focused PHPUnit test for the cookie-name encoding behavior

## Why

The login notification marker cookie name contains a URL-encoded bcrypt hash of the username. `urlencode()` does not encode `.` characters, but PHP normalizes dots in cookie names to underscores when populating `$_COOKIE`. If the bcrypt hash contains a dot, the next login sees a modified hash and `password_verify()` fails, causing another first-login notification email.

Encoding dots as `%2E` preserves the existing `urldecode()` verification flow while preventing PHP from altering the cookie key.

Fixes: https://github.com/openmediavault/openmediavault/issues/2196

Signed-off-by: Louis Bolin <st.jfisher@gmail.com>

## Testing

- `php -l deb/openmediavault/usr/share/php/openmediavault/functions.inc`
- `php -l deb/openmediavault/var/www/openmediavault/rpc/session.inc`
- `php -l deb/openmediavault/usr/share/openmediavault/unittests/php/test_openmediavault_functions.php`
- `phpunit --filter test_urlencode_cookie_name deb/openmediavault/usr/share/openmediavault/unittests/php/test_openmediavault_functions.php`
- Local PHP probe confirms existing dot-containing cookie names fail after PHP cookie parsing, while `%2E`-encoded names verify successfully

Note: Running the full `test_openmediavault_functions.php` file on Windows executes the new test successfully, but five pre-existing `build_path()` assertions fail because the test expectations are written for the Linux path separator.

- [x] References issue
- [x] Includes tests for new functionality or reproducer for bug
