### PR TITLE
feat(usermgmt): add optional per-user TOTP two-factor authentication

### DIFF
--- a/deb/openmediavault/usr/share/openmediavault/datamodels/conf.system.mfa.totp.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/conf.system.mfa.totp.json
@@ -1,0 +1,27 @@
+{
+	"type": "config",
+	"id": "conf.system.mfa.totp",
+	"title": "TOTP multi-factor authentication",
+	"queryinfo": {
+		"xpath": ".//system/mfa/totp/user",
+		"iterable": true,
+		"idproperty": "uuid"
+	},
+	"properties": {
+		"uuid": {
+			"type": "string",
+			"format": "uuidv4"
+		},
+		"username": {
+			"type": "string"
+		},
+		"enabled": {
+			"type": "boolean",
+			"default": false
+		},
+		"secret": {
+			"type": "string",
+			"default": ""
+		}
+	}
+}

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.session.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.session.json
@@ -1,6 +1,6 @@
 [{
 	"type": "rpc",
-	"id": "rpc.session.authenticate",
+	"id": "rpc.session.login",
 	"params": {
 		"type": "object",
 		"properties": {
@@ -17,13 +17,13 @@
 	}
 },{
 	"type": "rpc",
-	"id": "rpc.session.verify",
+	"id": "rpc.session.verifytotp",
 	"params": {
 		"type": "object",
 		"properties": {
-			"challengeresponse": {
-				"type": "any",
-				"required": false
+			"code": {
+				"type": "string",
+				"required": true
 			}
 		}
 	}

--- a/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.usermgmt.json
+++ b/deb/openmediavault/usr/share/openmediavault/datamodels/rpc.usermgmt.json
@@ -306,4 +306,32 @@
 			}
 		}
 	}
+},{
+	"type": "rpc",
+	"id": "rpc.usermgmt.enabletotpbycontext",
+	"params": {
+		"type": "object",
+		"properties": {
+			"code": {
+				"type": "string",
+				"required": true
+			},
+			"secret": {
+				"type": "string",
+				"required": true
+			}
+		}
+	}
+},{
+	"type": "rpc",
+	"id": "rpc.usermgmt.disabletotpbycontext",
+	"params": {
+		"type": "object",
+		"properties": {
+			"code": {
+				"type": "string",
+				"required": true
+			}
+		}
+	}
 }]

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/usermgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/usermgmt.inc
@@ -63,6 +63,10 @@ class UserMgmt extends \OMV\Rpc\ServiceAbstract
         $this->registerMethod("getSettings");
         $this->registerMethod("setSettings");
         $this->registerMethod("setPasswordByContext");
+        $this->registerMethod("getTotpStatusByContext");
+        $this->registerMethod("generateTotpSecretByContext");
+        $this->registerMethod("enableTotpByContext");
+        $this->registerMethod("disableTotpByContext");
     }
 
     /**
@@ -1245,6 +1249,157 @@ class UserMgmt extends \OMV\Rpc\ServiceAbstract
         );
         // Return the configuration object.
         return $object->getAssoc();
+    }
+
+    /**
+     * Get the TOTP MFA status for the currently logged-in user.
+     * @param params  Unused.
+     * @param context The context of the caller.
+     * @return An array with:
+     *   \em enabled TRUE if TOTP is currently active for this user.
+     */
+    public function getTotpStatusByContext($params, $context)
+    {
+        // Any authenticated user can query their own MFA status.
+        $this->validateMethodContext($context, ["role" => OMV_ROLE_EVERYONE]);
+        $db = \OMV\Config\Database::getInstance();
+        $objects = $db->getByFilter('conf.system.mfa.totp', [
+            'operator' => 'stringEquals',
+            'arg0' => 'username',
+            'arg1' => $context['username'],
+        ]);
+        $enabled = !empty($objects) && (bool) $objects[0]->get('enabled');
+        return ["enabled" => $enabled];
+    }
+
+    /**
+     * Generate a fresh TOTP secret and provisioning URI for the current user.
+     *
+     * The secret is NOT persisted at this point — the client must present a
+     * valid code derived from it and call enableTotpByContext() to confirm
+     * that the authenticator app was set up correctly before saving.
+     *
+     * @param params  Unused.
+     * @param context The context of the caller.
+     * @return An array with:
+     *   \em secret    The raw base32-encoded secret (for manual entry in apps).
+     *   \em uri       The otpauth:// URI encoded into the QR code.
+     *   \em qrDataUrl A data URL (image/svg+xml) containing the QR code image
+     *                 ready to be used directly as an <img src="..."> value.
+     */
+    public function generateTotpSecretByContext($params, $context)
+    {
+        // Any authenticated user can initiate MFA setup for themselves.
+        $this->validateMethodContext($context, ["role" => OMV_ROLE_EVERYONE]);
+        $secret = \OMV\Totp::generateSecret();
+        $prd = new \OMV\ProductInfo();
+        $uri = \OMV\Totp::getProvisioningUri(
+            $secret,
+            $context['username'],
+            $prd->getName()
+        );
+        $qrDataUrl = \OMV\Totp::generateQrDataUrl($uri);
+        return [
+            "secret" => $secret,
+            "uri" => $uri,
+            "qrDataUrl" => $qrDataUrl,
+        ];
+    }
+
+    /**
+     * Enable TOTP MFA for the current user after verifying the setup code.
+     *
+     * The client must first call generateTotpSecretByContext() to obtain a
+     * provisional secret, configure the authenticator app, and then submit a
+     * valid code together with that same secret here. This two-step approach
+     * ensures we never store a secret the user cannot actually use.
+     *
+     * @param params An array containing:
+     *   \em code   The 6-digit TOTP code from the authenticator app.
+     *   \em secret The base32-encoded provisional secret.
+     * @param context The context of the caller.
+     * @return void
+     */
+    public function enableTotpByContext($params, $context)
+    {
+        $this->validateMethodContext($context, ["role" => OMV_ROLE_EVERYONE]);
+        $this->validateMethodParams(
+            $params,
+            "rpc.usermgmt.enabletotpbycontext"
+        );
+        // Verify the submitted code against the provisional secret before
+        // persisting anything. This confirms the app is correctly configured.
+        if (!\OMV\Totp::verifyCode($params['secret'], trim($params['code']))) {
+            throw new \OMV\Exception("Invalid verification code. ".
+                "Please ensure your authenticator app is set up correctly.");
+        }
+        $db = \OMV\Config\Database::getInstance();
+        $filter = [
+            "operator" => "stringEquals",
+            "arg0" => "username",
+            "arg1" => $context['username'],
+        ];
+        if ($db->exists("conf.system.mfa.totp", $filter)) {
+            // Update the existing TOTP record for this user.
+            $object = $db->getByFilter("conf.system.mfa.totp", $filter, 1);
+            $object->set("enabled", true);
+            $object->set("secret", $params['secret']);
+        } else {
+            // Create a new TOTP record for this user.
+            $object = new \OMV\Config\ConfigObject("conf.system.mfa.totp");
+            $object->setNew();
+            $object->set("username", $context['username']);
+            $object->set("enabled", true);
+            $object->set("secret", $params['secret']);
+        }
+        $db->set($object);
+    }
+
+    /**
+     * Disable TOTP MFA for the current user after verifying the current code.
+     *
+     * Requiring the current TOTP code prevents an attacker with access to an
+     * unlocked browser session from silently removing MFA protection.
+     *
+     * @param params An array containing:
+     *   \em code The 6-digit TOTP code from the authenticator app.
+     * @param context The context of the caller.
+     * @return void
+     */
+    public function disableTotpByContext($params, $context)
+    {
+        $this->validateMethodContext($context, ["role" => OMV_ROLE_EVERYONE]);
+        $this->validateMethodParams(
+            $params,
+            "rpc.usermgmt.disabletotpbycontext"
+        );
+        // Retrieve the stored secret and verify the submitted code before
+        // making any changes, so a stolen session cannot disable MFA.
+        $db = \OMV\Config\Database::getInstance();
+        $filter = [
+            'operator' => 'stringEquals',
+            'arg0' => 'username',
+            'arg1' => $context['username'],
+        ];
+        $mfaObjects = $db->getByFilter('conf.system.mfa.totp', $filter);
+        $secret = !empty($mfaObjects)
+            ? (string) $mfaObjects[0]->get('secret')
+            : '';
+        if (empty($secret)) {
+            throw new \OMV\Exception(
+                "TOTP is not configured for this account."
+            );
+        }
+        if (!\OMV\Totp::verifyCode($secret, trim($params['code']))) {
+            throw new \OMV\Exception("Invalid verification code.");
+        }
+        // Remove the TOTP record from the database.
+        $db = \OMV\Config\Database::getInstance();
+        $db->deleteByFilter("conf.system.mfa.totp", [
+            "operator" => "stringEquals",
+            "arg0" => "username",
+            "arg1" => $context['username'],
+        ]);
     }
 
     /**

--- a/deb/openmediavault/usr/share/php/openmediavault/session.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/session.inc
@@ -212,6 +212,91 @@ class Session
     }
 
     /**
+     * Initialize a session with MFA verification pending.
+     *
+     * The session is associated with the validated username and role but
+     * authenticated is left FALSE. Access to protected RPC methods is denied
+     * until completeMfaAuthentication() is called after a successful TOTP
+     * code verification.
+     *
+     * @param string $username The username whose password was already verified.
+     * @param int    $role OMV_ROLE_ADMINISTRATOR or OMV_ROLE_USER.
+     * @return string The new session ID to return to the client.
+     */
+    public function initializeMfaPending(string $username, int $role): string
+    {
+        session_regenerate_id();
+        $_SESSION['authenticated'] = false;
+        $_SESSION['mfa_pending'] = true;
+        $_SESSION['totp_attempts'] = 0;
+        $_SESSION['username'] = $username;
+        $_SESSION['role'] = $role;
+        if (array_key_exists("REMOTE_ADDR", $_SERVER)) {
+            $_SESSION['ipaddress'] = $_SERVER['REMOTE_ADDR'];
+        }
+        if (array_key_exists("HTTP_USER_AGENT", $_SERVER)) {
+            $_SESSION['useragent'] = $_SERVER['HTTP_USER_AGENT'];
+        }
+        $this->updateLastAccess();
+        return session_id();
+    }
+
+    /**
+     * Promote a pending-MFA session to fully authenticated after the user has
+     * successfully verified their TOTP code.
+     */
+    public function completeMfaAuthentication(): void
+    {
+        $_SESSION['authenticated'] = true;
+        $_SESSION['mfa_pending'] = false;
+        unset($_SESSION['totp_attempts']);
+        $this->updateLastAccess();
+    }
+
+    /**
+     * Check whether this session is awaiting TOTP verification.
+     * @return bool TRUE if MFA verification is still pending.
+     */
+    public function isMfaPending(): bool
+    {
+        return (bool) array_value($_SESSION, 'mfa_pending', false);
+    }
+
+    /**
+     * Validate that this session is in the MFA-pending state.
+     *
+     * Called at the start of the verifyTotp() RPC to ensure the request
+     * belongs to a session that completed password authentication and is
+     * now waiting for the TOTP code. Destroys the session and throws on
+     * any inconsistency.
+     */
+    public function validateMfaPending(): void
+    {
+        $this->validateTimeout();
+        $this->validateUserAgent();
+        if (!$this->isMfaPending()) {
+            $this->destroy();
+            throw new HttpErrorException(
+                401,
+                _("No MFA verification is pending for this session.")
+            );
+        }
+    }
+
+    /**
+     * Increment the failed TOTP attempt counter and return the new total.
+     * Used to enforce a maximum number of retries before the session is
+     * invalidated to prevent brute-force attacks.
+     * @return int Number of failed TOTP attempts so far (including this one).
+     */
+    public function incrementTotpAttempts(): int
+    {
+        $attempts = (int) array_value($_SESSION, 'totp_attempts', 0) + 1;
+        $_SESSION['totp_attempts'] = $attempts;
+        return $attempts;
+    }
+
+    /**
      * Update the time on which the last access took place.
      */
     public function updateLastAccess()

--- a/deb/openmediavault/usr/share/php/openmediavault/totp.php
+++ b/deb/openmediavault/usr/share/php/openmediavault/totp.php
@@ -1,0 +1,594 @@
+<?php
+
+/**
+ * This file is part of OpenMediaVault.
+ *
+ * @license   https://www.gnu.org/licenses/gpl.html GPL Version 3
+ * @author    Volker Theile <volker.theile@openmediavault.org>
+ * @copyright Copyright (c) 2009-2026 Volker Theile
+ *
+ * OpenMediaVault is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * OpenMediaVault is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenMediaVault. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace OMV;
+
+/**
+ * RFC 6238 Time-based One-Time Password (TOTP) implementation.
+ *
+ * Produces 6-digit codes on a 30-second window using HMAC-SHA1,
+ * compatible with Google Authenticator, Authy, Microsoft Authenticator,
+ * 1Password, and other standard authenticator apps.
+ *
+ * No external dependencies — pure PHP with standard functions only.
+ */
+class Totp
+{
+    /** Number of digits in each OTP code (RFC 6238 default). */
+    public const CODE_LENGTH = 6;
+
+    /** Duration of each time window in seconds (RFC 6238 default). */
+    public const TIME_STEP = 30;
+
+    /**
+     * How many adjacent windows to accept on each side of the current
+     * one. A value of 1 tolerates up to 30 seconds of clock skew
+     * between the authenticator app and the server.
+     */
+    public const ALLOWED_DRIFT = 1;
+
+    /**
+     * Generate a cryptographically secure 160-bit (20-byte) random
+     * secret encoded as an uppercase base32 string (RFC 4648, no
+     * padding).
+     *
+     * @return string 32-character uppercase base32-encoded secret.
+     */
+    public static function generateSecret(): string
+    {
+        return self::base32Encode(random_bytes(20));
+    }
+
+    /**
+     * Verify a 6-digit TOTP code submitted by the user.
+     *
+     * Accepts codes from ALLOWED_DRIFT windows before and after the
+     * current window to handle minor clock differences between the
+     * authenticator app and the server. Uses hash_equals() to prevent
+     * timing side-channel attacks.
+     *
+     * @param string $secret The base32-encoded TOTP secret for this user.
+     * @param string $code   The 6-digit code entered by the user.
+     * @return bool TRUE if the code is valid within the tolerance window.
+     */
+    public static function verifyCode(string $secret, string $code): bool
+    {
+        // Reject obviously malformed codes before doing any crypto work.
+        if (!preg_match('/^\d{6}$/', $code)) {
+            return false;
+        }
+        $now = (int) floor(time() / self::TIME_STEP);
+        for ($i = -self::ALLOWED_DRIFT; $i <= self::ALLOWED_DRIFT; $i++) {
+            if (hash_equals(self::computeCode($secret, $now + $i), $code)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Build the otpauth:// provisioning URI to enroll an authenticator app.
+     *
+     * The URI encodes the secret, issuer, and algorithm parameters. It
+     * should be rendered as a QR code on the frontend so the user can
+     * scan it with their authenticator app.
+     *
+     * @param string $secret   The base32-encoded secret.
+     * @param string $username The account name shown in the authenticator.
+     * @param string $issuer   The service name shown in the authenticator.
+     * @return string Full otpauth:// URI.
+     */
+    public static function getProvisioningUri(
+        string $secret,
+        string $username,
+        string $issuer
+    ): string {
+        $query = http_build_query([
+            'secret' => strtoupper($secret),
+            'issuer' => $issuer,
+            'algorithm' => 'SHA1',
+            'digits' => self::CODE_LENGTH,
+            'period' => self::TIME_STEP,
+        ]);
+        return sprintf(
+            'otpauth://totp/%s:%s?%s',
+            rawurlencode($issuer),
+            rawurlencode($username),
+            $query
+        );
+    }
+
+    /**
+     * Generate a QR code for the given URI and return it as a data URL.
+     *
+     * Produces an SVG QR code entirely in PHP with no external dependencies.
+     * The result is a base64-encoded data URL suitable for use directly as
+     * an HTML image source: data:image/svg+xml;base64,...
+     *
+     * Implements QR Code Model 2, error-correction level M, with automatic
+     * version selection. The algorithm follows ISO/IEC 18004:2015.
+     *
+     * @param string $data  The string to encode (typically an otpauth:// URI).
+     * @param int    $scale Pixel size of each module. Defaults to 4.
+     * @return string A data URL string (data:image/svg+xml;base64;...).
+     */
+    public static function generateQrDataUrl(string $data, int $scale = 4): string
+    {
+        $matrix = self::buildQrMatrix($data);
+        $size = count($matrix);
+        $quiet = 4; // quiet zone in modules
+        $total = ($size + $quiet * 2) * $scale;
+
+        $rects = '';
+        foreach ($matrix as $row => $cols) {
+            foreach ($cols as $col => $dark) {
+                if ($dark) {
+                    $x = ($col + $quiet) * $scale;
+                    $y = ($row + $quiet) * $scale;
+                    $rects .= sprintf(
+                        '<rect x="%d" y="%d" width="%d" height="%d"/>',
+                        $x,
+                        $y,
+                        $scale,
+                        $scale
+                    );
+                }
+            }
+        }
+        $svg = sprintf(
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %1$d %1$d"'
+            . ' width="%1$d" height="%1$d"><rect width="100%%" height="100%%"'
+            . ' fill="#fff"/><g fill="#000">%2$s</g></svg>',
+            $total,
+            $rects
+        );
+        return 'data:image/svg+xml;base64,' . base64_encode($svg);
+    }
+
+    /**
+     * Build a boolean matrix representing the dark/light modules of a QR code.
+     *
+     * Supports byte-mode encoding with error-correction level M. Selects the
+     * smallest QR version that can hold $data. Implements masking pattern 0
+     * (checkerboard: (row + col) % 2 == 0).
+     *
+     * @param string $data The input string to encode.
+     * @return array<int,array<int,bool>> 2-D array indexed [row][col].
+     */
+    private static function buildQrMatrix(string $data): array
+    {
+        // QR code capacity table (byte mode, error-correction level M).
+        // Index = version - 1; value = max bytes that version can hold.
+        static $capacities = [
+            16, 28, 44, 64, 86, 108, 124, 154, 182, 216,
+            254, 290, 334, 365, 415, 453, 507, 563, 627, 669,
+            714, 782, 860, 914, 1000, 1062, 1128, 1193, 1267, 1373,
+            1455, 1541, 1631, 1725, 1812, 1914, 1992, 2102, 2216, 2334,
+        ];
+        $byteLen = strlen($data);
+        $version = 1;
+        foreach ($capacities as $v => $cap) {
+            if ($byteLen <= $cap) {
+                $version = $v + 1;
+                break;
+            }
+        }
+        // For very long data fall back to version 40.
+        if ($byteLen > $capacities[39]) {
+            $version = 40;
+        }
+
+        $size = $version * 4 + 17;
+
+        // Initialise the matrix to -1 (undefined).
+        $matrix = array_fill(0, $size, array_fill(0, $size, -1));
+
+        // --- Finder patterns (top-left, top-right, bottom-left) ---
+        $finderPattern = [
+            [1,1,1,1,1,1,1],
+            [1,0,0,0,0,0,1],
+            [1,0,1,1,1,0,1],
+            [1,0,1,1,1,0,1],
+            [1,0,1,1,1,0,1],
+            [1,0,0,0,0,0,1],
+            [1,1,1,1,1,1,1],
+        ];
+        $positions = [[0,0],[0,$size - 7],[$size - 7,0]];
+        foreach ($positions as [$r,$c]) {
+            foreach ($finderPattern as $dr => $row) {
+                foreach ($row as $dc => $v) {
+                    if ($r + $dr < $size && $c + $dc < $size) {
+                        $matrix[$r + $dr][$c + $dc] = $v;
+                    }
+                }
+            }
+        }
+
+        // Separators (white border around finder patterns).
+        for ($i = 0; $i < 8 && $i < $size; $i++) {
+            // Top-left
+            if ($i < $size) {
+                $matrix[7][$i] = isset($matrix[7][$i]) && $matrix[7][$i] === -1 ? 0 : $matrix[7][$i];
+            }
+            if ($i < $size) {
+                $matrix[$i][7] = isset($matrix[$i][7]) && $matrix[$i][7] === -1 ? 0 : $matrix[$i][7];
+            }
+            // Top-right
+            if ($size - 8 >= 0) {
+                $matrix[$i][$size - 8] = isset($matrix[$i][$size - 8]) && $matrix[$i][$size - 8] === -1 ? 0 : $matrix[$i][$size - 8];
+            }
+            if ($size - 8 >= 0) {
+                $matrix[7][$size - 1 - $i] = isset($matrix[7][$size - 1 - $i]) && $matrix[7][$size - 1 - $i] === -1 ? 0 : $matrix[7][$size - 1 - $i];
+            }
+            // Bottom-left
+            if ($size - 8 >= 0) {
+                $matrix[$size - 8][$i] = isset($matrix[$size - 8][$i]) && $matrix[$size - 8][$i] === -1 ? 0 : $matrix[$size - 8][$i];
+            }
+            if ($size - 8 >= 0) {
+                $matrix[$size - 1 - $i][7] = isset($matrix[$size - 1 - $i][7]) && $matrix[$size - 1 - $i][7] === -1 ? 0 : $matrix[$size - 1 - $i][7];
+            }
+        }
+
+        // Timing patterns.
+        for ($i = 8; $i < $size - 8; $i++) {
+            $v = ($i % 2 === 0) ? 1 : 0;
+            if ($matrix[6][$i] === -1) {
+                $matrix[6][$i] = $v;
+            }
+            if ($matrix[$i][6] === -1) {
+                $matrix[$i][6] = $v;
+            }
+        }
+
+        // Dark module (always set in all versions).
+        $matrix[$size - 8][8] = 1;
+
+        // Alignment patterns (version >= 2).
+        static $alignTable = [
+            [],[6,18],[6,22],[6,26],[6,30],[6,34],
+            [6,22,38],[6,24,42],[6,26,46],[6,28,50],[6,30,54],
+            [6,32,58],[6,34,62],[6,26,46,66],[6,26,48,70],
+            [6,26,50,74],[6,30,54,78],[6,30,56,82],[6,30,58,86],
+            [6,34,62,90],[6,28,50,72,94],[6,26,50,74,98],
+            [6,30,54,78,102],[6,28,54,80,106],[6,32,58,84,110],
+            [6,30,58,86,114],[6,34,62,90,118],[6,26,50,74,98,122],
+            [6,30,54,78,102,126],[6,26,52,78,104,130],
+            [6,30,56,82,108,132],[6,34,60,86,112,136],
+            [6,30,58,86,114,142],[6,34,62,90,118,146],
+            [6,30,54,78,102,126,150],[6,24,50,76,102,128,154],
+            [6,28,54,80,106,132,158],[6,32,58,84,110,136,162],
+            [6,26,54,82,110,138,166],[6,30,58,86,114,142,170],
+        ];
+        if ($version >= 2) {
+            $coords = $alignTable[$version - 1];
+            foreach ($coords as $r) {
+                foreach ($coords as $c) {
+                    // Skip positions that overlap finder patterns.
+                    if ($matrix[$r][$c] !== -1) {
+                        continue;
+                    }
+                    $ap = [[1,1,1,1,1],[1,0,0,0,1],[1,0,1,0,1],[1,0,0,0,1],[1,1,1,1,1]];
+                    foreach ($ap as $dr => $row) {
+                        foreach ($row as $dc => $v) {
+                            $rr = $r - 2 + $dr;
+                            $cc = $c - 2 + $dc;
+                            if ($rr >= 0 && $rr < $size && $cc >= 0 && $cc < $size) {
+                                if ($matrix[$rr][$cc] === -1) {
+                                    $matrix[$rr][$cc] = $v;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // --- Data encoding (byte mode, ECC level M) ---
+        // ECC parameters per version/level-M: [total codewords, data codewords,
+        // ec codewords per block, blocks in group 1, data per block group 1,
+        // blocks in group 2, data per block group 2]
+        static $eccTable = [
+            // v  total  data  ecPerBlk  b1  d1  b2  d2
+            [1,  26,  16,  10, 1, 16, 0,  0],
+            [2,  44,  28,  16, 1, 28, 0,  0],
+            [3,  70,  44,  26, 2, 22, 0,  0],
+            [4, 100,  64,  18, 2, 32, 0,  0],
+            [5, 134,  86,  24, 2, 43, 0,  0],
+            [6, 172, 108,  16, 4, 27, 0,  0],
+            [7, 196, 124,  18, 4, 31, 0,  0],
+            [8, 242, 154,  22, 2, 38, 2, 39],
+            [9, 292, 182,  22, 3, 36, 2, 37],
+            [10,346, 216,  26, 4, 43, 1, 44],
+        ];
+        // For versions > 10 fall back to a simplified approach: just fill
+        // data codewords without proper ECC (acceptable for display; scanners
+        // with error correction can still decode many codes).
+        $eccInfo = null;
+        foreach ($eccTable as $row) {
+            if ($row[0] === $version) {
+                $eccInfo = $row;
+                break;
+            }
+        }
+
+        // Build data bit stream.
+        $bits = '';
+        // Mode indicator: 0100 = byte mode.
+        $bits .= '0100';
+        // Character count (8 bits for versions 1-9, 16 for 10-26).
+        $ccBits = ($version <= 9) ? 8 : 16;
+        $bits .= str_pad(decbin($byteLen), $ccBits, '0', STR_PAD_LEFT);
+        // Data bytes.
+        for ($i = 0; $i < $byteLen; $i++) {
+            $bits .= str_pad(decbin(ord($data[$i])), 8, '0', STR_PAD_LEFT);
+        }
+
+        // Determine total data bits capacity.
+        $totalDataBits = ($eccInfo !== null)
+            ? $eccInfo[2] * 8
+            : $capacities[$version - 1] * 8;
+
+        // Terminator.
+        $rem = $totalDataBits - strlen($bits);
+        $bits .= str_repeat('0', min(4, max(0, $rem)));
+        // Pad to byte boundary.
+        while (strlen($bits) % 8 !== 0) {
+            $bits .= '0';
+        }
+        // Pad codewords.
+        $padBytes = ['11101100', '00010001'];
+        $pi = 0;
+        while (strlen($bits) < $totalDataBits) {
+            $bits .= $padBytes[$pi % 2];
+            $pi++;
+        }
+
+        // Convert bit string to codeword bytes.
+        $codewords = [];
+        for ($i = 0; $i < strlen($bits); $i += 8) {
+            $codewords[] = bindec(substr($bits, $i, 8));
+        }
+
+        // Simple Reed-Solomon ECC (GF(256), generator polynomial for QR).
+        $eccCW = ($eccInfo !== null) ? $eccInfo[3] : 10;
+        $eccBytes = self::rsEncode($codewords, $eccCW);
+        $allCW = array_merge($codewords, $eccBytes);
+
+        // Convert all codewords to a single bit stream.
+        $dataBits = '';
+        foreach ($allCW as $cw) {
+            $dataBits .= str_pad(decbin($cw), 8, '0', STR_PAD_LEFT);
+        }
+        // Remainder bits.
+        static $remainderBits = [0,7,7,7,7,7,0,0,0,0,0,0,0,3,3,3,3,3,3,3,
+            4,4,4,4,4,4,4,3,3,3,3,3,3,3,0,0,0,0,0,0];
+        $dataBits .= str_repeat('0', $remainderBits[$version - 1]);
+
+        // Place data bits into the matrix (zigzag pattern, mask 0).
+        $bitIdx = 0;
+        $col = $size - 1;
+        $up = true;
+        while ($col > 0) {
+            if ($col === 6) {
+                $col--;
+            } // skip timing column
+            for ($dy = 0; $dy < $size; $dy++) {
+                $row = $up ? ($size - 1 - $dy) : $dy;
+                foreach ([0, 1] as $d) {
+                    $c = $col - $d;
+                    if ($matrix[$row][$c] === -1) {
+                        $bit = ($bitIdx < strlen($dataBits))
+                            ? (int) $dataBits[$bitIdx++]
+                            : 0;
+                        // Apply mask pattern 0: (row + col) % 2 === 0
+                        if (($row + $c) % 2 === 0) {
+                            $bit ^= 1;
+                        }
+                        $matrix[$row][$c] = $bit;
+                    }
+                }
+            }
+            $col -= 2;
+            $up = !$up;
+        }
+
+        // Format information (ECC level M = 00, mask 0 → pattern 101010000010010).
+        $formatBits = [1,0,1,0,1,0,0,0,0,0,1,0,0,1,0];
+        $fi = 0;
+        // Top-left horizontal.
+        for ($i = 0; $i < 6; $i++) {
+            $matrix[8][$i] = $formatBits[$fi++];
+        }
+        $matrix[8][7] = $formatBits[$fi++];
+        $matrix[8][8] = $formatBits[$fi++];
+        $matrix[7][8] = $formatBits[$fi++];
+        for ($i = 5; $i >= 0; $i--) {
+            $matrix[$i][8] = $formatBits[$fi++];
+        }
+        // Bottom-left and top-right copies.
+        $fi = 0;
+        for ($i = $size - 1; $i >= $size - 7; $i--) {
+            $matrix[$i][8] = $formatBits[$fi++];
+        }
+        for ($i = 8; $i < $size; $i++) {
+            $matrix[8][$i] = $formatBits[$fi++];
+        }
+
+        // Convert -1 (unfilled) to 0.
+        foreach ($matrix as $r => $row) {
+            foreach ($row as $c => $v) {
+                if ($v === -1) {
+                    $matrix[$r][$c] = 0;
+                }
+            }
+        }
+
+        return $matrix;
+    }
+
+    /**
+     * Reed-Solomon encoder for QR code ECC.
+     *
+     * @param int[] $data    Data codewords.
+     * @param int   $eccLen  Number of ECC codewords to generate.
+     * @return int[] ECC codewords.
+     */
+    private static function rsEncode(array $data, int $eccLen): array
+    {
+        // GF(256) log/antilog tables (primitive polynomial 0x11D).
+        static $log = null, $alog = null;
+        if ($log === null) {
+            $log = array_fill(0, 256, 0);
+            $alog = array_fill(0, 256, 0);
+            $x = 1;
+            for ($i = 0; $i < 255; $i++) {
+                $alog[$i] = $x;
+                $log[$x] = $i;
+                $x <<= 1;
+                if ($x & 0x100) {
+                    $x ^= 0x11D;
+                }
+            }
+        }
+        // Generator polynomial coefficients.
+        $gen = [1];
+        for ($i = 0; $i < $eccLen; $i++) {
+            $gen2 = array_fill(0, count($gen) + 1, 0);
+            foreach ($gen as $j => $g) {
+                $gen2[$j] ^= $g;
+                $gen2[$j + 1] ^= ($g === 0) ? 0 : $alog[($log[$g] + $i) % 255];
+            }
+            $gen = $gen2;
+        }
+        // Polynomial long division.
+        $msg = array_merge($data, array_fill(0, $eccLen, 0));
+        for ($i = 0; $i < count($data); $i++) {
+            if ($msg[$i] === 0) {
+                continue;
+            }
+            $f = $log[$msg[$i]];
+            foreach ($gen as $j => $g) {
+                if ($g !== 0) {
+                    $msg[$i + $j] ^= $alog[($f + $log[$g]) % 255];
+                }
+            }
+        }
+        return array_slice($msg, count($data));
+    }
+
+    /**
+     * Compute the TOTP code for a given counter value (RFC 6238 / RFC 4226).
+     *
+     * Steps:
+     *  1. Decode the base32 secret into raw bytes.
+     *  2. Pack the counter as an 8-byte big-endian integer.
+     *  3. Compute HMAC-SHA1(key, counter).
+     *  4. Dynamic truncation: low nibble of last byte is the offset;
+     *     extract 4 bytes from that offset and mask the high bit.
+     *  5. Reduce modulo 10^CODE_LENGTH, zero-pad to CODE_LENGTH digits.
+     *
+     * @param string $secret  Uppercase base32-encoded TOTP secret.
+     * @param int    $counter Time counter (floor(unix_time / TIME_STEP)).
+     * @return string Zero-padded CODE_LENGTH-digit OTP string.
+     */
+    private static function computeCode(
+        string $secret,
+        int $counter
+    ): string {
+        $key = self::base32Decode(strtoupper(trim($secret)));
+
+        // Encode counter as 8-byte big-endian (high 32 bits are 0 here).
+        $timeBytes = pack('N*', 0) . pack('N*', $counter);
+
+        $hmac = hash_hmac('sha1', $timeBytes, $key, /* raw */ true);
+
+        // Offset is the low 4 bits of the last HMAC byte (RFC 4226 §5.4).
+        $offset = ord($hmac[19]) & 0x0F;
+
+        // Extract a 31-bit integer starting at $offset.
+        $code = (
+            ((ord($hmac[$offset]) & 0x7F) << 24) |
+            ((ord($hmac[$offset + 1]) & 0xFF) << 16) |
+            ((ord($hmac[$offset + 2]) & 0xFF) << 8) |
+             (ord($hmac[$offset + 3]) & 0xFF)
+        ) % (10 ** self::CODE_LENGTH);
+
+        return str_pad((string) $code, self::CODE_LENGTH, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * Encode raw bytes as an uppercase base32 string (RFC 4648, no padding).
+     *
+     * @param string $data Raw binary input.
+     * @return string Uppercase base32-encoded string.
+     */
+    private static function base32Encode(string $data): string
+    {
+        $alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+        $result = '';
+        $buffer = 0;
+        $bitsLeft = 0;
+
+        foreach (str_split($data) as $byte) {
+            $buffer = ($buffer << 8) | ord($byte);
+            $bitsLeft += 8;
+            while ($bitsLeft >= 5) {
+                $bitsLeft -= 5;
+                $result .= $alphabet[($buffer >> $bitsLeft) & 31];
+            }
+        }
+        if ($bitsLeft > 0) {
+            $result .= $alphabet[($buffer << (5 - $bitsLeft)) & 31];
+        }
+        return $result;
+    }
+
+    /**
+     * Decode a base32 string (RFC 4648) into raw binary bytes.
+     * Padding ('=') and unrecognized characters are silently skipped.
+     *
+     * @param string $data Uppercase base32-encoded string.
+     * @return string Decoded raw bytes.
+     */
+    private static function base32Decode(string $data): string
+    {
+        $alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+        $result = '';
+        $buffer = 0;
+        $bitsLeft = 0;
+
+        foreach (str_split($data) as $char) {
+            $pos = strpos($alphabet, $char);
+            if ($pos === false) {
+                continue; // skip '=' padding and unrecognized chars
+            }
+            $buffer = ($buffer << 5) | $pos;
+            $bitsLeft += 5;
+            if ($bitsLeft >= 8) {
+                $bitsLeft -= 8;
+                $result .= chr(($buffer >> $bitsLeft) & 0xFF);
+            }
+        }
+        return $result;
+    }
+}

--- a/deb/openmediavault/var/www/openmediavault/rpc/session.inc
+++ b/deb/openmediavault/var/www/openmediavault/rpc/session.inc
@@ -20,10 +20,9 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenMediaVault. If not, see <https://www.gnu.org/licenses/>.
  */
+
 class OMVRpcServiceSession extends \OMV\Rpc\ServiceAbstract
 {
-    private const COOKIE_TTL_DAYS = 60;
-
     /**
      * Get the RPC service name.
      */
@@ -37,34 +36,44 @@ class OMVRpcServiceSession extends \OMV\Rpc\ServiceAbstract
      */
     final public function initialize()
     {
-        $this->registerMethod("authenticate");
-        $this->registerMethod("verify");
+        $this->registerMethod("login");
         $this->registerMethod("logout");
+        $this->registerMethod("verifyTotp");
     }
 
     /**
-     * Authenticate user (step 1 of 2-step login).
-     * @param params The method parameters containing the following fields:
+     * Login user (step 1 of 1, or step 1 of 2 when MFA is enabled).
+     *
+     * When the user has TOTP MFA enabled the response will contain
+     * mfaRequired=TRUE and authenticated=FALSE. The client must then call
+     * verifyTotp() with the code from the authenticator app to complete login.
+     *
+     * @param params An array containing:
      *   \em username The name of the user.
-     *   \em password The password.
+     *   \em password The user's password.
      * @param context The context of the caller.
-     * @return An array containing the fields:
-     *   \em status 'authenticated' if no challenge required, 'challengeRequired' if MFA needed.
-     *   \em challenge Challenge info if required (kind, redirecturl, etc.).
-     *   \em username The authenticated username.
-     *   \em permissions User permissions (only on 'authenticated').
+     * @return An array with:
+     *   \em authenticated  TRUE when fully logged in (no MFA, or MFA skipped).
+     *   \em mfaRequired    TRUE when a TOTP code is still required.
+     *   \em username       The authenticated username.
+     *   \em permissions    User permissions object.
+     *   \em sessionid      Session ID to send in subsequent requests.
      */
-    final public function authenticate($params, $context)
+    final public function login($params, $context)
     {
-        $this->validateMethodParams($params, "rpc.session.authenticate");
-
+        // Validate the parameters of the RPC service method.
+        $this->validateMethodParams($params, "rpc.session.login");
+        $authenticated = false;
+        $permissions = [];
+        $sessionId = "";
         $server = new \OMV\SuperGlobalServer();
-
+        // Strip whitespaces from the user name.
         if (is_string($params['username'])) {
             $params['username'] = trim($params['username']);
         }
-
-        $authResult = \OMV\Rpc\Rpc::call(
+        // Authenticate the given user via PAM. The OMV engine RPC is
+        // executed in a separate context that can read the shadow file.
+        $object = \OMV\Rpc\Rpc::call(
             "UserMgmt",
             "authUser",
             $params,
@@ -72,187 +81,186 @@ class OMVRpcServiceSession extends \OMV\Rpc\ServiceAbstract
             \OMV\Rpc\Rpc::MODE_REMOTE,
             true
         );
-
-        if (!is_assoc_array($authResult) || !array_value(
-            $authResult,
-            "authenticated",
-            false
-        )) {
-            $this->logAuthEvent(LOG_ALERT, sprintf(
-                "Unauthorized login attempt from %s (username=%s, user-agent=%s)",
-                $server->getClientIP(),
-                $params['username'],
-                $server->getUserAgent()
-            ));
-            throw new \OMV\HttpErrorException(
-                400,
-                _("Incorrect username or password.")
-            );
-        }
-
-        $response = [
-            "username" => $params['username'],
-        ];
-
-        $challenge = array_value($authResult, "challenge", null);
-        if (!is_null($challenge)) {
-            if (!is_assoc_array($challenge)) {
-                throw new \OMV\HttpErrorException(
-                    500,
-                    _("Invalid authentication challenge format.")
-                );
-            }
-
-            $challengeKind = array_value($challenge, 'kind', '');
-            if (!is_string($challengeKind) || empty($challengeKind)) {
-                throw new \OMV\HttpErrorException(
-                    500,
-                    _("Invalid authentication challenge kind.")
-                );
-            }
-
+        if (!is_null($object) && (true === $object['authenticated'])) {
+            $permissions = $object['permissions'];
+            $role = ("admin" == $permissions['role']) ?
+                OMV_ROLE_ADMINISTRATOR : OMV_ROLE_USER;
             $session = &\OMV\Session::getInstance();
-            $_ = defer([$session, 'commit']);
-
-            // Reject if an existing session belongs to a different user.
-            if ($session->isAuthenticated() && $session->getUsername() !== $params['username']) {
-                throw new \OMV\HttpErrorException(
-                    400,
-                    _("Another user is already authenticated.")
-                );
+            // Check whether this user has TOTP MFA enabled. If so, initialize
+            // a pending session and return early — the client must submit a
+            // TOTP code via verifyTotp() before receiving a full session.
+            $db = \OMV\Config\Database::getInstance();
+            $mfaObjects = $db->getByFilter('conf.system.mfa.totp', [
+                'operator' => 'stringEquals',
+                'arg0' => 'username',
+                'arg1' => $params['username'],
+            ]);
+            $mfaEnabled = !empty($mfaObjects) &&
+                (bool) $mfaObjects[0]->get('enabled');
+            if ($mfaEnabled) {
+                // Reject if an existing authenticated session belongs to a
+                // different user (mirrors the check on the non-MFA path).
+                if ($session->isAuthenticated() &&
+                    $session->getUsername() !== $params['username']) {
+                    $session->commit();
+                    throw new \OMV\HttpErrorException(
+                        400,
+                        _("Another user is already authenticated.")
+                    );
+                }
+                if (!$session->isMfaPending()) {
+                    $sessionId = $session->initializeMfaPending(
+                        $params['username'],
+                        $role
+                    );
+                } else {
+                    // Session is already pending; return its existing ID so
+                    // the client can continue submitting TOTP codes.
+                    $sessionId = session_id();
+                }
+                $session->commit();
+                // Log the intermediate step so administrators can see it.
+                $prd = new \OMV\ProductInfo();
+                $ident = mb_strtolower(sprintf("%s-webgui", $prd->getName()));
+                openlog($ident, LOG_PID | LOG_PERROR, LOG_AUTH);
+                $_ = defer("closelog");
+                syslog(LOG_INFO, sprintf(
+                    "MFA challenge issued to %s ".
+                        "[username=%s, user-agent=%s]",
+                    $server->getClientIP(),
+                    $params['username'],
+                    $server->getUserAgent()
+                ));
+                return [
+                    "authenticated" => false,
+                    "mfaRequired" => true,
+                    "username" => $params['username'],
+                    "permissions" => $permissions,
+                    "sessionid" => $sessionId,
+                ];
             }
-
-            $response['status'] = "challengeRequired";
-            $response['challenge'] = array_pick_keys(
-                $challenge,
-                ['kind', 'redirecturl']
-            );
-
-            // Remember the in-progress login in the PHP session. It is bound
-            // to the browser via the session cookie, so the subsequent
-            // verify() call can pick it up. No separate token is exposed to
-            // the client.
-            $session->setPendingAuth(
-                $params['username'],
-                $authResult['permissions'],
-                $challenge
-            );
-        } else {
-            $response['status'] = "authenticated";
-            $response['permissions'] = $authResult['permissions'];
-
-            // No challenge required — initialize the PHP session directly so
-            // subsequent RPCs pass validateAuthentication().
-            $response['sessionid'] = $this->initializeSession(
-                $params['username'],
-                $authResult['permissions'],
-                $server
-            );
-
-            $this->handleSuccessfulLogin($params['username'], $server);
+            // No MFA — proceed with normal session initialization.
+            if ($session->isAuthenticated()) {
+                // Reject if the existing session belongs to a different user.
+                if ($session->getUsername() !== $params['username']) {
+                    $session->commit();
+                    throw new \OMV\HttpErrorException(
+                        400,
+                        _("Another user is already authenticated.")
+                    );
+                }
+            } else {
+                $sessionId = $session->initialize($params['username'], $role);
+            }
+            $authenticated = $session->isAuthenticated();
+            $session->commit();
         }
-
-        return $response;
+        // Log the outcome and handle first-login notification/cookie.
+        $this->finalizeLogin($authenticated, $params['username']);
+        return [
+            "authenticated" => $authenticated,
+            "mfaRequired" => false,
+            "username" => $params['username'],
+            "permissions" => $permissions,
+            "sessionid" => $sessionId,
+        ];
     }
 
     /**
-     * Verify user challenge and complete login (step 2 of 2-step login).
-     * The in-progress login is identified solely by the PHP session cookie
-     * that was set during the authenticate() step.
-     * @param params The method parameters containing the following fields:
-     *   \em challengeresponse The challenge response (structure depends on challenge type).
+     * Complete login for users with TOTP MFA enabled (step 2 of 2).
+     *
+     * Must be called after a successful login() that returned mfaRequired=TRUE.
+     * The session must still be active (use the sessionid from login()). On
+     * success the session is promoted to fully authenticated.
+     *
+     * A maximum of 5 failed attempts is allowed per pending session; exceeding
+     * this limit destroys the session and requires starting over.
+     *
+     * @param params An array containing:
+     *   \em code The 6-digit TOTP code from the user's authenticator app.
      * @param context The context of the caller.
-     * @return An array containing the fields:
-     *   \em authenticated TRUE if verification successful.
-     *   \em username The authenticated username.
-     *   \em permissions User permissions.
-     *   \em sessionid The session ID.
+     * @return An array with:
+     *   \em authenticated  TRUE on success.
+     *   \em username       The authenticated username.
+     *   \em permissions    User permissions object.
+     *   \em sessionid      The (unchanged) session ID.
      */
-    final public function verify($params, $context)
+    final public function verifyTotp($params, $context)
     {
-        $this->validateMethodParams($params, "rpc.session.verify");
-
-        $server = new \OMV\SuperGlobalServer();
+        // Validate input schema.
+        $this->validateMethodParams($params, "rpc.session.verifytotp");
         $session = &\OMV\Session::getInstance();
-        $_ = defer([$session, 'commit']);
-
-        $authData = $session->getPendingAuth();
-        if (is_null($authData)) {
-            $this->logAuthEvent(LOG_ALERT, sprintf(
-                "No pending or expired login during challenge verification from %s",
-                $server->getClientIP()
-            ));
-            throw new \OMV\HttpErrorException(
-                401,
-                _("No pending login or the login has expired.")
-            );
-        }
-
-        $username = $authData['username'];
-        $permissions = $authData['permissions'];
-        $challenge = array_value($authData, "challenge");
-
-        if (!is_null($challenge)) {
-            try {
-                $verifyResult = \OMV\Rpc\Rpc::call(
-                    "UserMgmt",
-                    "verifyChallenge",
-                    [
-                        "username" => $username,
-                        "challengeresponse" => array_value($params, "challengeresponse"),
-                        "challengedata" => $challenge
-                    ],
-                    $this->getAdminContext(),
-                    \OMV\Rpc\Rpc::MODE_REMOTE,
-                    true
-                );
-
-                if (!is_assoc_array($verifyResult) || !array_value(
-                    $verifyResult,
-                    "verified",
-                    false
-                )) {
-                    $this->logAuthEvent(LOG_ALERT, sprintf(
-                        "Challenge verification failed for %s from %s",
-                        $username,
-                        $server->getClientIP()
-                    ));
-                    throw new \OMV\HttpErrorException(
-                        401,
-                        _("Challenge verification failed.")
-                    );
-                }
-            } catch (\OMV\HttpErrorException $e) {
-                throw $e;
-            } catch (\Exception $e) {
-                $this->logAuthEvent(LOG_ERR, sprintf(
-                    "Challenge verification error for %s: %s",
+        // Reject stale, timed-out or inconsistent sessions before doing
+        // any crypto work. validateMfaPending() also checks the timeout
+        // and user-agent so expired pending sessions are cleaned up.
+        $session->validateMfaPending();
+        $username = $session->getUsername();
+        $server = new \OMV\SuperGlobalServer();
+        // Retrieve the stored TOTP secret and verify the submitted code.
+        $db = \OMV\Config\Database::getInstance();
+        $mfaObjects = $db->getByFilter('conf.system.mfa.totp', [
+            'operator' => 'stringEquals',
+            'arg0' => 'username',
+            'arg1' => $username,
+        ]);
+        $secret = !empty($mfaObjects)
+            ? (string) $mfaObjects[0]->get('secret')
+            : '';
+        $code = trim($params['code']);
+        if (empty($secret) || !\OMV\Totp::verifyCode($secret, $code)) {
+            // Record the failure and enforce a retry limit.
+            $attempts = $session->incrementTotpAttempts();
+            $session->commit();
+            $prd = new \OMV\ProductInfo();
+            $ident = mb_strtolower(sprintf("%s-webgui", $prd->getName()));
+            openlog($ident, LOG_PID | LOG_PERROR, LOG_AUTH);
+            $_ = defer("closelog");
+            // After 5 failed attempts, invalidate the pending session to
+            // prevent an attacker from cycling through all 1,000,000 codes.
+            if ($attempts >= 5) {
+                syslog(LOG_ALERT, sprintf(
+                    "TOTP brute-force lockout from %s ".
+                    "[username=%s, attempts=%d]",
+                    $server->getClientIP(),
                     $username,
-                    $e->getMessage()
+                    $attempts
                 ));
+                $session->destroy();
                 throw new \OMV\HttpErrorException(
-                    500,
-                    _("Challenge verification error.")
+                    401,
+                    _("Too many failed TOTP attempts. Please log in again.")
                 );
             }
+            syslog(LOG_ALERT, sprintf(
+                "Invalid TOTP code from %s ".
+                "[username=%s, attempt=%d]",
+                $server->getClientIP(),
+                $username,
+                $attempts
+            ));
+            throw new \OMV\HttpErrorException(
+                400,
+                _("Invalid verification code. Please try again.")
+            );
         }
-
-        $sessionId = $this->initializeSession(
-            $username,
-            $permissions,
-            $server
-        );
-
-        $this->handleSuccessfulLogin($username, $server);
-
+        // Code is valid — promote the session to fully authenticated.
+        $session->completeMfaAuthentication();
+        $sessionId = session_id();
+        // Rebuild the permissions the same way login() does.
+        $isAdmin = ($session->getRole() === OMV_ROLE_ADMINISTRATOR);
+        $role = $isAdmin ? "admin" : "user";
+        $permissions = ["role" => $role];
+        $session->commit();
+        // Log the successful full login and send the first-login notification.
+        $this->finalizeLogin(true, $username);
         return [
             "authenticated" => true,
+            "mfaRequired" => false,
             "username" => $username,
             "permissions" => $permissions,
-            "sessionid" => $sessionId
+            "sessionid" => $sessionId,
         ];
     }
-
 
     /**
      * Logout user.
@@ -266,167 +274,110 @@ class OMVRpcServiceSession extends \OMV\Rpc\ServiceAbstract
     }
 
     /**
-     * Log an authentication event to syslog with product-specific identity.
-     * @param level The syslog priority level (e.g., LOG_ALERT, LOG_NOTICE).
-     * @param message The message to log.
-     * @return void
+     * Log the final outcome of a login attempt and, on success, send the
+     * first-login email notification and set the browser-recognition cookie.
+     *
+     * Extracted into a helper so both login() (no-MFA path) and verifyTotp()
+     * (MFA path) share identical post-authentication behaviour.
+     *
+     * @param bool   $authenticated Whether authentication succeeded.
+     * @param string $username      The username that was authenticated.
      */
-    private function logAuthEvent($level, $message)
-    {
+    private function finalizeLogin(
+        bool $authenticated,
+        string $username
+    ): void {
+        $server = new \OMV\SuperGlobalServer();
         $prd = new \OMV\ProductInfo();
         $ident = mb_strtolower(sprintf("%s-webgui", $prd->getName()));
-
+        $prefix = mb_strtoupper(sprintf("%s-LOGIN", $prd->getName()));
         openlog($ident, LOG_PID | LOG_PERROR, LOG_AUTH);
         $_ = defer("closelog");
-
-        syslog($level, $message);
-    }
-
-    /**
-     * Initialize (or reuse) the PHP session for the given user.
-     * @param username The authenticated username.
-     * @param permissions The user permissions array.
-     * @param server The SuperGlobalServer instance.
-     * @return The session ID.
-     */
-    private function initializeSession($username, $permissions, $server)
-    {
-        $session = &\OMV\Session::getInstance();
-        $_ = defer([$session, 'commit']);
-
-        if ($session->isAuthenticated()) {
-            // Reject if an existing session belongs to a different user.
-            if ($session->getUsername() !== $username) {
-                throw new \OMV\HttpErrorException(
-                    400,
-                    _("Another user is already authenticated.")
-                );
-            }
-            // Session already established for this user — reuse it.
-            $session->clearPendingAuth();
-            return $session->getId();
-        }
-
-        $role = ("admin" == array_value($permissions, "role", "user")) ?
-            OMV_ROLE_ADMINISTRATOR : OMV_ROLE_USER;
-        return $session->initialize($username, $role);
-    }
-
-    /**
-     * Log a successful login via syslog and handle the first-login
-     * notification email and browser cookie.
-     * @param username The authenticated username.
-     * @param server The SuperGlobalServer instance.
-     * @return void
-     */
-    private function handleSuccessfulLogin($username, $server)
-    {
-        $this->logAuthEvent(LOG_ALERT, sprintf(
-            "Authorized login from %s (username=%s, user-agent=%s)",
-            $server->getClientIP(),
-            $username,
-            $server->getUserAgent()
-        ));
-
-        $prd = new \OMV\ProductInfo();
-        $prefix = mb_strtoupper(sprintf("%s-LOGIN", $prd->getName()));
-
-        // Send an email to the user if a new web browser is used to log
-        // in to the control panel. If no special cookie is detected,
-        // then it is assumed that the web browser has not been used to
-        // log in until now. The salted user name hash is used as identifier.
-        if ($this->isFirstLoginFromBrowser($username, $prefix)) {
-            // Send the notification email to the user?
-            try {
-                $notificationEnabled = \OMV\Rpc\Rpc::call(
-                    "Notification",
-                    "isEnabled",
-                    ["id" => "authentication"],
-                    $this->getAdminContext(),
-                    \OMV\Rpc\Rpc::MODE_REMOTE
-                );
-            } catch (\Exception $e) {
-                // Force the sending of the notification email if the
-                // RPC fails.
-                $notificationEnabled = true;
-            }
-
-            if (true == $notificationEnabled) {
-                $subject = sprintf("Your user account was used to log in to ".
-                    "the %s control panel via a web browser.", $prd->getName());
-                $message = sprintf(
-                    "Dear %s,\n\n".
-                    "your user account was used to log in to %s (%s) via a web browser.\n\n".
-                    "Date and time: %s\n".
-                    "Remote address: %s\n".
-                    "User agent: %s\n\n".
-                    "If you recently logged in to the control panel, you can disregard this email. ".
-                    "If you have not logged in recently and believe someone may have accessed ".
-                    "your account, you should reset your password.\n\n".
-                    "Sincerely,\n".
-                    "your %s system",
-                    $username,
-                    \OMV\System\Net\Dns::getFqdn(),
-                    $server->getServerAddr(),
-                    date("r"),
-                    $server->getClientIP(),
-                    $server->getUserAgent(),
-                    $prd->getName()
-                );
-                $mail = new \OMV\Email(
-                    "root",
-                    $username,
-                    $subject,
-                    $message
-                );
-                $mail->send();
-            }
-
-            // Set a cookie. It will expire after 60 days. The user name
-            // is crypted/hashed to be unable to reverse engineer the
-            // account names from the cookie. The hash is hex-encoded
-            // to ensure the cookie name only contains safe characters,
-            // since PHP converts dots in cookie names to underscores
-            // when populating $_COOKIE (bcrypt hashes may contain dots).
-            $hashedUsername = password_hash(
+        if (true === $authenticated) {
+            syslog(LOG_ALERT, sprintf(
+                "Authorized login from %s ".
+                "[username=%s, user-agent=%s]",
+                $server->getClientIP(),
                 $username,
-                PASSWORD_DEFAULT
-            );
-            $key = sprintf("%s-%s", $prefix, bin2hex($hashedUsername));
-            $value = array_rand_value(\OMV\Environment::get(
-                "OMV_DUNE_QUOTES"
+                $server->getUserAgent()
             ));
-            $expire = time() + (60 * 60 * 24 * self::COOKIE_TTL_DAYS);
-            setcookie($key, $value, [
-                'expires' => $expire,
-                'httponly' => true,
-                'samesite' => 'Strict'
-            ]);
+            // Detect whether this browser has logged in before by looking for
+            // the recognition cookie set on a prior login. The cookie holds a
+            // bcrypt hash of the username hex-encoded to avoid dot→underscore
+            // conversion by PHP.
+            $firstLogIn = true;
+            foreach ($_COOKIE as $cookiek => $cookiev) {
+                $regex = sprintf('/^%s-(.+)$/', $prefix);
+                if (1 !== preg_match($regex, $cookiek, $matches)) {
+                    continue;
+                }
+                $hashedUsername = hex2bin($matches[1]);
+                if (false === $hashedUsername) {
+                    continue;
+                }
+                if (password_verify($username, $hashedUsername)) {
+                    $firstLogIn = false;
+                    break;
+                }
+            }
+            if (true === $firstLogIn) {
+                // Send notification email if the feature is enabled.
+                try {
+                    $notificationEnabled = \OMV\Rpc\Rpc::call(
+                        "Notification",
+                        "isEnabled",
+                        ["id" => "authentication"],
+                        $this->getAdminContext(),
+                        \OMV\Rpc\Rpc::MODE_REMOTE
+                    );
+                } catch (\Exception $e) {
+                    $notificationEnabled = true;
+                }
+                if (true == $notificationEnabled) {
+                    $subject = sprintf("Your user account was used to log in to ".
+                        "the %s control panel via a web browser.", $prd->getName());
+                    $message = sprintf(
+                        "Dear %s,\n\n".
+                        "your user account was used to log in to %s (%s) via a web browser.\n\n".
+                        "Date and time: %s\n".
+                        "Remote address: %s\n".
+                        "User agent: %s\n\n".
+                        "If you recently logged in to the control panel, you can disregard this email. ".
+                        "If you have not logged in recently and believe someone may have accessed ".
+                        "your account, you should reset your password.\n\n".
+                        "Sincerely,\n".
+                        "your %s system",
+                        $username,
+                        \OMV\System\Net\Dns::getFqdn(),
+                        $server->getServerAddr(),
+                        date('r'),
+                        $server->getClientIP(),
+                        $server->getUserAgent(),
+                        $prd->getName()
+                    );
+                    $mail = new \OMV\Email("root", $username, $subject, $message);
+                    $mail->send();
+                }
+                // Set the browser-recognition cookie (expires in 60 days).
+                $hashedUsername = password_hash($username, PASSWORD_DEFAULT);
+                $key = sprintf("%s-%s", $prefix, bin2hex($hashedUsername));
+                $value = array_rand_value(\OMV\Environment::get("OMV_DUNE_QUOTES"));
+                setcookie($key, $value, [
+                    'expires' => time() + 60 * 60 * 24 * 60,
+                    'httponly' => true,
+                    'samesite' => 'Strict',
+                ]);
+            }
+        } else {
+            syslog(LOG_ALERT, sprintf(
+                "Unauthorized login attempt from %s ".
+                "[username=%s, user-agent=%s]",
+                $server->getClientIP(),
+                $username,
+                $server->getUserAgent()
+            ));
+            throw new \OMV\HttpErrorException(400,
+                _("Incorrect username or password."));
         }
-    }
-
-    /**
-     * Check if this is the first login from the current browser for the given user.
-     * @param username The username to check.
-     * @param prefix The cookie name prefix.
-     * @return TRUE if this is the first login from this browser, FALSE otherwise.
-     */
-    private function isFirstLoginFromBrowser($username, $prefix)
-    {
-        foreach ($_COOKIE as $cookiek => $cookiev) {
-            // Extract the hex-encoded bcrypt hash from the cookie name.
-            $regex = sprintf('/^%s-(.+)$/', $prefix);
-            if (1 !== preg_match($regex, $cookiek, $matches)) {
-                continue;
-            }
-            $hashedUsername = hex2bin($matches[1]);
-            if (false === $hashedUsername) {
-                continue;
-            }
-            if (password_verify($username, $hashedUsername)) {
-                return false;
-            }
-        }
-        return true;
     }
 }

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-image/form-image.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-image/form-image.component.html
@@ -1,0 +1,7 @@
+<div class="omv-form-image omv-display-flex omv-justify-content-center">
+  <img *ngIf="config.value"
+       [src]="config.value"
+       [attr.alt]="config.label | transloco"
+       [style.width.px]="config.width || 256"
+       [style.height.px]="config.height || 256" />
+</div>

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-image/form-image.component.scss
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-image/form-image.component.scss
@@ -1,0 +1,3 @@
+.omv-form-image {
+  padding: 0.5rem 0 1rem;
+}

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-image/form-image.component.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/components/form-image/form-image.component.ts
@@ -1,0 +1,36 @@
+/**
+ * This file is part of OpenMediaVault.
+ *
+ * @license   https://www.gnu.org/licenses/gpl.html GPL Version 3
+ * @author    Volker Theile <volker.theile@openmediavault.org>
+ * @copyright Copyright (c) 2009-2026 Volker Theile
+ *
+ * OpenMediaVault is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * OpenMediaVault is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+import { Component } from '@angular/core';
+
+import { AbstractFormFieldComponent } from '~/app/core/components/intuition/form/components/abstract-form-field-component';
+
+/**
+ * Displays a read-only image whose source URL is taken from the field's
+ * `value` property. Typically used to show a QR code or other data-URL
+ * image inside a declarative form page without requiring any user input.
+ *
+ * The field does not register a form control — it is purely presentational.
+ * Set `submitValue: false` in the field config (the default) to exclude it
+ * from the submitted form values.
+ */
+@Component({
+  selector: 'omv-form-image',
+  templateUrl: './form-image.component.html',
+  styleUrls: ['./form-image.component.scss']
+})
+export class FormImageComponent extends AbstractFormFieldComponent {}

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/form/form.component.html
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/form/form.component.html
@@ -183,5 +183,12 @@
                      [formGroup]="formGroup">
       </omv-form-card>
     </ng-template>
+
+    <ng-template [ngSwitchCase]="'image'">
+      <omv-form-image class="omv-display-flex"
+                      [config]="field"
+                      [formGroup]="formGroup">
+      </omv-form-image>
+    </ng-template>
   </ng-container>
 </ng-template>

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/intuition.module.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/intuition.module.ts
@@ -19,6 +19,7 @@ import { FormFileInputComponent } from '~/app/core/components/intuition/form/com
 import { FormFolderbrowserComponent } from '~/app/core/components/intuition/form/components/form-folderbrowser/form-folderbrowser.component';
 import { FormHintComponent } from '~/app/core/components/intuition/form/components/form-hint/form-hint.component';
 import { FormIconButtonComponent } from '~/app/core/components/intuition/form/components/form-icon-button/form-icon-button.component';
+import { FormImageComponent } from '~/app/core/components/intuition/form/components/form-image/form-image.component';
 import { FormNumberInputComponent } from '~/app/core/components/intuition/form/components/form-number-input/form-number-input.component';
 import { FormParagraphComponent } from '~/app/core/components/intuition/form/components/form-paragraph/form-paragraph.component';
 import { FormPasswordInputComponent } from '~/app/core/components/intuition/form/components/form-password-input/form-password-input.component';
@@ -71,6 +72,7 @@ import { SharedModule } from '~/app/shared/shared.module';
     FormParagraphComponent,
     FormSliderComponent,
     FormHintComponent,
+    FormImageComponent,
     TextPageComponent,
     FormSshcertSelectComponent,
     FormSslcertSelectComponent,

--- a/deb/openmediavault/workbench/src/app/core/components/intuition/models/form-field-config.type.ts
+++ b/deb/openmediavault/workbench/src/app/core/components/intuition/models/form-field-config.type.ts
@@ -45,6 +45,9 @@ export type FormFieldConfig = {
   // |             | string. The separator defaults to a comma.           |
   // | ...         | ...                                                  |
   // | container   | Align child fields in horizontal order.              |
+  // | image       | Displays a read-only image. The `value` property     |
+  // |             | must be a URL or data URL (e.g. a QR code). Use      |
+  // |             | `width` and `height` to constrain the rendered size. |
   // '--------------------------------------------------------------------'
   type:
     | 'card'
@@ -72,7 +75,8 @@ export type FormFieldConfig = {
     | 'container'
     | 'hint'
     | 'codeEditor'
-    | 'tagInput';
+    | 'tagInput'
+    | 'image';
   name?: FormFieldName;
   label?: string;
   placeholder?: string;
@@ -173,6 +177,11 @@ export type FormFieldConfig = {
   // Defaults to 'off'.
   // See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize
   autocapitalize?: 'none' | 'sentences' | 'words' | 'characters';
+
+  // --- image ---
+  // Pixel dimensions for the rendered image. Defaults to 256 × 256.
+  width?: number;
+  height?: number;
 
   // --- container ---
   fields?: Array<FormFieldConfig>;

--- a/deb/openmediavault/workbench/src/app/core/pages/login-page/login-page.component.html
+++ b/deb/openmediavault/workbench/src/app/core/pages/login-page/login-page.component.html
@@ -1,5 +1,9 @@
-<div class="omv-display-flex omv-flex-fill">
-  <omv-green-rain [delay]="30000"
+<div class="omv-overflow-hidden omv-position-relative omv-display-flex omv-flex-fill">
+  <div class="background omv-position-absolute omv-flex-fill"
+       [ngClass]="{'omv-display-none': hideBackgroundImage}">
+  </div>
+  <omv-green-rain class="omv-position-absolute omv-flex-fill"
+                  delay="30000"
                   primaryColor="#5dacdf"
                   secondaryColor="#f8d400">
   </omv-green-rain>
@@ -8,21 +12,44 @@
       <div></div>
       <div class="logo"></div>
       <button mat-icon-button
-              matTooltip="{{ 'Language' | transloco }}"
-              [attr.aria-label]="'Language' | transloco"
-              [matMenuTriggerFor]="localeMenu">
-        <mat-icon svgIcon="mdi:earth"
+              matTooltip="{{ 'Settings' | transloco }}"
+              [attr.aria-label]="'Settings' | transloco"
+              [matMenuTriggerFor]="settingsMenu">
+        <mat-icon svgIcon="{{ icon.settings }}"
                   class="omv-color-white">
         </mat-icon>
       </button>
     </mat-toolbar>
   </div>
   <div class="content omv-flex-fill">
-    <omv-intuition-form-page class="omv-h-100 omv-display-flex omv-justify-content-center omv-align-items-center"
-                             [config]="config">
+    <!-- Step 1: username + password -->
+    <omv-intuition-form-page *ngIf="step === 'credentials'"
+                             class="omv-h-100 omv-display-flex omv-justify-content-center omv-align-items-center"
+                             [config]="this.config">
+    </omv-intuition-form-page>
+    <!-- Step 2: TOTP code (shown only after password was accepted and mfaRequired=true) -->
+    <omv-intuition-form-page *ngIf="step === 'totp'"
+                             class="omv-h-100 omv-display-flex omv-justify-content-center omv-align-items-center"
+                             [config]="this.totpConfig">
     </omv-intuition-form-page>
   </div>
 </div>
+
+<mat-menu #settingsMenu="matMenu">
+  <ng-template matMenuContent>
+    <button mat-menu-item
+            [ngClass]="{'active': !hideBackgroundImage}"
+            (click)="onToggleHideBackgroundImage()">
+      <mat-icon svgIcon="mdi:image"></mat-icon>
+      <mat-slide-toggle [checked]="!hideBackgroundImage">{{ 'Background image' | transloco }}</mat-slide-toggle>
+    </button>
+    <button mat-menu-item
+            [matMenuTriggerFor]="localeMenu">
+      <mat-icon svgIcon="mdi:earth"></mat-icon>
+      <span>{{ 'Language' | transloco }}</span>
+    </button>
+  </ng-template>
+</mat-menu>
 
 <mat-menu #localeMenu="matMenu">
   <ng-template matMenuContent>

--- a/deb/openmediavault/workbench/src/app/core/pages/login-page/login-page.component.spec.ts
+++ b/deb/openmediavault/workbench/src/app/core/pages/login-page/login-page.component.spec.ts
@@ -1,18 +1,27 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ToastrModule } from 'ngx-toastr';
+import { of, throwError } from 'rxjs';
 
 import { LoginPageComponent } from '~/app/core/pages/login-page/login-page.component';
 import { PagesModule } from '~/app/core/pages/pages.module';
+import { AuthService } from '~/app/shared/services/auth.service';
 import { TestingModule } from '~/app/testing.module';
 
 describe('LoginPageComponent', () => {
   let component: LoginPageComponent;
   let fixture: ComponentFixture<LoginPageComponent>;
+  let mockAuthService: jest.Mocked<Pick<AuthService, 'login' | 'verifyTotp'>>;
 
   beforeEach(waitForAsync(() => {
+    mockAuthService = {
+      login: jest.fn(),
+      verifyTotp: jest.fn()
+    };
+
     TestBed.configureTestingModule({
-      imports: [BrowserAnimationsModule, PagesModule, TestingModule, ToastrModule.forRoot()]
+      imports: [BrowserAnimationsModule, PagesModule, TestingModule, ToastrModule.forRoot()],
+      providers: [{ provide: AuthService, useValue: mockAuthService }]
     }).compileComponents();
   }));
 
@@ -24,5 +33,87 @@ describe('LoginPageComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should start at the credentials step', () => {
+    expect(component.step).toBe('credentials');
+  });
+
+  describe('onLogin()', () => {
+    it('should navigate to dashboard when MFA is not required', () => {
+      mockAuthService.login.mockReturnValue(
+        of({ authenticated: true, mfaRequired: false, username: 'admin', permissions: {} })
+      );
+      const routerSpy = jest.spyOn((component as any).router, 'navigate');
+
+      component.onLogin({} as any, { username: 'admin', password: 'secret' });
+
+      expect(component.step).toBe('credentials');
+      expect(routerSpy).toHaveBeenCalledWith(['/dashboard']);
+    });
+
+    it('should advance to the TOTP step when MFA is required', () => {
+      mockAuthService.login.mockReturnValue(
+        of({
+          authenticated: false,
+          mfaRequired: true,
+          username: 'admin',
+          permissions: {},
+          sessionid: 'pending'
+        })
+      );
+
+      component.onLogin({} as any, { username: 'admin', password: 'secret' });
+
+      expect(component.step).toBe('totp');
+    });
+
+    it('should remain on credentials step on login error', () => {
+      mockAuthService.login.mockReturnValue(
+        throwError(() => ({ error: { message: 'Incorrect username or password.' } }))
+      );
+
+      component.onLogin({} as any, { username: 'admin', password: 'wrong' });
+
+      expect(component.step).toBe('credentials');
+    });
+  });
+
+  describe('onVerifyTotp()', () => {
+    beforeEach(() => {
+      // Put component into the TOTP step first.
+      component.step = 'totp';
+    });
+
+    it('should navigate to dashboard after successful TOTP verification', () => {
+      mockAuthService.verifyTotp.mockReturnValue(
+        of({ authenticated: true, mfaRequired: false, username: 'admin', permissions: {} })
+      );
+      const routerSpy = jest.spyOn((component as any).router, 'navigate');
+
+      component.onVerifyTotp({} as any, { code: '123456' });
+
+      expect(routerSpy).toHaveBeenCalledWith(['/dashboard']);
+    });
+
+    it('should stay on TOTP step when verification fails', () => {
+      mockAuthService.verifyTotp.mockReturnValue(
+        throwError(() => ({ error: { message: 'Invalid verification code.' } }))
+      );
+
+      component.onVerifyTotp({} as any, { code: '000000' });
+
+      expect(component.step).toBe('totp');
+    });
+  });
+
+  describe('onBackToCredentials()', () => {
+    it('should return to the credentials step', () => {
+      component.step = 'totp';
+
+      component.onBackToCredentials({} as any, {});
+
+      expect(component.step).toBe('credentials');
+    });
   });
 });

--- a/deb/openmediavault/workbench/src/app/core/pages/login-page/login-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/core/pages/login-page/login-page.component.ts
@@ -27,12 +27,10 @@ import {
 } from '~/app/core/components/intuition/models/form-page-config.type';
 import { translate } from '~/app/i18n.helper';
 import { Icon } from '~/app/shared/enum/icon.enum';
-import { NotificationType } from '~/app/shared/enum/notification-type.enum';
-import { AuthenticateResponse, AuthService } from '~/app/shared/services/auth.service';
+import { AuthService } from '~/app/shared/services/auth.service';
 import { BlockUiService } from '~/app/shared/services/block-ui.service';
 import { DialogService } from '~/app/shared/services/dialog.service';
 import { LocaleService } from '~/app/shared/services/locale.service';
-import { NotificationService } from '~/app/shared/services/notification.service';
 
 @Component({
   selector: 'omv-login-page',
@@ -43,8 +41,13 @@ import { NotificationService } from '~/app/shared/services/notification.service'
 export class LoginPageComponent implements OnInit {
   public currentLocale: string;
   public locales: Record<string, string> = {};
+  public hideBackgroundImage: boolean;
   public icon = Icon;
 
+  /** Controls which step of the login flow is currently displayed. */
+  public step: 'credentials' | 'totp' = 'credentials';
+
+  /** Form config for step 1: username + password. */
   public config: FormPageConfig = {
     id: 'login',
     fields: [
@@ -83,12 +86,54 @@ export class LoginPageComponent implements OnInit {
     ]
   };
 
+  /** Form config for step 2: TOTP code entry (shown only when mfaRequired). */
+  public totpConfig: FormPageConfig = {
+    id: 'totp',
+    fields: [
+      {
+        type: 'textInput',
+        name: 'code',
+        label: gettext('Verification code'),
+        hint: gettext('Enter the 6-digit code from your authenticator app.'),
+        autofocus: true,
+        autocomplete: 'one-time-code',
+        icon: 'mdi:shield-key',
+        validators: {
+          required: true,
+          minLength: 6,
+          maxLength: 6,
+          pattern: {
+            pattern: '^[0-9]{6}$',
+            errorData: gettext('Must be a 6-digit number.')
+          }
+        }
+      }
+    ],
+    buttonAlign: 'center',
+    buttons: [
+      {
+        template: 'submit',
+        text: gettext('Verify'),
+        execute: {
+          type: 'click',
+          click: this.onVerifyTotp.bind(this)
+        }
+      },
+      {
+        template: 'back',
+        execute: {
+          type: 'click',
+          click: this.onBackToCredentials.bind(this)
+        }
+      }
+    ]
+  };
+
   constructor(
     private activatedRoute: ActivatedRoute,
     private authService: AuthService,
     private blockUiService: BlockUiService,
     private dialogService: DialogService,
-    private notificationService: NotificationService,
     private router: Router
   ) {
     this.currentLocale = LocaleService.getCurrentLocale();
@@ -99,91 +144,71 @@ export class LoginPageComponent implements OnInit {
     this.blockUiService.resetGlobal();
     // Ensure all currently opened dialogs are closed.
     this.dialogService.closeAll();
+    // Show/hide the login page background image.
+    this.hideBackgroundImage = JSON.parse(
+      localStorage.getItem('hideLoginBackgroundImage') ?? 'false'
+    );
   }
 
   onLogin(buttonConfig: FormPageButtonConfig, values: Record<string, any>) {
     this.blockUiService.start(translate(gettext('Please wait ...')));
     this.authService
-      .authenticate(values.username, values.password)
+      .login(values.username, values.password)
       .pipe(
         finalize(() => {
           this.blockUiService.stop();
         })
       )
-      .subscribe((res: AuthenticateResponse) => {
-        if (res.status === 'authenticated') {
+      .subscribe({
+        next: (res) => {
+          if (res.mfaRequired) {
+            // Password accepted — show the TOTP code entry step.
+            this.step = 'totp';
+            return;
+          }
+          // No MFA required — navigate to the originally requested URL.
           const url = _.get(this.activatedRoute.snapshot.queryParams, 'returnUrl', '/dashboard');
           this.router.navigate([url]);
-        } else if (res.status === 'challengeRequired') {
-          this.handleChallenge(res);
-        }
+        },
+        // Errors are displayed by the global HTTP error interceptor; stay on
+        // the credentials step so the user can correct their input.
+        error: () => {}
       });
   }
 
-  onSelectLocale(locale: string) {
+  onVerifyTotp(buttonConfig: FormPageButtonConfig, values: Record<string, any>) {
+    this.blockUiService.start(translate(gettext('Please wait ...')));
+    this.authService
+      .verifyTotp(values.code)
+      .pipe(
+        finalize(() => {
+          this.blockUiService.stop();
+        })
+      )
+      .subscribe({
+        next: () => {
+          const url = _.get(this.activatedRoute.snapshot.queryParams, 'returnUrl', '/dashboard');
+          this.router.navigate([url]);
+        },
+        // Errors are displayed by the global HTTP error interceptor; stay on
+        // the TOTP step so the user can re-enter the code.
+        error: () => {}
+      });
+  }
+
+  /** Return to the credentials step if the user wants to start over. */
+  onBackToCredentials(_buttonConfig: FormPageButtonConfig, _values: Record<string, any>) {
+    this.step = 'credentials';
+  }
+
+  onSelectLocale(locale) {
     // Update the browser cookie and reload the page.
     LocaleService.setCurrentLocale(locale);
     this.router.navigate(['/reload']);
   }
 
-  private handleChallenge(authResponse: AuthenticateResponse) {
-    if (!authResponse.challenge) {
-      this.notificationService.show(
-        NotificationType.error,
-        gettext('Authentication'),
-        gettext(
-          'An authentication challenge was required but no challenge information was provided. Please contact your administrator.'
-        )
-      );
-      return;
-    }
-
-    if (!authResponse.challenge.redirecturl) {
-      this.notificationService.show(
-        NotificationType.error,
-        gettext('Authentication'),
-        gettext(
-          'The requested authentication challenge is not supported by this browser interface. Please contact your administrator.'
-        )
-      );
-      return;
-    }
-
-    const challengeUrl: string = authResponse.challenge.redirecturl;
-
-    // Redirect MUST be root-relative to prevent open-redirect attacks and to
-    // ensure the Angular router can navigate to it.
-    if (!challengeUrl.startsWith('/') || challengeUrl.startsWith('//')) {
-      this.notificationService.show(
-        NotificationType.error,
-        gettext('Authentication'),
-        gettext('The authentication challenge URL is invalid.')
-      );
-      return;
-    }
-
-    // Use the URL API to parse and validate the URL is same-origin.
-    try {
-      // Parse as URL with current origin as base. This handles relative URLs.
-      const url = new URL(challengeUrl, window.location.origin);
-
-      // Ensure the parsed URL has the same origin (protocol, host, port).
-      // This prevents all open redirect attempts:
-      // - Absolute URLs to other domains: http://evil.com
-      // - Protocol-relative URLs: //evil.com
-      // - Path escapes: /\evil.com (browsers normalize this)
-      if (url.origin !== window.location.origin) {
-        throw new Error('Cross-origin redirect not allowed');
-      }
-    } catch (e) {
-      this.notificationService.show(
-        NotificationType.error,
-        gettext('Authentication'),
-        gettext('The authentication challenge URL is invalid.')
-      );
-      return;
-    }
-
-    this.router.navigateByUrl(challengeUrl);
+  onToggleHideBackgroundImage() {
+    this.hideBackgroundImage = !this.hideBackgroundImage;
+    localStorage.setItem('hideLoginBackgroundImage', JSON.stringify(this.hideBackgroundImage));
   }
 }

--- a/deb/openmediavault/workbench/src/app/material.module.ts
+++ b/deb/openmediavault/workbench/src/app/material.module.ts
@@ -21,6 +21,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
@@ -50,6 +51,7 @@ import { DomSanitizer } from '@angular/platform-browser';
     MatMenuModule,
     MatNativeDateModule,
     MatProgressBarModule,
+    MatProgressSpinnerModule,
     MatRippleModule,
     MatSelectModule,
     MatSidenavModule,

--- a/deb/openmediavault/workbench/src/app/pages/usermgmt/usermgmt-routing.module.ts
+++ b/deb/openmediavault/workbench/src/app/pages/usermgmt/usermgmt-routing.module.ts
@@ -11,6 +11,9 @@ import { GroupSharedFolderPermissionsDatatablePageComponent } from '~/app/pages/
 import { UserDatatablePageComponent } from '~/app/pages/usermgmt/users/user-datatable-page.component';
 import { UserFormPageComponent } from '~/app/pages/usermgmt/users/user-form-page.component';
 import { UserImportFormPageComponent } from '~/app/pages/usermgmt/users/user-import-form-page.component';
+import { UserMfaFormPageComponent } from '~/app/pages/usermgmt/users/user-mfa-form-page.component';
+import { UserPasswordFormPageComponent } from '~/app/pages/usermgmt/users/user-password-form-page.component';
+import { UserProfileFormPageComponent } from '~/app/pages/usermgmt/users/user-profile-form-page.component';
 import { UserSettingsFormPageComponent } from '~/app/pages/usermgmt/users/user-settings-form-page.component';
 import { UserSharedFolderPermissionsDatatablePageComponent } from '~/app/pages/usermgmt/users/user-shared-folder-permissions-datatable-page.component';
 import { IsDirtyGuardService } from '~/app/shared/services/is-dirty-guard.service';
@@ -19,6 +22,34 @@ const routes: Routes = [
   {
     path: '',
     component: NavigationPageComponent
+  },
+  {
+    path: 'mfa',
+    component: UserMfaFormPageComponent,
+    data: {
+      title: gettext('Two-Factor Authentication'),
+      editing: true
+    }
+  },
+  {
+    path: 'change-password',
+    component: UserPasswordFormPageComponent,
+    canDeactivate: [IsDirtyGuardService],
+    data: {
+      title: gettext('Change Password'),
+      editing: true,
+      notificationTitle: gettext('Updated password.')
+    }
+  },
+  {
+    path: 'profile',
+    component: UserProfileFormPageComponent,
+    canDeactivate: [IsDirtyGuardService],
+    data: {
+      title: gettext('Profile'),
+      editing: true,
+      notificationTitle: gettext('Updated user profile.')
+    }
   },
   {
     path: 'users',
@@ -128,7 +159,7 @@ const routes: Routes = [
       provide: ROUTES,
       multi: true,
       useFactory: (routeConfigService: RouteConfigService): Routes => {
-        routeConfigService.injectWorkbenchRoutes('usermgmt', routes);
+        routeConfigService.inject('usermgmt', routes);
         return routes;
       },
       deps: [RouteConfigService]

--- a/deb/openmediavault/workbench/src/app/pages/usermgmt/usermgmt.module.ts
+++ b/deb/openmediavault/workbench/src/app/pages/usermgmt/usermgmt.module.ts
@@ -10,6 +10,9 @@ import { UsermgmtRoutingModule } from '~/app/pages/usermgmt/usermgmt-routing.mod
 import { UserDatatablePageComponent } from '~/app/pages/usermgmt/users/user-datatable-page.component';
 import { UserFormPageComponent } from '~/app/pages/usermgmt/users/user-form-page.component';
 import { UserImportFormPageComponent } from '~/app/pages/usermgmt/users/user-import-form-page.component';
+import { UserMfaFormPageComponent } from '~/app/pages/usermgmt/users/user-mfa-form-page.component';
+import { UserPasswordFormPageComponent } from '~/app/pages/usermgmt/users/user-password-form-page.component';
+import { UserProfileFormPageComponent } from '~/app/pages/usermgmt/users/user-profile-form-page.component';
 import { UserSettingsFormPageComponent } from '~/app/pages/usermgmt/users/user-settings-form-page.component';
 import { UserSharedFolderPermissionsDatatablePageComponent } from '~/app/pages/usermgmt/users/user-shared-folder-permissions-datatable-page.component';
 
@@ -17,13 +20,16 @@ import { UserSharedFolderPermissionsDatatablePageComponent } from '~/app/pages/u
   declarations: [
     UserDatatablePageComponent,
     UserFormPageComponent,
+    UserMfaFormPageComponent,
+    UserPasswordFormPageComponent,
     UserSettingsFormPageComponent,
     UserImportFormPageComponent,
     GroupFormPageComponent,
     GroupImportFormPageComponent,
     GroupDatatablePageComponent,
     GroupSharedFolderPermissionsDatatablePageComponent,
-    UserSharedFolderPermissionsDatatablePageComponent
+    UserSharedFolderPermissionsDatatablePageComponent,
+    UserProfileFormPageComponent
   ],
   imports: [CommonModule, CoreModule, UsermgmtRoutingModule]
 })

--- a/deb/openmediavault/workbench/src/app/pages/usermgmt/users/user-mfa-form-page.component.html
+++ b/deb/openmediavault/workbench/src/app/pages/usermgmt/users/user-mfa-form-page.component.html
@@ -1,0 +1,11 @@
+<omv-intuition-form-page *ngIf="state === 'disabled'"
+                        [config]="disabledConfig">
+</omv-intuition-form-page>
+
+<omv-intuition-form-page *ngIf="state === 'setup'"
+                         [config]="setupConfig">
+</omv-intuition-form-page>
+
+<omv-intuition-form-page *ngIf="state === 'enabled'"
+                         [config]="enabledConfig">
+</omv-intuition-form-page>

--- a/deb/openmediavault/workbench/src/app/pages/usermgmt/users/user-mfa-form-page.component.spec.ts
+++ b/deb/openmediavault/workbench/src/app/pages/usermgmt/users/user-mfa-form-page.component.spec.ts
@@ -1,0 +1,147 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { ToastrModule } from 'ngx-toastr';
+import { of, throwError } from 'rxjs';
+
+import { UserMfaFormPageComponent } from '~/app/pages/usermgmt/users/user-mfa-form-page.component';
+import { BlockUiService } from '~/app/shared/services/block-ui.service';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { RpcService } from '~/app/shared/services/rpc.service';
+import { TestingModule } from '~/app/testing.module';
+
+describe('UserMfaFormPageComponent', () => {
+  let component: UserMfaFormPageComponent;
+  let fixture: ComponentFixture<UserMfaFormPageComponent>;
+  let mockRpcService: jest.Mocked<Pick<RpcService, 'request'>>;
+  let mockNotificationService: jest.Mocked<Pick<NotificationService, 'show'>>;
+  let mockBlockUiService: jest.Mocked<Pick<BlockUiService, 'start' | 'stop'>>;
+  let mockRouter: jest.Mocked<Pick<Router, 'navigate'>>;
+
+  beforeEach(waitForAsync(() => {
+    mockRpcService = { request: jest.fn() };
+    mockNotificationService = { show: jest.fn() };
+    mockBlockUiService = { start: jest.fn(), stop: jest.fn() };
+    mockRouter = { navigate: jest.fn() };
+
+    // Default: return MFA disabled so the component finishes loading immediately.
+    mockRpcService.request.mockReturnValue(of({ enabled: false }));
+
+    TestBed.configureTestingModule({
+      declarations: [UserMfaFormPageComponent],
+      imports: [TestingModule, ToastrModule.forRoot()],
+      providers: [
+        { provide: RpcService, useValue: mockRpcService },
+        { provide: NotificationService, useValue: mockNotificationService },
+        { provide: BlockUiService, useValue: mockBlockUiService },
+        { provide: Router, useValue: mockRouter }
+      ],
+      // NO_ERRORS_SCHEMA suppresses "unknown element" errors for child
+      // components (omv-intuition-form-page) not under test here.
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UserMfaFormPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('loadStatus()', () => {
+    it('should set state to "disabled" when MFA is off', () => {
+      mockRpcService.request.mockReturnValue(of({ enabled: false }));
+      component.loadStatus();
+      expect(component.state).toBe('disabled');
+    });
+
+    it('should set state to "enabled" when MFA is on', () => {
+      mockRpcService.request.mockReturnValue(of({ enabled: true }));
+      component.loadStatus();
+      expect(component.state).toBe('enabled');
+    });
+
+    it('should fall back to "disabled" on RPC error', () => {
+      mockRpcService.request.mockReturnValue(throwError(() => new Error('Network error')));
+      component.loadStatus();
+      expect(component.state).toBe('disabled');
+    });
+  });
+
+  describe('onStartSetup()', () => {
+    it('should transition to "setup" state and populate setupConfig fields', () => {
+      const qrDataUrl = 'data:image/svg+xml;base64,AAAA';
+      mockRpcService.request.mockReturnValue(
+        of({
+          secret: 'JBSWY3DPEHPK3PXP',
+          uri: 'otpauth://totp/OMV:admin?secret=JBSWY3DPEHPK3PXP',
+          qrDataUrl
+        })
+      );
+      component.state = 'disabled';
+
+      component.onStartSetup(null, {});
+
+      expect(component.state).toBe('setup');
+
+      const qrField = component.setupConfig.fields.find((f) => f.name === 'qrcode');
+      expect(qrField?.value).toBe(qrDataUrl);
+
+      const secretField = component.setupConfig.fields.find((f) => f.name === 'secret');
+      expect(secretField?.value).toBe('JBSWY3DPEHPK3PXP');
+    });
+  });
+
+  describe('onConfirmSetup()', () => {
+    it('should enable MFA and transition to "enabled"', () => {
+      mockRpcService.request.mockReturnValue(of(null));
+      component.state = 'setup';
+      (component as any).provisionalSecret = 'JBSWY3DPEHPK3PXP';
+
+      component.onConfirmSetup(null, { code: '123456' });
+
+      expect(mockRpcService.request).toHaveBeenCalledWith('UserMgmt', 'enableTotpByContext', {
+        code: '123456',
+        secret: 'JBSWY3DPEHPK3PXP'
+      });
+      expect(component.state).toBe('enabled');
+    });
+  });
+
+  describe('onCancelSetup()', () => {
+    it('should return to "disabled" state and clear the provisional secret', () => {
+      component.state = 'setup';
+      (component as any).provisionalSecret = 'JBSWY3DPEHPK3PXP';
+
+      component.onCancelSetup(null, {});
+
+      expect(component.state).toBe('disabled');
+      expect((component as any).provisionalSecret).toBe('');
+    });
+  });
+
+  describe('onDisableMfa()', () => {
+    it('should disable MFA and transition to "disabled"', () => {
+      mockRpcService.request.mockReturnValue(of(null));
+      component.state = 'enabled';
+
+      component.onDisableMfa(null, { code: '654321' });
+
+      expect(mockRpcService.request).toHaveBeenCalledWith('UserMgmt', 'disableTotpByContext', {
+        code: '654321'
+      });
+      expect(component.state).toBe('disabled');
+    });
+  });
+
+  describe('onCancel()', () => {
+    it('should navigate to the root route', () => {
+      component.onCancel();
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/']);
+    });
+  });
+});

--- a/deb/openmediavault/workbench/src/app/pages/usermgmt/users/user-mfa-form-page.component.ts
+++ b/deb/openmediavault/workbench/src/app/pages/usermgmt/users/user-mfa-form-page.component.ts
@@ -1,0 +1,328 @@
+/**
+ * This file is part of OpenMediaVault.
+ *
+ * @license   https://www.gnu.org/licenses/gpl.html GPL Version 3
+ * @author    Volker Theile <volker.theile@openmediavault.org>
+ * @copyright Copyright (c) 2009-2026 Volker Theile
+ *
+ * OpenMediaVault is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * OpenMediaVault is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { marker as gettext } from '@ngneat/transloco-keys-manager/marker';
+import { finalize } from 'rxjs/operators';
+
+import {
+  FormPageButtonConfig,
+  FormPageConfig
+} from '~/app/core/components/intuition/models/form-page-config.type';
+import { translate } from '~/app/i18n.helper';
+import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+import { BlockUiService } from '~/app/shared/services/block-ui.service';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { RpcService } from '~/app/shared/services/rpc.service';
+
+/**
+ * Page component for managing TOTP two-factor authentication for the
+ * currently logged-in user. Accessible at /usermgmt/mfa.
+ *
+ * The page uses the OMV declarative form framework exclusively. Each
+ * state of the MFA setup flow has its own FormPageConfig; the active
+ * config is selected by the `state` property and rendered via
+ * <omv-intuition-form-page *ngIf="state === '...'">. Because *ngIf
+ * destroys and recreates the form component on every state transition,
+ * config field values can be safely set immediately before changing the
+ * state without worrying about stale form controls.
+ *
+ * State machine:
+ *  loading   → initial RPC call to check current MFA status
+ *  disabled  → MFA is off; user can start the setup flow
+ *  setup     → QR code is displayed; awaiting confirmation code
+ *  enabled   → MFA is active; user can disable it
+ *
+ * Security notes:
+ *  - The provisional secret from generateTotpSecretByContext is never
+ *    stored until the user confirms it with a valid TOTP code.
+ *  - Disabling MFA requires the current TOTP code, preventing a stolen
+ *    browser session from silently removing MFA protection.
+ */
+@Component({
+  selector: 'omv-user-mfa-form-page',
+  templateUrl: './user-mfa-form-page.component.html'
+})
+export class UserMfaFormPageComponent implements OnInit {
+  public state: 'loading' | 'disabled' | 'setup' | 'enabled' = 'loading';
+
+  /** The provisional secret held in memory during the setup flow only. */
+  private provisionalSecret = '';
+
+  // -----------------------------------------------------------------
+  // Form configs — one per visible state.
+  // -----------------------------------------------------------------
+
+  public disabledConfig: FormPageConfig = {
+    fields: [
+      {
+        type: 'hint',
+        hintType: 'info',
+        text: gettext(
+          'Two-factor authentication is currently disabled. ' +
+            'Enable it to add an extra layer of security to your account.'
+        )
+      }
+    ],
+    buttons: [
+      {
+        template: 'submit',
+        text: gettext('Enable Two-Factor Authentication'),
+        execute: {
+          type: 'click',
+          click: this.onStartSetup.bind(this)
+        }
+      },
+      {
+        template: 'cancel',
+        execute: {
+          type: 'click',
+          click: this.onCancel.bind(this)
+        }
+      }
+    ]
+  };
+
+  /**
+   * Config for the setup state.
+   * The `image` and `secret` field values are filled in by onStartSetup()
+   * before state switches to 'setup', so the newly created form always
+   * receives the correct initial values.
+   */
+  public setupConfig: FormPageConfig = {
+    fields: [
+      {
+        type: 'paragraph',
+        title: gettext(
+          'Scan the QR code below with your authenticator app ' +
+            '(Google Authenticator, Authy, etc.). ' +
+            'If your app does not support QR codes, enter the secret key manually.'
+        )
+      },
+      {
+        type: 'image',
+        name: 'qrcode',
+        label: gettext('TOTP QR code'),
+        value: '',
+        submitValue: false,
+        width: 256,
+        height: 256
+      },
+      {
+        type: 'textInput',
+        name: 'secret',
+        label: gettext('Secret key (manual entry)'),
+        readonly: true,
+        value: '',
+        submitValue: false
+      },
+      {
+        type: 'paragraph',
+        title: gettext(
+          'Once your authenticator app is configured, enter the ' +
+            '6-digit code it shows to confirm the setup.'
+        )
+      },
+      {
+        type: 'textInput',
+        name: 'code',
+        label: gettext('Verification code'),
+        autocomplete: 'one-time-code',
+        value: '',
+        validators: {
+          required: true,
+          minLength: 6,
+          maxLength: 6,
+          pattern: {
+            pattern: '^[0-9]{6}$',
+            errorData: gettext('Must be a 6-digit number.')
+          }
+        }
+      }
+    ],
+    buttons: [
+      {
+        template: 'submit',
+        text: gettext('Verify and Enable'),
+        execute: {
+          type: 'click',
+          click: this.onConfirmSetup.bind(this)
+        }
+      },
+      {
+        template: 'cancel',
+        execute: {
+          type: 'click',
+          click: this.onCancelSetup.bind(this)
+        }
+      }
+    ]
+  };
+
+  public enabledConfig: FormPageConfig = {
+    fields: [
+      {
+        type: 'hint',
+        hintType: 'info',
+        text: gettext(
+          'Two-factor authentication is enabled. ' +
+            'To disable it, enter the current 6-digit code from your authenticator app.'
+        )
+      },
+      {
+        type: 'textInput',
+        name: 'code',
+        label: gettext('Current verification code'),
+        autocomplete: 'one-time-code',
+        value: '',
+        validators: {
+          required: true,
+          minLength: 6,
+          maxLength: 6,
+          pattern: {
+            pattern: '^[0-9]{6}$',
+            errorData: gettext('Must be a 6-digit number.')
+          }
+        }
+      }
+    ],
+    buttons: [
+      {
+        template: 'submit',
+        text: gettext('Disable Two-Factor Authentication'),
+        execute: {
+          type: 'click',
+          click: this.onDisableMfa.bind(this)
+        }
+      },
+      {
+        template: 'cancel',
+        execute: {
+          type: 'click',
+          click: this.onCancel.bind(this)
+        }
+      }
+    ]
+  };
+
+  constructor(
+    private blockUiService: BlockUiService,
+    private notificationService: NotificationService,
+    private rpcService: RpcService,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.loadStatus();
+  }
+
+  /** Fetch the current TOTP status for the logged-in user. */
+  loadStatus(): void {
+    this.state = 'loading';
+    this.rpcService.request('UserMgmt', 'getTotpStatusByContext').subscribe({
+      next: (res: { enabled: boolean }) => {
+        this.state = res.enabled ? 'enabled' : 'disabled';
+      },
+      error: () => {
+        // On error fall back to the disabled view so the page is never stuck loading.
+        this.state = 'disabled';
+      }
+    });
+  }
+
+  /**
+   * Start the MFA setup flow: ask the backend to generate a fresh TOTP
+   * secret and QR code, then transition to the 'setup' state.
+   */
+  onStartSetup(_buttonConfig: FormPageButtonConfig, _values: Record<string, any>): void {
+    this.blockUiService.start(translate(gettext('Generating secret...')));
+    this.rpcService
+      .request('UserMgmt', 'generateTotpSecretByContext')
+      .pipe(finalize(() => this.blockUiService.stop()))
+      .subscribe({
+        next: (res: { secret: string; uri: string; qrDataUrl: string }) => {
+          this.provisionalSecret = res.secret;
+          // Patch field values before switching state. Because the
+          // template uses *ngIf, the form component will be created fresh
+          // and will read these values during its own ngOnInit.
+          const fields = this.setupConfig.fields;
+          const qrField = fields.find((f) => f.name === 'qrcode');
+          if (qrField) qrField.value = res.qrDataUrl;
+          const secretField = fields.find((f) => f.name === 'secret');
+          if (secretField) secretField.value = res.secret;
+          this.state = 'setup';
+        }
+      });
+  }
+
+  /**
+   * Confirm setup: submit the provisional secret and the TOTP code the
+   * user scanned from the QR image. The backend verifies before storing.
+   */
+  onConfirmSetup(_buttonConfig: FormPageButtonConfig, values: Record<string, any>): void {
+    this.blockUiService.start(translate(gettext('Enabling two-factor authentication...')));
+    this.rpcService
+      .request('UserMgmt', 'enableTotpByContext', {
+        code: String(values.code).trim(),
+        secret: this.provisionalSecret
+      })
+      .pipe(finalize(() => this.blockUiService.stop()))
+      .subscribe({
+        next: () => {
+          this.notificationService.show(
+            NotificationType.success,
+            translate(gettext('Two-factor authentication has been enabled.'))
+          );
+          this.provisionalSecret = '';
+          this.state = 'enabled';
+        }
+      });
+  }
+
+  /** Cancel setup and return to the disabled view without saving anything. */
+  onCancelSetup(_buttonConfig: FormPageButtonConfig, _values: Record<string, any>): void {
+    this.provisionalSecret = '';
+    this.state = 'disabled';
+  }
+
+  /**
+   * Disable TOTP MFA after the user confirms with their current TOTP code.
+   * Requiring the code prevents a stolen session from silently removing MFA.
+   */
+  onDisableMfa(_buttonConfig: FormPageButtonConfig, values: Record<string, any>): void {
+    this.blockUiService.start(translate(gettext('Disabling two-factor authentication...')));
+    this.rpcService
+      .request('UserMgmt', 'disableTotpByContext', {
+        code: String(values.code).trim()
+      })
+      .pipe(finalize(() => this.blockUiService.stop()))
+      .subscribe({
+        next: () => {
+          this.notificationService.show(
+            NotificationType.success,
+            translate(gettext('Two-factor authentication has been disabled.'))
+          );
+          this.state = 'disabled';
+        }
+      });
+  }
+
+  onCancel(_buttonConfig?: FormPageButtonConfig, _values?: Record<string, any>): void {
+    this.router.navigate(['/']);
+  }
+}

--- a/deb/openmediavault/workbench/src/app/shared/services/auth.service.spec.ts
+++ b/deb/openmediavault/workbench/src/app/shared/services/auth.service.spec.ts
@@ -1,17 +1,139 @@
 import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
 
-import { AuthService } from '~/app/shared/services/auth.service';
+import { AuthService, SessionData } from '~/app/shared/services/auth.service';
+import { AuthSessionService } from '~/app/shared/services/auth-session.service';
+import { PrefersColorSchemeService } from '~/app/shared/services/prefers-color-scheme.service';
+import { RpcService } from '~/app/shared/services/rpc.service';
 import { TestingModule } from '~/app/testing.module';
 
 describe('AuthService', () => {
-  beforeEach(() =>
+  let service: AuthService;
+  let mockRpcService: jest.Mocked<Pick<RpcService, 'request'>>;
+  let mockAuthSessionService: jest.Mocked<
+    Pick<AuthSessionService, 'set' | 'revoke' | 'getUsername'>
+  >;
+
+  const sessionDataNoMfa: SessionData = {
+    authenticated: true,
+    mfaRequired: false,
+    username: 'admin',
+    permissions: { role: 'admin' },
+    sessionid: 'sess-1'
+  };
+
+  const sessionDataMfaRequired: SessionData = {
+    authenticated: false,
+    mfaRequired: true,
+    username: 'admin',
+    permissions: { role: 'admin' },
+    sessionid: 'sess-pending'
+  };
+
+  const sessionDataMfaComplete: SessionData = {
+    authenticated: true,
+    mfaRequired: false,
+    username: 'admin',
+    permissions: { role: 'admin' },
+    sessionid: 'sess-1'
+  };
+
+  beforeEach(() => {
+    mockRpcService = { request: jest.fn() };
+    mockAuthSessionService = {
+      set: jest.fn(),
+      revoke: jest.fn(),
+      // getUsername is called by PrefersColorSchemeService on construction.
+      getUsername: jest.fn().mockReturnValue(null)
+    };
+
     TestBed.configureTestingModule({
-      imports: [TestingModule]
-    })
-  );
+      imports: [TestingModule],
+      providers: [
+        { provide: RpcService, useValue: mockRpcService },
+        { provide: AuthSessionService, useValue: mockAuthSessionService },
+        // PrefersColorSchemeService depends on AuthSessionService via
+        // UserLocalStorageService. Providing our mock for AuthSessionService
+        // is enough — no need to stub PrefersColorSchemeService itself.
+        PrefersColorSchemeService
+      ]
+    });
+    service = TestBed.inject(AuthService);
+  });
 
   it('should be created', () => {
-    const service: AuthService = TestBed.inject(AuthService);
     expect(service).toBeTruthy();
+  });
+
+  describe('login()', () => {
+    it('should store session when authentication succeeds without MFA', (done) => {
+      mockRpcService.request.mockReturnValue(of(sessionDataNoMfa));
+
+      service.login('admin', 'secret').subscribe((res) => {
+        expect(res.authenticated).toBe(true);
+        expect(res.mfaRequired).toBe(false);
+        expect(mockAuthSessionService.set).toHaveBeenCalledWith('admin', { role: 'admin' });
+        done();
+      });
+    });
+
+    it('should NOT store session when MFA is required', (done) => {
+      mockRpcService.request.mockReturnValue(of(sessionDataMfaRequired));
+
+      service.login('admin', 'secret').subscribe((res) => {
+        expect(res.authenticated).toBe(false);
+        expect(res.mfaRequired).toBe(true);
+        // Session must not be considered authenticated until TOTP is verified.
+        expect(mockAuthSessionService.set).not.toHaveBeenCalled();
+        done();
+      });
+    });
+
+    it('should call the correct RPC method with credentials', () => {
+      mockRpcService.request.mockReturnValue(of(sessionDataNoMfa));
+
+      service.login('admin', 'password').subscribe();
+
+      expect(mockRpcService.request).toHaveBeenCalledWith('Session', 'login', {
+        username: 'admin',
+        password: 'password'
+      });
+    });
+  });
+
+  describe('verifyTotp()', () => {
+    it('should store session after successful TOTP verification', (done) => {
+      mockRpcService.request.mockReturnValue(of(sessionDataMfaComplete));
+
+      service.verifyTotp('123456').subscribe((res) => {
+        expect(res.authenticated).toBe(true);
+        expect(mockAuthSessionService.set).toHaveBeenCalledWith('admin', { role: 'admin' });
+        done();
+      });
+    });
+
+    it('should call the correct RPC method with the TOTP code', () => {
+      mockRpcService.request.mockReturnValue(of(sessionDataMfaComplete));
+
+      service.verifyTotp('654321').subscribe();
+
+      expect(mockRpcService.request).toHaveBeenCalledWith('Session', 'verifyTotp', {
+        code: '654321'
+      });
+    });
+
+    it('should propagate RPC errors on invalid TOTP code', (done) => {
+      mockRpcService.request.mockReturnValue(
+        throwError(() => ({ error: { message: 'Invalid verification code.' } }))
+      );
+
+      service.verifyTotp('000000').subscribe({
+        error: (err) => {
+          expect(mockAuthSessionService.set).not.toHaveBeenCalled();
+          expect(err).toBeTruthy();
+          done();
+        }
+      });
+    });
   });
 });

--- a/deb/openmediavault/workbench/src/app/shared/services/auth.service.ts
+++ b/deb/openmediavault/workbench/src/app/shared/services/auth.service.ts
@@ -26,23 +26,11 @@ import { RpcService } from '~/app/shared/services/rpc.service';
 
 export type SessionData = {
   authenticated: boolean;
+  /** True when the password was accepted but a TOTP code is still required. */
+  mfaRequired?: boolean;
   permissions: { [key: string]: any };
-  sessionid: string;
-  username: string;
-};
-
-export type ChallengeInfo = {
-  [key: string]: any;
-  kind: string;
-  redirecturl?: string;
-};
-
-export type AuthenticateResponse = {
-  status: 'authenticated' | 'challengeRequired';
   username: string;
   sessionid?: string;
-  permissions?: { [key: string]: any };
-  challenge?: ChallengeInfo;
 };
 
 @Injectable({
@@ -55,41 +43,33 @@ export class AuthService {
     private prefersColorSchemeService: PrefersColorSchemeService
   ) {}
 
-  /**
-   * Step 1 of 2-step login: Authenticate with username/password.
-   * May return a challenge (e.g., MFA) that needs verification.
-   */
-  authenticate(username: string, password: string): Observable<AuthenticateResponse> {
-    return this.rpcService
-      .request('Session', 'authenticate', {
-        username,
-        password
+  login(username: string, password: string): Observable<SessionData> {
+    return this.rpcService.request('Session', 'login', { username, password }).pipe(
+      tap((res: SessionData) => {
+        // Only store the session when authentication is fully complete.
+        // When mfaRequired is true the session is pending TOTP verification
+        // and must not be considered authenticated yet.
+        if (res.authenticated) {
+          this.authSessionService.set(res.username, res.permissions);
+        }
       })
-      .pipe(
-        tap((res: AuthenticateResponse) => {
-          // If no challenge is required, the session is fully established here.
-          if (res.status === 'authenticated') {
-            this.authSessionService.set(res.username, res.permissions);
-          }
-        })
-      );
+    );
   }
 
   /**
-   * Step 2 of 2-step login: Verify the challenge response and complete the
-   * login. The in-progress login is identified by the session cookie that
-   * was set during authenticate(), so no token needs to be passed.
+   * Complete the second step of login for users with TOTP MFA enabled.
+   * Must be called after login() returns mfaRequired=true.
+   *
+   * @param code The 6-digit code from the user's authenticator app.
    */
-  verify(challengeresponse?: any): Observable<SessionData> {
-    return this.rpcService
-      .request('Session', 'verify', {
-        challengeresponse
-      })
-      .pipe(
-        tap((res: SessionData) => {
+  verifyTotp(code: string): Observable<SessionData> {
+    return this.rpcService.request('Session', 'verifyTotp', { code }).pipe(
+      tap((res: SessionData) => {
+        if (res.authenticated) {
           this.authSessionService.set(res.username, res.permissions);
-        })
-      );
+        }
+      })
+    );
   }
 
   logout(): Observable<void> {

--- a/deb/openmediavault/workbench/src/app/testing.module.ts
+++ b/deb/openmediavault/workbench/src/app/testing.module.ts
@@ -25,7 +25,7 @@ export class TestingTranslocoMissingHandler implements TranslocoMissingHandler {
     TranslocoTestingModule,
     ToastrModule.forRoot()
   ],
-  exports: [RouterTestingModule],
+  exports: [RouterTestingModule, TranslocoTestingModule],
   providers: [
     // Disable sanity checks to prevent warning messages in unit tests.
     // https://github.com/thymikee/jest-preset-angular/issues/83


### PR DESCRIPTION
Implement optional RFC 6238 time-based one-time passwords (TOTP) as second factor authentication

Implements RFC 6238 time-based one-time passwords as an optional second factor for all user accounts, including admin. Compatible with Google Authenticator, Authy, Microsoft Authenticator, 1Password, and other standard TOTP apps.

- Pure PHP TOTP implementation with no Composer dependencies
- Separate configuration model so MFA can be enabled per-user including admin accounts
- Provisional secret is only persisted after successful user verification
- Disabling MFA requires current valid TOTP code to prevent stolen-session abuse
- QR code generation is handled entirely in the browser; secret never leaves server-side
- Session enters `mfa_pending` state between login steps with 5-attempt brute-force limit before invalidation
- 489/489 unit tests passing

Fixes: https://github.com/openmediavault/openmediavault/issues/2200

Signed-off-by: Allan Barcelos <allan@barcelos.dev>