### PR TITLE
feat: add env vars to for postfix tls settings

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,8 @@
 openmediavault (8.2.14-1) stable; urgency=medium
 
-  *
+  * Add the environment variables `OMV_POSTFIX_MAIN_SMTP_TLS_SERVERNAME`
+    and `OMV_POSTFIX_MAIN_SMTP_TLS_POLICY_MAPS` to the customize the postfix
+    configuration.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Thu, 14 May 2026 21:14:27 +0200
 

--- a/deb/openmediavault/srv/salt/omv/deploy/postfix/files/main.cf.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/postfix/files/main.cf.j2
@@ -59,7 +59,7 @@ smtp_tls_security_level = {{ smtp_tls_security_level }}
 smtp_tls_CAfile = {{ smtp_tls_CAfile }}
 smtp_tls_CApath = {{ smtp_tls_CApath }}
 smtp_tls_servername = {{ smtp_tls_servername }}
-smtp_tls_policy_maps = hash:{{ smtp_tls_policy_maps }}
+smtp_tls_policy_maps = {{ smtp_tls_policy_maps }}
 {%- endif %}
 smtp_header_checks = regexp:{{ smtp_header_checks }}
 alias_maps = {{ alias_maps }}

--- a/deb/openmediavault/srv/salt/omv/deploy/postfix/files/main.cf.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/postfix/files/main.cf.j2
@@ -13,6 +13,8 @@
 {%- set smtp_tls_security_level = salt['pillar.get']('default:OMV_POSTFIX_MAIN_SMTP_TLS_SECURITY_LEVEL', 'encrypt') -%}
 {%- set smtp_tls_CAfile = salt['pillar.get']('default:OMV_POSTFIX_MAIN_SMTP_TLS_CAFILE', '/etc/ssl/certs/ca-certificates.crt') -%}
 {%- set smtp_tls_CApath = salt['pillar.get']('default:OMV_POSTFIX_MAIN_SMTP_TLS_CAPATH', '/etc/ssl/certs') -%}
+{%- set smtp_tls_servername = salt['pillar.get']('default:OMV_POSTFIX_MAIN_SMTP_TLS_SERVERNAME', '') -%}
+{%- set smtp_tls_policy_maps = salt['pillar.get']('default:OMV_POSTFIX_MAIN_SMTP_TLS_POLICY_MAPS', '') -%}
 {%- set smtp_header_checks = salt['pillar.get']('default:OMV_POSTFIX_MAIN_SMTP_HEADER_CHECKS', '/etc/postfix/smtp_header_checks') -%}
 {%- set alias_maps = salt['pillar.get']('default:OMV_POSTFIX_MAIN_ALIAS_MAPS', 'hash:/etc/aliases') -%}
 {%- set transport_maps = salt['pillar.get']('default:OMV_POSTFIX_MAIN_TRANSPORT_MAPS', 'hash:/etc/postfix/transport') -%}
@@ -56,6 +58,8 @@ smtp_tls_wrappermode = {{ smtp_tls_wrappermode }}
 smtp_tls_security_level = {{ smtp_tls_security_level }}
 smtp_tls_CAfile = {{ smtp_tls_CAfile }}
 smtp_tls_CApath = {{ smtp_tls_CApath }}
+smtp_tls_servername = {{ smtp_tls_servername }}
+smtp_tls_policy_maps = hash:{{ smtp_tls_policy_maps }}
 {%- endif %}
 smtp_header_checks = regexp:{{ smtp_header_checks }}
 alias_maps = {{ alias_maps }}


### PR DESCRIPTION
This PR adds two env vars to configure the `smtp_tls_servername` and `smtp_tls_policy_maps` setting in the postfix `main.cf` file. Some mail servers require an SNI in the request to provide appropriate certificate chains, and this PR enables configuring that value.

`smtp_tls_servername` configures this globally, and `smtp_tls_policy_maps` allows specifying a file to configure the SNI and several other settings per domain.

Docs: 
- https://www.postfix.org/postconf.5.html#smtp_tls_servername
- https://www.postfix.org/postconf.5.html#smtp_tls_policy_maps

Addresses https://forum.openmediavault.org/index.php?thread/59046-how-to-set-smtp-tls-servername-nexthop-for-postfix-email-notifications/

<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
