### PR TITLE
Improve Avahi IPv4/IPv6 mode detection and publish flags

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,6 @@
 openmediavault (8.3.1-1) stable; urgency=medium
 
-  *
+  * Improve Avahi IPv4/IPv6 mode detection and publish flags.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Wed, 27 May 2026 20:33:05 +0200
 

--- a/deb/openmediavault/debian/openmediavault.postinst
+++ b/deb/openmediavault/debian/openmediavault.postinst
@@ -676,6 +676,9 @@ case "$1" in
 		if dpkg --compare-versions "$2" lt-nl "8.2.13"; then
 			omv_module_set_dirty nginx
 		fi
+		if dpkg --compare-versions "$2" lt-nl "8.3.1"; then
+			omv_module_set_dirty avahi
+		fi
 
 		########################################################################
 		# Trigger the restart of the omv-engined daemon to load and use the

--- a/deb/openmediavault/srv/salt/omv/deploy/avahi/files/etc-avahi-avahi-daemon_conf.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/avahi/files/etc-avahi-avahi-daemon_conf.j2
@@ -1,23 +1,25 @@
-{%- set use_ipv4 = salt['pillar.get']('default:OMV_AVAHIDAEMON_USE_IPV4', 'yes') -%}
-{%- set use_ipv6 = salt['pillar.get']('default:OMV_AVAHIDAEMON_USE_IPV6', 'yes') -%}
 {%- set allow_interfaces = salt['pillar.get']('default:OMV_AVAHIDAEMON_ALLOW_INTERFACES', '') -%}
 {%- set allow_point_to_point = salt['pillar.get']('default:OMV_AVAHIDAEMON_ALLOW_POINT_TO_POINT', 'no') -%}
 {%- set enable_reflector = salt['pillar.get']('default:OMV_AVAHIDAEMON_ENABLE_REFLECTOR', 'no') -%}
 {%- set rlimit_nproc = salt['pillar.get']('default:OMV_AVAHIDAEMON_RLIMIT_NPROC', '3') -%}
 {%- set publish_hinfo = salt['pillar.get']('default:OMV_AVAHIDAEMON_PUBLISH_HINFO', 'no') -%}
 {%- set publish_workstation = salt['pillar.get']('default:OMV_AVAHIDAEMON_PUBLISH_WORKSTATION', 'no') -%}
+{%- set interfaces = salt['omv_conf.get_by_filter']('conf.system.network.interface', {'operator': 'stringEnum', 'arg0': 'type', 'arg1': ['ethernet', 'bond', 'bridge', 'wifi']}) -%}
+{%- set ipv4_interfaces = interfaces | selectattr('method', 'in', ['dhcp', 'static']) | list -%}
+{%- set ipv6_interfaces = interfaces | selectattr('method6', 'in', ['auto', 'dhcp', 'static']) | list -%}
+{%- set ipv4_enabled = ipv4_interfaces | length > 0 -%}
+{%- set ipv6_enabled = ipv6_interfaces | length > 0 -%}
+{%- set dual_stack_enabled = ipv4_enabled and ipv6_enabled -%}
 {%- if allow_interfaces | length == 0 %}
-{%- set allow_interfaces = salt['omv_conf.get_by_filter']('conf.system.network.interface',
-  {'operator': 'and', 'arg0': {'operator': 'stringEnum', 'arg0': 'type', 'arg1': ['ethernet', 'bond', 'bridge', 'wifi']}, 'arg1': {'operator': 'or', 'arg0': {'operator': 'stringNotEquals', 'arg0': 'method', 'arg1': 'manual'}, 'arg1': {'operator': 'stringNotEquals', 'arg0': 'method6', 'arg1': 'manual'}}}) |
-  map(attribute='devicename') | join(',') -%}
+{%- set allow_interfaces = (ipv4_interfaces + ipv6_interfaces) | map(attribute='devicename') | join(',') -%}
 {%- endif %}
 {{ pillar['headers']['multiline'] }}
 [server]
 #host-name=foo
 #domain-name=local
 #browse-domains=0pointer.de, zeroconf.org
-use-ipv4={{ use_ipv4 }}
-use-ipv6={{ use_ipv6 }}
+use-ipv4={{ ipv4_enabled | yesno }}
+use-ipv6={{ ipv6_enabled | yesno }}
 {%- if allow_interfaces | length > 0 %}
 allow-interfaces={{ allow_interfaces }}
 {%- else %}
@@ -49,8 +51,8 @@ publish-workstation={{ publish_workstation }}
 #publish-domain=yes
 #publish-dns-servers=192.168.50.1, 192.168.50.2
 #publish-resolv-conf-dns-servers=yes
-#publish-aaaa-on-ipv4=yes
-#publish-a-on-ipv6=no
+publish-aaaa-on-ipv4={{ dual_stack_enabled | yesno }}
+publish-a-on-ipv6={{ dual_stack_enabled | yesno }}
 
 [reflector]
 enable-reflector={{ enable_reflector }}


### PR DESCRIPTION
Refactored Avahi network mode handling to derive IPv4/IPv6 availability from configured network interfaces more reliably. The template now uses explicit method-based filtering for IPv4 (`dhcp`, `static`) and IPv6 (`auto`, `dhcp`, `static`), computes dual-stack state explicitly, and applies it consistently to `use-ipv4`, `use-ipv6`, `publish-aaaa-on-ipv4`, and `publish-a-on-ipv6`.


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
