### PR TITLE
Add caching functionality

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -2,6 +2,8 @@ openmediavault (8.3.1-1) stable; urgency=medium
 
   * Update i18n files.
   * Improve Avahi IPv4/IPv6 mode detection and publish flags.
+  * Improve storage and filesystem performance in the PHP backend by
+    introducing TTL-based caches.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Wed, 27 May 2026 20:33:05 +0200
 

--- a/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/filesystem.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/filesystem.inc
@@ -957,7 +957,8 @@ class Filesystem extends \OMV\System\BlockDevice implements FilesystemInterface,
 
     /**
      * Get the object of the class which implements the file system
-     * for the given type.
+     * for the given type. Results are cached for the given TTL to avoid
+     * repeated subprocess calls on the same filesystem object.
      * @param string $type The file system type, e.g. 'btrfs' or 'ext4'.
      * @param string $id The UUID or device path of the filesystem, e.g.
      *   <ul>
@@ -965,39 +966,59 @@ class Filesystem extends \OMV\System\BlockDevice implements FilesystemInterface,
      *   \li /dev/sde1
      *   \li /dev/disk/by-id/scsi-SATA_ST3200XXXX2AS_5XWXXXR6-part1
      *   </ul>
+     * @param int $ttl Cache lifetime in seconds. Defaults to 5.
      * @return The class object (which implements the interface
      *   OMV\System\Filesystem\FilesystemInterface), otherwise NULL.
      */
-    public static function getImplByType($type, $id)
+    public static function getImplByType($type, $id, int $ttl = 5)
     {
+        static $caches = [];
+        if (!isset($caches[$ttl])) {
+            $caches[$ttl] = new \OMV\Util\TtlCache($ttl);
+        }
+        $cache = $caches[$ttl];
         $mngr = Backend\Manager::getInstance();
         if (null == ($backend = $mngr->getBackendByType($type))) {
             return null;
         }
-        return $backend->getImpl($id);
+        $key = sprintf("%s:%s", $type, $id);
+        if ($cache->has($key)) {
+            return $cache->get($key);
+        }
+        return $cache->set($key, $backend->getImpl($id));
     }
 
     /**
      * Get the object of the class which implements the filesystem
-     * for the given mount point.
+     * for the given mount point. Results are cached for the given TTL
+     * to avoid repeated subprocess calls for the same mount point.
      * @param dir The file system path prefix, e.g. '/home/ftp/data'.
+     * @param int $ttl Cache lifetime in seconds. Defaults to 5.
      * @return The class object (which implements the interface
      *   OMV\System\Filesystem\FilesystemInterface) or NULL on failure.
      */
-    public static function getImplByMountPoint($dir)
+    public static function getImplByMountPoint($dir, int $ttl = 5)
     {
+        static $caches = [];
+        if (!isset($caches[$ttl])) {
+            $caches[$ttl] = new \OMV\Util\TtlCache($ttl);
+        }
+        $cache = $caches[$ttl];
         if (true === empty($dir)) {
             return null;
+        }
+        if ($cache->has($dir)) {
+            return $cache->get($dir);
         }
         // Exit immediately if the specified directory is no mount point.
         $mp = new \OMV\System\MountPoint($dir);
         if (false === $mp->isMountPoint()) {
-            return null;
+            return $cache->set($dir, null);
         }
         // Try to get the backend using the filesystem type. This has
         // to be done especially when using union filesystems.
         $info = $mp->getInfo();
-        return self::getImplByType($info['fstype'], $info['source']);
+        return $cache->set($dir, self::getImplByType($info['fstype'], $info['source'], $ttl));
     }
 
     /**

--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevice.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevice.inc
@@ -650,20 +650,29 @@ class StorageDevice extends \OMV\System\BlockDevice implements StorageDeviceInte
      *   \li /dev/disk/by-path/pci-0000:00:10.0-scsi-0:0:0:0
      *   \li /dev/disk/by-uuid/ad3ee177-777c-4ad3-8353-9562f85c0895
      *   </ul>
+     * @param int ttl Cache lifetime in seconds. Defaults to 5.
      * @return object|null The object of the class implementing the given
      *   storage device, otherwise NULL.
      */
-    public static function getStorageDevice($deviceFile)
+    public static function getStorageDevice($deviceFile, int $ttl = 5)
     {
+        static $caches = [];
+        if (!isset($caches[$ttl])) {
+            $caches[$ttl] = new \OMV\Util\TtlCache($ttl);
+        }
+        $cache = $caches[$ttl];
+        if ($cache->has($deviceFile)) {
+            return $cache->get($deviceFile);
+        }
         $mngr = Backend\Manager::getInstance();
         if (null == ($backend = $mngr->getBackend($deviceFile))) {
             return null;
         }
         $result = $backend->getImpl($deviceFile);
         if (is_null($result) || !$result->exists()) {
-            return null;
+            $result = null;
         }
-        return $result;
+        return $cache->set($deviceFile, $result);
     }
 
     /**

--- a/deb/openmediavault/usr/share/php/openmediavault/util/ttlcache.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/util/ttlcache.inc
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * This file is part of OpenMediaVault.
+ *
+ * @license   https://www.gnu.org/licenses/gpl.html GPL Version 3
+ * @author    Volker Theile <volker.theile@openmediavault.org>
+ * @copyright Copyright (c) 2009-2026 Volker Theile
+ *
+ * OpenMediaVault is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * OpenMediaVault is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenMediaVault. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace OMV\Util;
+
+/**
+ * A simple TTL-based in-memory cache.
+ * @ingroup api
+ */
+class TtlCache
+{
+    private array $data = [];
+    private int $ttl;
+
+    /**
+     * Constructor.
+     * @param int $ttl Cache lifetime in seconds.
+     */
+    public function __construct(int $ttl)
+    {
+        $this->ttl = $ttl;
+    }
+
+    /**
+     * Check whether the cache contains a valid (non-expired) entry for
+     * the given key.
+     * @param string $key The cache key.
+     * @return bool TRUE if a valid entry exists, otherwise FALSE.
+     */
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $this->data)
+            && $this->data[$key]['expires'] > time();
+    }
+
+    /**
+     * Get the cached value for the given key.
+     * @param string $key The cache key.
+     * @return mixed The cached value, or NULL if the key does not exist
+     *   or has expired.
+     */
+    public function get(string $key)
+    {
+        if (!$this->has($key)) {
+            return null;
+        }
+        return $this->data[$key]['value'];
+    }
+
+    /**
+     * Store a value in the cache under the given key. Expired entries
+     * are purged automatically on every write to keep memory usage low.
+     * @param string $key The cache key.
+     * @param mixed $value The value to cache.
+     * @return mixed The cached value.
+     */
+    public function set(string $key, $value)
+    {
+        // Purge expired entries before adding a new one.
+        $now = time();
+        foreach ($this->data as $k => $entry) {
+            if ($entry['expires'] <= $now) {
+                $this->remove($k);
+            }
+        }
+        $this->data[$key] = [
+            'value'   => $value,
+            'expires' => $now + $this->ttl,
+        ];
+        return $value;
+    }
+
+    /**
+     * Remove a single entry from the cache.
+     * @param string $key The cache key.
+     * @return void
+     */
+    public function remove(string $key): void
+    {
+        unset($this->data[$key]);
+    }
+
+    /**
+     * Remove all entries from the cache.
+     * @return void
+     */
+    public function clear(): void
+    {
+        $this->data = [];
+    }
+}


### PR DESCRIPTION
A simple caching system will be implemented that is NOT cross-process (too complicated to implement). Since every RPC is executed as a separate process anyway (omv-engined is a forking daemon), a simple solution will suffice.

Here is the log output of listing 30 shared folders. 
Before:
```
RPC response (service=ShareMgmt, method=getList, time=1258ms): {"response":{"total":30,"data":
```
After:
```
RPC response (service=ShareMgmt, method=getList, time=211ms): {"response":{"total":30,"data":
```

<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
