### PR TITLE
restart monit if monit reload fails

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/monit/95start.sls
+++ b/deb/openmediavault/srv/salt/omv/deploy/monit/95start.sls
@@ -29,3 +29,10 @@ reload_monit_service:
     - watch:
       - file: "/etc/monit/monitrc"
       - file: "/etc/monit/conf.d/openmediavault-*.conf"
+
+# If the reload fails (e.g. monit is in a stale state), restart instead.
+restart_monit_service:
+  service.running:
+    - name: monit
+    - onfail:
+      - service: reload_monit_service


### PR DESCRIPTION
We have been seeing quite a few problems with monit failing to reload lately.  I have even seen this on my own systems.  monit is in a stale state and a reload does not clear the stale file(s) in /var/tmp.  Doing a monit restart fixes the issue in every case I have seen.

salt will try to reload monit unit and if it fails, it will restart the unit.