### PR TITLE
Add UPS dashboard widgets (Network UPS Tools)

### DIFF
--- a/deb/openmediavault-nut/debian/changelog
+++ b/deb/openmediavault-nut/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-nut (8.0.4-1) stable; urgency=medium
+
+  * Issue #1612: Add dashboard widgets.
+
+ -- Volker Theile <volker.theile@openmediavault.org>  Fri, 24 Jul 2026 10:34:28 +0200
+
 openmediavault-nut (8.0.3-1) stable; urgency=medium
 
   * Upgrade to SaltStack 3008.

--- a/deb/openmediavault-nut/debian/control
+++ b/deb/openmediavault-nut/debian/control
@@ -9,7 +9,7 @@ Homepage: https://www.openmediavault.org
 
 Package: openmediavault-nut
 Architecture: all
-Depends: openmediavault (>= 8.4.0), nut, udev
+Depends: openmediavault (>= 8.5.5), nut, udev
 Priority: optional
 Description: openmediavault Network UPS Tools (NUT) plugin
  Network UPS Tools (NUT) is a client/server monitoring system that

--- a/deb/openmediavault-nut/usr/share/openmediavault/engined/rpc/nut.inc
+++ b/deb/openmediavault-nut/usr/share/openmediavault/engined/rpc/nut.inc
@@ -20,24 +20,24 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenMediaVault. If not, see <https://www.gnu.org/licenses/>.
  */
+
+namespace Engined\Rpc;
+
+require_once("openmediavault/functions.inc");
+
 class OMVRpcServiceNetworkUPSTools extends \OMV\Rpc\ServiceAbstract
 {
-    /**
-     * Get the RPC service name.
-     */
     public function getName()
     {
         return "Nut";
     }
 
-    /**
-     * Initialize the RPC service.
-     */
     public function initialize()
     {
         $this->registerMethod("get");
         $this->registerMethod("set");
         $this->registerMethod("getStats");
+        $this->registerMethod("getVariables");
     }
 
     /**
@@ -94,25 +94,96 @@ class OMVRpcServiceNetworkUPSTools extends \OMV\Rpc\ServiceAbstract
         $this->validateMethodContext($context, [
             "role" => OMV_ROLE_ADMINISTRATOR
         ]);
-        // Is service enabled?
         $db = \OMV\Config\Database::getInstance();
         $object = $db->get("conf.service.nut");
         if (false === $object->get("enable")) {
-            $stats = gettext("Service disabled");
-        } else {
-            $mode = $object->get("mode");
-            $cmdArgs = [];
-            if ("netclient" === $mode) {
-                $remoteUps = $object->get("upsname")."@".$object->get("netclienthostname");
-                $cmdArgs[] = escapeshellarg($remoteUps);
-            } else {
-                $cmdArgs[] = escapeshellarg($object->get("upsname"));
-            }
-            $cmd = new \OMV\System\Process("upsc", $cmdArgs);
-            $cmd->setRedirect2to1();
-            $cmd->execute($output);
-            $stats = implode("\n", $output);
+            return gettext("Service disabled");
         }
-        return $stats;
+        return implode("\n", $this->getUpscOutput($object));
+    }
+
+    /**
+     * Get the UPS variables as a flat "key => value" object for the
+     * dashboard widgets. Both the battery gauge and the information grid
+     * consume this single method; the grid maps it to rows via the
+     * widget's "itemTemplates", the gauge reads the charge props.
+     *
+     * Variable names have their dots replaced by underscores so they can
+     * be referenced in widget templates (e.g. "battery.charge" becomes
+     * "battery_charge"). Numeric values are cast to numbers; duration
+     * variables (e.g. "battery.runtime") stay as raw seconds and are
+     * formatted in the widget template via the "duration" filter.
+     *
+     * @param params The method parameters.
+     * @param context The context of the caller.
+     * @return An associative array of UPS variables. "battery_charge" and
+     *   "battery_charge_low" are always present as numbers (the gauge
+     *   needs them), defaulting to 0 when the service is disabled or the
+     *   UPS does not report them.
+     */
+    public function getVariables($params, $context)
+    {
+        $this->validateMethodContext($context, [
+            "role" => OMV_ROLE_ADMINISTRATOR
+        ]);
+        // The gauge always needs these as numbers; default to 0 when the
+        // service is disabled or the UPS does not report them.
+        $result = ["battery_charge" => 0, "battery_charge_low" => 0];
+        $db = \OMV\Config\Database::getInstance();
+        $object = $db->get("conf.service.nut");
+        if (false === $object->get("enable")) {
+            return $result;
+        }
+        $vars = $this->parseVars($this->getUpscOutput($object));
+        foreach ($vars as $key => $value) {
+            $result[str_replace(".", "_", $key)] = is_numeric($value) ? $value + 0 : $value;
+        }
+        return $result;
+    }
+
+    /**
+     * Run "upsc" for the configured UPS and return its output lines.
+     * @param object The "conf.service.nut" configuration object.
+     * @return An array containing the lines of the "upsc" output.
+     */
+    private function getUpscOutput($object)
+    {
+        $cmdArgs = [];
+        if ("netclient" === $object->get("mode")) {
+            $remoteUps = $object->get("upsname")."@".$object->get("netclienthostname");
+            $cmdArgs[] = escapeshellarg($remoteUps);
+        } else {
+            $cmdArgs[] = escapeshellarg($object->get("upsname"));
+        }
+        $cmd = new \OMV\System\Process("upsc", $cmdArgs);
+        $cmd->setRedirect2to1();
+        $cmd->setRequireOutput();
+        $cmd->execute($output);
+        return $output;
+    }
+
+    /**
+     * Parse "upsc" output into a "key => value" map. Lines without a
+     * ": " separator (e.g. the "Init SSL" notice) and lines whose key
+     * is not a lowercase variable name (e.g. upsd "Error:" messages)
+     * are ignored.
+     * @param output The "upsc" output lines.
+     * @return An associative array mapping variable names to values.
+     */
+    private function parseVars($output)
+    {
+        $vars = [];
+        foreach ($output as $line) {
+            $parts = explode(": ", $line, 2);
+            if (2 !== count($parts)) {
+                continue;
+            }
+            $key = trim($parts[0]);
+            if (!preg_match('/^[a-z][a-z0-9._]*$/', $key)) {
+                continue;
+            }
+            $vars[$key] = trim($parts[1]);
+        }
+        return $vars;
     }
 }

--- a/deb/openmediavault-nut/usr/share/openmediavault/workbench/dashboard.d/nut-battery.yaml
+++ b/deb/openmediavault-nut/usr/share/openmediavault/workbench/dashboard.d/nut-battery.yaml
@@ -1,0 +1,30 @@
+version: "1.0"
+type: dashboard-widget
+data:
+  id: 16b7007d-1585-4920-8893-073af0e3356c
+  permissions:
+    role:
+      - admin
+  title: _("UPS Battery")
+  description: _("Battery charge with the low-battery shutdown threshold marked.")
+  type: chart
+  reloadPeriod: 30000
+  chart:
+    type: advanced-gauge
+    maxHeight: "150px"
+    maxWidth: "150px"
+    min: 0
+    max: 100
+    request:
+      service: Nut
+      method: getVariables
+    label:
+      formatter: template
+      formatterConfig: "{{ value | tofixed(0) }}%"
+    dataConfig:
+      - label: _("Charge")
+        prop: battery_charge
+        backgroundColor: "#4cd964"
+      - label: _("Low")
+        prop: battery_charge_low
+        backgroundColor: "#ff3b30"

--- a/deb/openmediavault-nut/usr/share/openmediavault/workbench/dashboard.d/nut-info.yaml
+++ b/deb/openmediavault-nut/usr/share/openmediavault/workbench/dashboard.d/nut-info.yaml
@@ -1,0 +1,50 @@
+version: "1.0"
+type: dashboard-widget
+data:
+  id: c812d727-6579-4e03-b2c1-756d93786664
+  permissions:
+    role:
+      - admin
+  title: _("UPS Information")
+  description: _("UPS device and battery information.")
+  type: grid
+  reloadPeriod: 30000
+  grid:
+    class: "omv-grid-cols-3"
+    item:
+      title: "{{ key }}"
+      content: "{{ value }}"
+      contentClass: "omv-text-wrap"
+    store:
+      proxy:
+        service: Nut
+        get:
+          method: getVariables
+      # The single RPC returns a flat key/value object; map it to the
+      # displayed rows here. Reorder/extend freely. Variables the UPS
+      # does not report render as "N/A" via the `notavailable` filter.
+      itemTemplates:
+        - key: _("Manufacturer")
+          value: "{{ device_mfr | notavailable }}"
+        - key: _("Model")
+          value: "{{ device_model | notavailable }}"
+        - key: _("Battery type")
+          value: "{{ battery_type | notavailable }}"
+        - key: _("Status")
+          value: "{{ ups_status | notavailable }}"
+        - key: _("Input voltage")
+          value: "{{ input_voltage | notavailable }} V"
+        - key: _("Load")
+          value: "{{ ups_load | notavailable }} %"
+        - key: _("Battery voltage")
+          value: "{{ battery_voltage | notavailable }} V"
+        - key: _("Runtime")
+          value: "{{ battery_runtime | duration('mmm[m]ss[s]') | notavailable }}"
+        - key: _("Battery date")
+          value: "{{ battery_mfr_date | notavailable }}"
+        - key: _("Battery low")
+          value: "{{ battery_charge_low | notavailable }} %"
+        - key: _("Charge warning")
+          value: "{{ battery_charge_warning | notavailable }} %"
+        - key: _("Runtime low")
+          value: "{{ battery_runtime_low | duration('mmm[m]ss[s]') | notavailable }}"


### PR DESCRIPTION
## Summary
Adds two dashboard widgets to the Network UPS Tools plugin:
- **UPS Information** — a grid of device/battery details.
- **UPS Battery** — a gauge of battery charge with the low-battery shutdown threshold marked.

Backed by two new RPC methods, `Nut.getBatteryStats` (a parsed `battery.*` object for the gauge) and `Nut.getInformation` (curated `[{key, value}]` rows for the grid), which share private `upsc` fetch/parse helpers. `Nut.getStats` is unchanged for callers — it still returns the raw output used by the NUT diagnostics page.

Implements the status-display request in #1612. The command-button idea mentioned there is out of scope for this PR.

## Screenshots
<img width="2389" height="1246" alt="OMV Dashboard - Widgets preview" src="https://github.com/user-attachments/assets/fc24d1df-f4c7-4b87-923d-904ec36773b6" />
<img width="2389" height="1246" alt="OMV Diagnostics/Services/UPS - upsc text blob still working" src="https://github.com/user-attachments/assets/7f2e64d2-6cb6-48a0-bdfe-3696b96b09d5" />


## Testing
Manually verified on OMV 7.7.24-7 (Sandworm) against a real UPS: both widgets render after restarting `openmediavault-engined` and running `omv-mkworkbench dashboard`. No PHPUnit tests — dashboard widgets across the repo ship without them, and the RPC shells out to `upsc`.

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug