### PR TITLE
Add quotes around OMV_MDMGMT_ALLOW_USB_DEVICES constant

### DIFF
--- a/deb/openmediavault-md/usr/share/openmediavault/engined/rpc/mdmgmt.inc
+++ b/deb/openmediavault-md/usr/share/openmediavault/engined/rpc/mdmgmt.inc
@@ -255,7 +255,7 @@ class MdMgmt extends \OMV\Rpc\ServiceAbstract
             }
             // Skip devices that are connected via USB.
             if ((true === $sd->isUsb()) && !\OMV\Environment::getBoolean(
-                OMV_MDMGMT_ALLOW_USB_DEVICES,
+                "OMV_MDMGMT_ALLOW_USB_DEVICES",
                 false
             )) {
                 continue;


### PR DESCRIPTION
- [x] References issue
- [x] Includes tests for new functionality or reproducer for bug

This PR fixes issue #2238 - Undefined constant error in openmediavault-md 8.1.2-1.

The constant name `OMV_MDMGMT_ALLOW_USB_DEVICES` needs to be passed as a string to 
`OMV\Environment::getBoolean()` for proper environment variable lookup.

**File changed:**
- `deb/openmediavault-md/usr/share/openmediavault/engined/rpc/mdmgmt.inc` (line 258)

**Change:**
- From: `OMV_MDMGMT_ALLOW_USB_DEVICES,`
- To: `"OMV_MDMGMT_ALLOW_USB_DEVICES",`