### PR TITLE
Issue #2106: Do not offer non-empty disks as file system candidates

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,7 @@
 openmediavault (8.5.2-1) stable; urgency=medium
 
-  *
+  * Issue #2106: Do not offer non-empty storage devices as file system
+    candidates. Thanks to John O'Callaghan for the contribution.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Thu, 09 Jul 2026 07:18:18 +0200
 

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/filesystemmgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/filesystemmgmt.inc
@@ -615,38 +615,47 @@ class OMVRpcServiceFileSystemMgmt extends \OMV\Rpc\ServiceAbstract
         // Prepare the result list.
         $result = [];
         foreach ($devs as $sd) {
-            /* Do not check for references, otherwise a device file which is configured
-               for S.M.A.R.T. monitoring is not added as a candidate.
-                        // Check if the device is referenced/used by a plugin.
-                        $db = \OMV\Config\Database::getInstance();
-                        if (TRUE === $db->exists("conf.service", [
-                              "operator" => "stringContains",
-                              "arg0" => "devicefile",
-                              "arg1" => $sd->getDeviceFile()
-                          ]))
-                            continue;
-            */
-            // Does this device already contain a file system?
-            if (in_array($sd->getCanonicalDeviceFile(), $usedDevs)) {
-                continue;
-            }
-            // Skip devices that are not empty, i.e. they still contain a
-            // partition table, a file system or a RAID/LVM/LUKS signature.
-            // This also covers signatures that are not reported by
-            // Filesystem::getFilesystems(), e.g. ZFS pool members. Such a
-            // device must be wiped before it can be reused. See issue #2106.
-            if ($sd->hasSignature()) {
-                continue;
-            }
-            // The device is a potential candidate to create a file system
-            // on it.
-            $result[] = [
-                "devicefile" => $sd->getDeviceFile(),
-                "size" => $sd->getSize(),
-                "description" => $sd->getDescription()
-            ];
+            $procs[] = $this->asyncProc(function () use ($sd, $usedDevs) {
+                /* Do not check for references, otherwise a device file which is configured
+                   for S.M.A.R.T. monitoring is not added as a candidate.
+                            // Check if the device is referenced/used by a plugin.
+                            $db = \OMV\Config\Database::getInstance();
+                            if (TRUE === $db->exists("conf.service", [
+                                  "operator" => "stringContains",
+                                  "arg0" => "devicefile",
+                                  "arg1" => $sd->getDeviceFile()
+                              ]))
+                                continue;
+                */
+                // Does this device already contain a file system?
+                if (in_array($sd->getCanonicalDeviceFile(), $usedDevs)) {
+                    return false;
+                }
+                // Skip devices that are not empty, i.e. they still contain a
+                // partition table, a file system or a RAID/LVM/LUKS signature.
+                // This also covers signatures that are not reported by
+                // Filesystem::getFilesystems(), e.g. ZFS pool members. Such a
+                // device must be wiped before it can be reused.
+                if ($sd->hasSignature()) {
+                    return false;
+                }
+                // The device is a potential candidate to create a file system
+                // on it.
+                return [
+                    "devicefile" => $sd->getDeviceFile(),
+                    "size" => $sd->getSize(),
+                    "description" => $sd->getDescription()
+                ];
+            });
         }
-        return $result;
+        // Remove items that are not eligible candidates (those items
+        // returned a boolean `false`).
+        return array_values(
+            array_filter(
+                $this->waitAsyncProcs($procs),
+                "is_assoc_array"
+            )
+        );
     }
 
     /**

--- a/deb/openmediavault/usr/share/openmediavault/engined/rpc/filesystemmgmt.inc
+++ b/deb/openmediavault/usr/share/openmediavault/engined/rpc/filesystemmgmt.inc
@@ -630,6 +630,14 @@ class OMVRpcServiceFileSystemMgmt extends \OMV\Rpc\ServiceAbstract
             if (in_array($sd->getCanonicalDeviceFile(), $usedDevs)) {
                 continue;
             }
+            // Skip devices that are not empty, i.e. they still contain a
+            // partition table, a file system or a RAID/LVM/LUKS signature.
+            // This also covers signatures that are not reported by
+            // Filesystem::getFilesystems(), e.g. ZFS pool members. Such a
+            // device must be wiped before it can be reused. See issue #2106.
+            if ($sd->hasSignature()) {
+                continue;
+            }
             // The device is a potential candidate to create a file system
             // on it.
             $result[] = [

--- a/deb/openmediavault/usr/share/openmediavault/workbench/component.d/omv-storage-filesystem-btrfs-create-form-page.yaml
+++ b/deb/openmediavault/usr/share/openmediavault/workbench/component.d/omv-storage-filesystem-btrfs-create-form-page.yaml
@@ -36,7 +36,7 @@ data:
         name: devicefiles
         label: _("Devices")
         placeholder: _("Select devices ...")
-        hint: _("Select the devices that will be used to create the file system. Only empty devices are listed; wipe a device to reuse it.")
+        hint: _("Select the devices that will be used to create the file system.")
         multiple: true
         valueField: devicefile
         textField: description

--- a/deb/openmediavault/usr/share/openmediavault/workbench/component.d/omv-storage-filesystem-btrfs-create-form-page.yaml
+++ b/deb/openmediavault/usr/share/openmediavault/workbench/component.d/omv-storage-filesystem-btrfs-create-form-page.yaml
@@ -6,7 +6,7 @@ data:
   config:
     hints:
       - type: info
-        text: _("If a device is not listed here, it is usually because the device already contains a file system or partitions. With the former, the file system can be mounted <a href='#/storage/filesystems/mount'>here</a>. For the latter, please <a href='#/storage/disks'>wipe</a> the device as partitions are not supported.")
+        text: _("If a device is not listed here, it is usually because the device is not empty, i.e. it already contains a file system, partitions or another signature such as a ZFS, LVM, Linux RAID or LUKS member. An existing file system can be mounted <a href='#/storage/filesystems/mount'>here</a>. Otherwise, please <a href='#/storage/disks'>wipe</a> the device to be able to reuse it.")
         dismissible: true
         stateId: 199e8c7a-ee3b-11ed-9fb1-2750842abc68
     fields:
@@ -36,7 +36,7 @@ data:
         name: devicefiles
         label: _("Devices")
         placeholder: _("Select devices ...")
-        hint: _("Select the devices that will be used to create the file system.")
+        hint: _("Select the devices that will be used to create the file system. Only empty devices are listed; wipe a device to reuse it.")
         multiple: true
         valueField: devicefile
         textField: description

--- a/deb/openmediavault/usr/share/openmediavault/workbench/component.d/omv-storage-filesystem-generic-create-form-page.yaml
+++ b/deb/openmediavault/usr/share/openmediavault/workbench/component.d/omv-storage-filesystem-generic-create-form-page.yaml
@@ -6,7 +6,7 @@ data:
   config:
     hints:
       - type: info
-        text: _("If a device is not listed here, it is usually because the device already contains a file system or partitions. With the former, the file system can be mounted <a href='#/storage/filesystems/mount'>here</a>. For the latter, please <a href='#/storage/disks'>wipe</a> the device as partitions are not supported.")
+        text: _("If a device is not listed here, it is usually because the device is not empty, i.e. it already contains a file system, partitions or another signature such as a ZFS, LVM, Linux RAID or LUKS member. An existing file system can be mounted <a href='#/storage/filesystems/mount'>here</a>. Otherwise, please <a href='#/storage/disks'>wipe</a> the device to be able to reuse it.")
         dismissible: true
         stateId: 199e8c7a-ee3b-11ed-9fb1-2750842abc68
     fields:
@@ -20,7 +20,7 @@ data:
         name: devicefile
         label: _("Device")
         placeholder: _("Select a device ...")
-        hint: _("Select the device that will be used to create the file system.")
+        hint: _("Select the device that will be used to create the file system. Only empty devices are listed; wipe a device to reuse it.")
         valueField: devicefile
         textField: description
         store:

--- a/deb/openmediavault/usr/share/openmediavault/workbench/component.d/omv-storage-filesystem-generic-create-form-page.yaml
+++ b/deb/openmediavault/usr/share/openmediavault/workbench/component.d/omv-storage-filesystem-generic-create-form-page.yaml
@@ -20,7 +20,7 @@ data:
         name: devicefile
         label: _("Device")
         placeholder: _("Select a device ...")
-        hint: _("Select the device that will be used to create the file system. Only empty devices are listed; wipe a device to reuse it.")
+        hint: _("Select the device that will be used to create the file system.")
         valueField: devicefile
         textField: description
         store:

--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevice.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevice.inc
@@ -305,6 +305,34 @@ class StorageDevice extends \OMV\System\BlockDevice implements StorageDeviceInte
     }
 
     /**
+     * Check whether the device still contains any signature, e.g. a
+     * partition table, a file system or a RAID/LVM/LUKS member signature.
+     * This detects signatures that are not reported by
+     * \OMV\System\Filesystem\Filesystem::getFilesystems(), e.g. ZFS pool
+     * members (`zfs_member`), LVM physical volumes (`LVM2_member`), Linux
+     * software RAID members (`linux_raid_member`) or LUKS containers
+     * (`crypto_LUKS`). A device without any signature is considered empty
+     * and can be used to create a new file system on it.
+     * @return boolean TRUE if the device contains at least one signature,
+     *   otherwise FALSE.
+     */
+    public function hasSignature(): bool
+    {
+        $cmdArgs = [];
+        $cmdArgs[] = "--parsable";
+        $cmdArgs[] = "--noheadings";
+        $cmdArgs[] = "--output type";
+        $cmdArgs[] = escapeshellarg($this->getDeviceFile());
+        $cmd = new \OMV\System\Process("wipefs", $cmdArgs);
+        $cmd->setQuiet(true);
+        $cmd->execute($output, $exitStatus);
+        if ($exitStatus !== 0) {
+            return false;
+        }
+        return !empty(array_filter($output, "strlen"));
+    }
+
+    /**
      * Get the device names of the partitions of this device.
      * @return array Returns an array of device names.
      */


### PR DESCRIPTION
Fixes #2106

## Problem
The **Create file system** device selection is populated by `FileSystemMgmt::getCandidates`. It only excluded devices used as slaves (LVM/mdraid) or whose file system is reported by `Filesystem::getFilesystems()`. A disk carrying a signature that OMV core does not enumerate — most notably **ZFS pool members**, but also foreign/unmounted file systems or a leftover partition table — was still offered as a candidate, allowing an accidental `mkfs` over data (e.g. a live ZFS pool, as reported in #2106).

## Change
- Add `StorageDevice::hasSignature()`, a `wipefs`-based probe (read-only, `--no*` list mode — it does **not** modify the device) that returns `TRUE` when a device carries any signature: a partition table, or a file system / RAID / LVM / LUKS member signature. This is the symmetric counterpart of the existing **Wipe** action — a device has a signature iff it needs wiping — and in one call also covers `crypto_LUKS`, `LVM2_member` and `linux_raid_member`.
- `getCandidates` now skips a device when `hasSignature()` returns `TRUE`. A truly empty/wiped disk returns no signature and remains a valid candidate for all file system types.
- Update the create-file-system forms (generic + btrfs) so the page hint and the device-select field hint explain that only empty devices are listed and that a device must be wiped to be reused.

## Notes / testing
I don't have OMV hardware to exercise this against real disks, so this has **not** been run end-to-end — I'd appreciate a maintainer smoke test:
1. With a `zfs_member` / LUKS / LVM / leftover-GPT disk present, confirm it no longer appears under Storage ▸ File Systems ▸ Create.
2. Wipe a disk and confirm it reappears as a candidate for ext4/xfs/btrfs.

The one runtime assumption is that `wipefs --parsable --noheadings --output type <dev>` prints one line per signature and nothing for an empty disk (standard util-linux behaviour). PHP files pass `php -l`; the two YAML component files parse cleanly.