### PR TITLE
Issue #1796: Add page size selector to datatable footer

### DIFF
--- a/deb/openmediavault/workbench/src/app/shared/components/datatable/datatable.component.html
+++ b/deb/openmediavault/workbench/src/app/shared/components/datatable/datatable.component.html
@@ -66,6 +66,48 @@
                [sortType]="sortType"
                (sort)="onSort($event)"
                (page)="onPage($event)">
+  <ngx-datatable-footer>
+    <ng-template ngx-datatable-footer-template
+                 let-rowCount="rowCount"
+                 let-pageSize="pageSize"
+                 let-selectedCount="selectedCount"
+                 let-curPage="curPage"
+                 let-offset="offset">
+      <div class="page-count">
+        <span *ngIf="selectionType !== 'none'">
+          {{ selectedCount?.toLocaleString() }} {{ messages.selectedMessage }} /
+        </span>
+        {{ rowCount?.toLocaleString() }} {{ messages.totalMessage }}
+      </div>
+      <div class="omv-datatable-footer-actions">
+        <mat-form-field *ngIf="pagingEnabled"
+                        class="omv-datatable-page-size">
+          <mat-select [value]="limit"
+                      (selectionChange)="onPageSizeChange($event.value)"
+                      matTooltip="{{ 'Items per page' | transloco }}"
+                      [attr.aria-label]="'Items per page' | transloco">
+            <mat-option *ngFor="let size of pageSizeOptions"
+                        [value]="size">
+              {{ size }}
+            </mat-option>
+            <mat-option [value]="0">
+              {{ 'All' | transloco }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+        <datatable-pager [pagerLeftArrowIcon]="'datatable-icon-left'"
+                         [pagerRightArrowIcon]="'datatable-icon-right'"
+                         [pagerPreviousIcon]="'datatable-icon-prev'"
+                         [pagerNextIcon]="'datatable-icon-skip'"
+                         [page]="curPage"
+                         [size]="pageSize"
+                         [count]="rowCount"
+                         [hidden]="limit <= 0 || rowCount / pageSize <= 1"
+                         (change)="table.onFooterPage($event)">
+        </datatable-pager>
+      </div>
+    </ng-template>
+  </ngx-datatable-footer>
 </ngx-datatable>
 
 <mat-menu #columnMenu="matMenu">

--- a/deb/openmediavault/workbench/src/app/shared/components/datatable/datatable.component.scss
+++ b/deb/openmediavault/workbench/src/app/shared/components/datatable/datatable.component.scss
@@ -167,6 +167,21 @@ omv-datatable {
         padding: 0 1.2rem;
       }
 
+      .omv-datatable-footer-actions {
+        display: flex;
+        align-items: center;
+      }
+
+      .omv-datatable-page-size {
+        font-size: var(--mat-font-size-body-1);
+        width: 4rem;
+
+        .mat-form-field-infix {
+          padding-bottom: unset;
+          border-top: unset;
+        }
+      }
+
       .datatable-pager {
         margin: 0 10px;
 

--- a/deb/openmediavault/workbench/src/app/shared/components/datatable/datatable.component.spec.ts
+++ b/deb/openmediavault/workbench/src/app/shared/components/datatable/datatable.component.spec.ts
@@ -3,11 +3,13 @@ import { ToastrModule } from 'ngx-toastr';
 
 import { ComponentsModule } from '~/app/shared/components/components.module';
 import { DatatableComponent } from '~/app/shared/components/datatable/datatable.component';
+import { UserLocalStorageService } from '~/app/shared/services/user-local-storage.service';
 import { TestingModule } from '~/app/testing.module';
 
 describe('DatatableComponent', () => {
   let component: DatatableComponent;
   let fixture: ComponentFixture<DatatableComponent>;
+  let userLocalStorageService: UserLocalStorageService;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -18,10 +20,69 @@ describe('DatatableComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(DatatableComponent);
     component = fixture.componentInstance;
+    userLocalStorageService = TestBed.inject(UserLocalStorageService);
+    // Stub the storage service so the tests neither touch the browser
+    // local storage nor issue the backing RPC request.
+    jest.spyOn(userLocalStorageService, 'set').mockImplementation(() => undefined);
+    jest.spyOn(userLocalStorageService, 'get').mockReturnValue(null);
     fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should include the current limit in the page size options', () => {
+    const newFixture = TestBed.createComponent(DatatableComponent);
+    newFixture.componentInstance.limit = 20;
+    newFixture.detectChanges();
+    expect(newFixture.componentInstance.pageSizeOptions).toEqual([10, 20, 25, 50, 100]);
+  });
+
+  it('should not duplicate a preset limit in the page size options', () => {
+    const newFixture = TestBed.createComponent(DatatableComponent);
+    newFixture.componentInstance.limit = 50;
+    newFixture.detectChanges();
+    expect(newFixture.componentInstance.pageSizeOptions).toEqual([10, 25, 50, 100]);
+  });
+
+  it('should update the limit and reset the offset on page size change', () => {
+    component.offset = 3;
+    component.onPageSizeChange(100);
+    expect(component.limit).toBe(100);
+    expect(component.offset).toBe(0);
+  });
+
+  it('should persist the page size as a global setting', () => {
+    component.onPageSizeChange(50);
+    expect(userLocalStorageService.set).toHaveBeenCalledWith('datatable_pagesize', '50');
+  });
+
+  it('should send limit -1 for remote paging when All is selected', () => {
+    component.remotePaging = true;
+    let params: any;
+    component.loadDataEvent.subscribe((value) => (params = value));
+    component.onPageSizeChange(0);
+    expect(component.limit).toBe(0);
+    expect(params.limit).toBe(-1);
+  });
+
+  it('should restore the persisted page size on init', () => {
+    jest.spyOn(userLocalStorageService, 'get').mockReturnValue('50');
+    const newFixture = TestBed.createComponent(DatatableComponent);
+    newFixture.detectChanges();
+    expect(newFixture.componentInstance.limit).toBe(50);
+  });
+
+  it('should not apply the stored page size when paging is disabled', () => {
+    jest.spyOn(userLocalStorageService, 'get').mockReturnValue('50');
+    const newFixture = TestBed.createComponent(DatatableComponent);
+    newFixture.componentInstance.limit = 0;
+    newFixture.detectChanges();
+    expect(newFixture.componentInstance.limit).toBe(0);
   });
 });

--- a/deb/openmediavault/workbench/src/app/shared/components/datatable/datatable.component.ts
+++ b/deb/openmediavault/workbench/src/app/shared/components/datatable/datatable.component.ts
@@ -61,6 +61,12 @@ export type DataTableCellChanged = {
   column: DatatableColumn;
 };
 
+// The key used to persist the user's preferred page size. This is
+// deliberately global (not per `stateId`) so the choice applies to
+// every datatable, while still being stored per user and device type
+// in the backend via the `UserLocalStorageService`.
+const PAGE_SIZE_STORAGE_KEY = 'datatable_pagesize';
+
 @Component({
   selector: 'omv-datatable',
   templateUrl: './datatable.component.html',
@@ -194,7 +200,9 @@ export class DatatableComponent implements Datatable, OnInit, OnDestroy, OnChang
   autoReload?: boolean | number = false;
 
   // Page size to show. To disable paging, set the limit to 0.
-  // Defaults to 25.
+  // Defaults to 25. This value can be changed by the user via the
+  // page size selector in the footer; the choice is persisted as a
+  // global per-user setting via the `UserLocalStorageService`.
   @Input()
   limit? = 25;
 
@@ -251,6 +259,15 @@ export class DatatableComponent implements Datatable, OnInit, OnDestroy, OnChang
   public icon = Icon;
   public rows = [];
   public offset = 0;
+  // The page size options offered in the footer selector. The special
+  // value `0` ('All') is rendered separately in the template. The list
+  // is augmented in `ngOnInit` with the current limit if it is not one
+  // of the presets.
+  public pageSizeOptions = [10, 25, 50, 100];
+  // Whether this datatable was configured with paging enabled. Used to
+  // decide if the user's global page size preference may be applied and
+  // if the page size selector is shown.
+  public pagingEnabled = true;
   public selection = new DatatableSelection();
   public filteredColumns: DatatableColumn[];
   public messages: {
@@ -299,6 +316,18 @@ export class DatatableComponent implements Datatable, OnInit, OnDestroy, OnChang
     this.initTemplates();
     // Sanitize configuration.
     this.sanitizeConfig();
+    // Remember whether this datatable was configured with paging so
+    // that a stored global preference does not enable paging on views
+    // that intentionally disabled it (limit = 0).
+    this.pagingEnabled = this.limit > 0;
+    // Apply the user's preferred page size (if any) before the data is
+    // loaded for the first time.
+    this.loadPageSize();
+    // Make sure the current limit is always selectable in the footer,
+    // even if it is not one of the presets (e.g. a page-specific limit).
+    if (this.limit > 0 && !this.pageSizeOptions.includes(this.limit)) {
+      this.pageSizeOptions = [...this.pageSizeOptions, this.limit].sort((a, b) => a - b);
+    }
     // Initialize timer or simply load the data once.
     // Note, we'll also use the RxJS timer when loading the data only once,
     // that's because this will prevent us from getting an 'Expression has
@@ -342,7 +371,10 @@ export class DatatableComponent implements Datatable, OnInit, OnDestroy, OnChang
   reloadData(): void {
     const params: DataTableLoadParams = {};
     if (this.remotePaging) {
-      _.merge(params, { offset: this.offset, limit: this.limit });
+      // A limit of `0` ('All') must be sent as `-1` to disable paging
+      // on the server; the backend interprets any `limit >= 0` as a
+      // slice, so `0` would otherwise return no rows at all.
+      _.merge(params, { offset: this.offset, limit: this.limit > 0 ? this.limit : -1 });
     }
     if (this.remoteSorting && !_.isEmpty(this.sorters)) {
       _.merge(params, { dir: this.sorters[0].dir, prop: this.sorters[0].prop });
@@ -403,6 +435,19 @@ export class DatatableComponent implements Datatable, OnInit, OnDestroy, OnChang
   onPage({ count, pageSize, limit, offset }): void {
     if (this.remotePaging) {
       this.offset = offset;
+      this.reloadData();
+    }
+  }
+
+  onPageSizeChange(limit: number): void {
+    this.limit = limit;
+    // Jump back to the first page, otherwise the current offset might
+    // be out of range for the new page size.
+    this.offset = 0;
+    this.savePageSize();
+    // In client-side paging mode the '[limit]' input change is enough
+    // to redraw the table, only remote paging needs a reload.
+    if (this.remotePaging) {
       this.reloadData();
     }
   }
@@ -569,5 +614,24 @@ export class DatatableComponent implements Datatable, OnInit, OnDestroy, OnChang
       `datatable_state_${this.stateId}`,
       JSON.stringify(columnsConfig)
     );
+  }
+
+  private loadPageSize(): void {
+    // Do not override views that intentionally disabled paging.
+    if (!this.pagingEnabled) {
+      return;
+    }
+    const value = this.userLocalStorageService.get(PAGE_SIZE_STORAGE_KEY);
+    if (_.isString(value)) {
+      const limit = _.toNumber(value);
+      // The value '0' is valid and means 'All'.
+      if (_.isFinite(limit) && limit >= 0) {
+        this.limit = limit;
+      }
+    }
+  }
+
+  private savePageSize(): void {
+    this.userLocalStorageService.set(PAGE_SIZE_STORAGE_KEY, String(this.limit));
   }
 }


### PR DESCRIPTION
Allow the user to change the number of items shown per page directly from the datatable's pagination bar.

An **Items per page** selector (10 / 25 / 50 / 100 / All) is added to the datatable footer, next to the pager. The chosen value is persisted as a global per-user setting through the existing `UserLocalStorageService`, so it is stored on the server (per user and device type) and restored on login — consistent with how column visibility and sorting are already handled. There is no new service and no backend change; the `WebGui.setLocalStorageItem` RPC already exists.

### Notes
- **Placement & persistence** follow the feedback given on the earlier #1900 (the selector lives in the pagination bar, and the value is stored via the same backend-synced mechanism as the other table settings). #1900 can be closed in favour of this.
- **Global on purpose:** the preference is intentionally global rather than per-table (per `stateId`), so setting it once applies everywhere. Selecting **All** is an explicit opt-in.
- Views that intentionally disable paging (`limit = 0`) are left untouched, and for remote-paged tables **All** is sent to the backend as `limit = -1` (the RPC treats any `limit >= 0` as a slice, so `0` would return no rows).

### Testing
- `npm run lint` (eslint + angular template rules + tsc + stylelint + prettier) — passes
- `ng test` for `datatable.component.spec.ts` — 8/8 pass (adds coverage for persistence, restore-on-init, the remote `All -> -1` path, and the paging-disabled guard)
- `ng build --configuration production` — clean AOT build

Fixes #1796

- [x] References issue
- [x] Includes tests for new functionality
