### PR TITLE
nginx: update security.conf

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/nginx/files/security.conf.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/nginx/files/security.conf.j2
@@ -1,11 +1,11 @@
 {%- set ssl_protocols = salt['pillar.get']('default:OMV_NGINX_SITE_WEBGUI_SSL_PROTOCOLS', 'TLSv1.2 TLSv1.3') -%}
 {%- set ssl_prefer_server_ciphers = salt['pillar.get']('default:OMV_NGINX_SITE_WEBGUI_SSL_PREFER_SERVER_CIPHERS', 'off') -%}
 {%- set ssl_ciphers = salt['pillar.get']('default:OMV_NGINX_SITE_WEBGUI_SSL_CIPHERS', 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305') -%}
-{%- set ssl_ecdh_curve = salt['pillar.get']('default:OMV_NGINX_SITE_WEBGUI_SSL_ECDH_CURVE', 'X25519:prime256v1:secp384r1') -%}
+{%- set ssl_ecdh_curve = salt['pillar.get']('default:OMV_NGINX_SITE_WEBGUI_SSL_ECDH_CURVE', 'X25519MLKEM768:X25519:prime256v1:secp384r1') -%}
 {{ pillar['headers']['multiline'] }}
 {%- if config.enablessl | to_bool %}
 # PFS (Perfect Forward Secrecy)
-# https://ssl-config.mozilla.org/#server=nginx&version=1.26.3&config=intermediate&openssl=3.5.1&ocsp=false&guideline=5.7
+# https://configurator.tlsref.org/#server=nginx&version=1.26.3&config=intermediate&openssl=3.5.6&hsts&guideline=6.0
 ssl_protocols {{ ssl_protocols }};
 ssl_prefer_server_ciphers {{ ssl_prefer_server_ciphers }};
 ssl_ciphers "{{ ssl_ciphers }}";


### PR DESCRIPTION
nginx: update security.conf

Enable the X25519MLKEM768 hybrid post-quantum key exchange for nginx. OMV is now based on Debian 13 which ships OpenSSL 3.5 where X25519MLKEM768 is available.

Update the Mozilla SSL configuration generator URL to its new location at configurator.tlsref.org. The settings for the configurator remain unchanged, however the configurator has a newer policy version which recommends X25519MLKEM768.

Fixes: #2245

Signed-off-by: Jannis Pinter <jannis@pinterjann.is>