### PR TITLE
Modify "sharename" regex according to MS-FSCC share name specification

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,7 @@
 openmediavault (8.5.5-1) stable; urgency=medium
 
-  * 
+  * Modify the `sharename` validation according to MS-FSCC share name
+    specification.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Thu, 23 Jul 2026 19:13:38 +0200
 

--- a/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/datamodel/schema.py
+++ b/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/datamodel/schema.py
@@ -125,19 +125,14 @@ class Schema(openmediavault.json.Schema):
                         "The value '%s' is no PGP public key." % value,
                     ) from None
             elif "sharename" == schema['format']:
-                # We are using the SMB/CIFS file/directory naming convention
-                # for this:
-                # All characters are legal in the basename and extension
-                # except the space character (0x20) and:
-                # "./\[]:+|<>=;,*?
-                # A share name or server or workstation name SHOULD not
-                # begin with a period (“.”) nor should it include two
-                # adjacent periods (“..”).
-                # References:
-                # http://tools.ietf.org/html/draft-leach-cifs-v1-spec-01
-                # http://msdn.microsoft.com/en-us/library/aa365247%28VS.85%29.aspx
+                # Validate according to MS-FSCC share name specification:
+                # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/dc9978d7-6299-4c5a-a22d-a039cdc716ea
+                # - Illegal characters: " \ / [ ] : | < > + = ; , * ?
+                # - Control characters 0x00-0x1F are illegal
+                # - Leading and trailing spaces are not allowed
+                # - All other Unicode characters (incl. spaces within the name) are legal
                 if not re.match(
-                    r'^[^"/\\\[\]:+|<>=;,*?. ]+(?:\.[^"/\\\[\]:+|<>=;,*?. ]+)*$',
+                    r'^(?![ ])[^"\x00-\x1f\\/\[\]:|<>+=;,*?]+(?<! )$',
                     value,
                 ):
                     raise openmediavault.json.SchemaValidationException(

--- a/deb/openmediavault/usr/share/openmediavault/unittests/php/test_openmediavault_datamodel_schema.php
+++ b/deb/openmediavault/usr/share/openmediavault/unittests/php/test_openmediavault_datamodel_schema.php
@@ -531,25 +531,52 @@ class test_openmediavault_datamodel_schema extends \PHPUnit\Framework\TestCase
         $schema->checkFormat("Hörbücher", [ "format" => "sharename" ], "field1");
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testCheckFormatSharename4()
+    {
+        $schema = $this->getSchema();
+        $schema->checkFormat(".foo", [ "format" => "sharename" ], "field1");
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testCheckFormatSharename5()
+    {
+        $schema = $this->getSchema();
+        $schema->checkFormat("bar..foo", [ "format" => "sharename" ], "field1");
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testCheckFormatSharename6()
+    {
+        $schema = $this->getSchema();
+        $schema->checkFormat("my share", [ "format" => "sharename" ], "field1");
+    }
+
     public function testCheckFormatSharenameFail1()
     {
         $schema = $this->getSchema();
         $this->expectException(\OMV\Json\SchemaValidationException::class);
-        $schema->checkFormat(".foo", [ "format" => "sharename" ], "field1");
+        $schema->checkFormat(" share", [ "format" => "sharename" ], "field1");
     }
 
     public function testCheckFormatSharenameFail2()
     {
         $schema = $this->getSchema();
         $this->expectException(\OMV\Json\SchemaValidationException::class);
-        $schema->checkFormat("bar..foo", [ "format" => "sharename" ], "xyz");
+        $schema->checkFormat("share ", [ "format" => "sharename" ], "field1");
     }
 
     public function testCheckFormatSharenameFail3()
     {
         $schema = $this->getSchema();
         $this->expectException(\OMV\Json\SchemaValidationException::class);
-        $schema->checkFormat("my share", [ "format" => "sharename" ], "field1");
+        $schema->checkFormat("my/share", [ "format" => "sharename" ], "field1");
     }
 
     /**

--- a/deb/openmediavault/usr/share/openmediavault/unittests/python/test_openmediavault_datamodel_schema.py
+++ b/deb/openmediavault/usr/share/openmediavault/unittests/python/test_openmediavault_datamodel_schema.py
@@ -292,12 +292,24 @@ class SchemaTestCase(unittest.TestCase):
         schema = openmediavault.datamodel.Schema({})
         schema._check_format("Hörbücher", {"format": "sharename"}, "field1")
 
+    def test_check_format_sharename_4(self):
+        schema = openmediavault.datamodel.Schema({})
+        schema._check_format(".foo", {"format": "sharename"}, "field1")
+
+    def test_check_format_sharename_5(self):
+        schema = openmediavault.datamodel.Schema({})
+        schema._check_format("bar..foo", {"format": "sharename"}, "field1")
+
+    def test_check_format_sharename_6(self):
+        schema = openmediavault.datamodel.Schema({})
+        schema._check_format("my share", {"format": "sharename"}, "field1")
+
     def test_check_format_sharename_fail_1(self):
         schema = openmediavault.datamodel.Schema({})
         self.assertRaises(
             openmediavault.json.SchemaValidationException,
             lambda: schema._check_format(
-                ".foo", {"format": "sharename"}, "field1"
+                " share", {"format": "sharename"}, "field1"
             )
         )
 
@@ -306,7 +318,7 @@ class SchemaTestCase(unittest.TestCase):
         self.assertRaises(
             openmediavault.json.SchemaValidationException,
             lambda: schema._check_format(
-                "bar..foo", {"format": "sharename"}, "xyz"
+                "share ", {"format": "sharename"}, "field1"
             )
         )
 
@@ -315,7 +327,7 @@ class SchemaTestCase(unittest.TestCase):
         self.assertRaises(
             openmediavault.json.SchemaValidationException,
             lambda: schema._check_format(
-                "my share", {"format": "sharename"}, "field1"
+                "my/share", {"format": "sharename"}, "field1"
             )
         )
 

--- a/deb/openmediavault/usr/share/php/openmediavault/datamodel/schema.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/datamodel/schema.inc
@@ -125,19 +125,14 @@ class Schema extends \OMV\Json\Schema
                     }
                     break;
                 case "sharename":
-                    // We are using the SMB/CIFS file/directory naming convention
-                    // for this:
-                    // All characters are legal in the basename and extension
-                    // except the space character (0x20) and:
-                    // "./\[]:+|<>=;,*?
-                    // A share name or server or workstation name SHOULD not
-                    // begin with a period (“.”) nor should it include two
-                    // adjacent periods (“..”).
-                    // References:
-                    // http://tools.ietf.org/html/draft-leach-cifs-v1-spec-01
-                    // http://msdn.microsoft.com/en-us/library/aa365247%28VS.85%29.aspx
+                    // Validate according to MS-FSCC share name specification:
+                    // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/dc9978d7-6299-4c5a-a22d-a039cdc716ea
+                    // - Illegal characters: " \ / [ ] : | < > + = ; , * ?
+                    // - Control characters 0x00-0x1F are illegal
+                    // - Leading and trailing spaces are not allowed
+                    // - All other Unicode characters (incl. spaces within the name) are legal
                     if (!preg_match(
-                        '/^[^"\/\\\[\]:+|<>=;,*?. ]+(?:\.[^"\/\\\[\]:+|<>=;,*?. ]+)*$/',
+                        '~^(?![ ])[^"\x00-\x1F\\\/\[\]:|<>+=;,*?]+(?<! )$~u',
                         $value
                     )) {
                         throw new \OMV\Json\SchemaValidationException(

--- a/deb/openmediavault/workbench/src/app/shared/forms/custom-validators.spec.ts
+++ b/deb/openmediavault/workbench/src/app/shared/forms/custom-validators.spec.ts
@@ -472,27 +472,42 @@ describe('CustomValidators', () => {
         expect(validator(formControl)).toBeNull();
       });
 
-      it('should not validate shareName [1] (leading period)', () => {
+      it('should validate shareName [4] (leading period)', () => {
         formControl.setValue('.share');
-        expect(validator(formControl)).toEqual({
-          pattern:
-            'This field contains invalid characters, e.g. a blank or "/[]:+|<>=;,*? character.'
-        });
+        expect(validator(formControl)).toBeNull();
       });
 
-      it('should not validate shareName [2] (consecutive periods)', () => {
+      it('should validate shareName [5] (consecutive periods)', () => {
         formControl.setValue('my..share');
+        expect(validator(formControl)).toBeNull();
+      });
+
+      it('should validate shareName [6] (space within name)', () => {
+        formControl.setValue('my share');
+        expect(validator(formControl)).toBeNull();
+      });
+
+      it('should not validate shareName [1] (leading space)', () => {
+        formControl.setValue(' share');
         expect(validator(formControl)).toEqual({
           pattern:
-            'This field contains invalid characters, e.g. a blank or "/[]:+|<>=;,*? character.'
+            'This field contains invalid characters (e.g. "\\/[]:+|<>=;,*?) or has leading/trailing spaces.'
         });
       });
 
-      it('should not validate shareName [3] (blank)', () => {
-        formControl.setValue('my share');
+      it('should not validate shareName [2] (trailing space)', () => {
+        formControl.setValue('share ');
         expect(validator(formControl)).toEqual({
           pattern:
-            'This field contains invalid characters, e.g. a blank or "/[]:+|<>=;,*? character.'
+            'This field contains invalid characters (e.g. "\\/[]:+|<>=;,*?) or has leading/trailing spaces.'
+        });
+      });
+
+      it('should not validate shareName [3] (illegal character)', () => {
+        formControl.setValue('my/share');
+        expect(validator(formControl)).toEqual({
+          pattern:
+            'This field contains invalid characters (e.g. "\\/[]:+|<>=;,*?) or has leading/trailing spaces.'
         });
       });
     });

--- a/deb/openmediavault/workbench/src/app/shared/forms/custom-validators.ts
+++ b/deb/openmediavault/workbench/src/app/shared/forms/custom-validators.ts
@@ -38,16 +38,13 @@ const regExp = {
   // - https://github.com/shadow-maint/shadow/blob/55e75ec6b2f8878c6c269570a4470730092c1b39/lib/chkname.c#L52
   // - https://salsa.debian.org/debian/adduser/-/blob/debian/latest/adduser.conf?ref_type=heads#L88
   userName: /^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*\$?$/,
-  // We are using the SMB/CIFS file/directory naming convention for this:
-  // All characters are legal in the basename and extension except the
-  // space character (0x20) and:
-  // "./\[]:+|<>=;,*?
-  // A share name or server or workstation name SHOULD not begin with a
-  // period (“.”) nor should it include two adjacent periods (“..”).
-  // References:
-  // http://tools.ietf.org/html/draft-leach-cifs-v1-spec-01
-  // http://msdn.microsoft.com/en-us/library/aa365247%28VS.85%29.aspx
-  shareName: /^[^"/\\\[\]:+|<>=;,*?. ]+(?:\.[^"/\\\[\]:+|<>=;,*?. ]+)*$/,
+  // Validate according to MS-FSCC share name specification:
+  // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/dc9978d7-6299-4c5a-a22d-a039cdc716ea
+  // - Illegal characters: " \ / [ ] : | < > + = ; , * ?
+  // - Control characters 0x00-0x1F are illegal
+  // - Leading and trailing spaces are not allowed
+  // - All other Unicode characters (incl. spaces within the name) are legal
+  shareName: /^(?![ ])[^"\x00-\x1F\\\/\[\]:|<>+=;,*?]+(?<! )$/,
   ipv4NetCidr:
     /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/(3[0-2]|[0-2]?[0-9])$/,
   ipv6NetCidr: /^(?:[a-f0-9]{1,4}:){7}[a-f0-9]{1,4}\/(12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9])$/i,
@@ -272,7 +269,7 @@ export class CustomValidators {
         return CustomValidators.pattern(
           regExp.shareName,
           gettext(
-            'This field contains invalid characters, e.g. a blank or "/[]:+|<>=;,*? character.'
+            'This field contains invalid characters (e.g. "\\/[]:+|<>=;,*?) or has leading/trailing spaces.'
           )
         );
       case 'email':


### PR DESCRIPTION
References:
- https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/dc9978d7-6299-4c5a-a22d-a039cdc716ea

Note: The max. length of 80 characters is enforced via the JSON schema maxLength property.


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
