### PR TITLE
Restore catia vfs object for macOS SMB filename compatibility

### DIFF
--- a/deb/openmediavault/srv/salt/omv/deploy/samba/files/homes.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/samba/files/homes.j2
@@ -37,6 +37,7 @@ follow symlinks = {{ config.homesfollowsymlinks | to_bool | yesno }}
 wide links = {{ config.homeswidelinks | to_bool | yesno }}
 {%- set vfs_objects = vfs_objects.split(' ') %}
 {%- if enable_timemachine_vfs | to_bool %}
+{%- set _ = vfs_objects.append('catia') %}
 {%- set _ = vfs_objects.append('fruit') %}
 {%- set _ = vfs_objects.append('streams_xattr') %}
 {%- endif %}

--- a/deb/openmediavault/srv/salt/omv/deploy/samba/files/shares.j2
+++ b/deb/openmediavault/srv/salt/omv/deploy/samba/files/shares.j2
@@ -27,6 +27,8 @@
 {%- set fruit_veto_appledouble = salt['pillar.get']('default:OMV_SAMBA_SHARE_FRUIT_VETOAPPLEDOUBLE', 'no') -%}
 {%- set fruit_wipe_intentionally_left_blank_rfork = salt['pillar.get']('default:OMV_SAMBA_SHARE_FRUIT_WIPEINTENTIONALLYLEFTBLANKRFORK', 'yes') -%}
 {%- set fruit_delete_empty_adfiles = salt['pillar.get']('default:OMV_SAMBA_SHARE_FRUIT_DELETEEMPTYADFILES', 'yes') -%}
+{%- set fruit_model = salt['pillar.get']('default:OMV_SAMBA_SHARE_FRUIT_MODEL', 'MacSamba') -%}
+{%- set fruit_posix_rename = salt['pillar.get']('default:OMV_SAMBA_SHARE_FRUIT_POSIXRENAME', 'yes') -%}
 {%- set shadow_sort = salt['pillar.get']('default:OMV_SAMBA_SHARE_SHADOW_SORT', 'desc') -%}
 {%- set dfree_command = salt['pillar.get']('default:OMV_SAMBA_SHARE_DFREECOMMAND', '/usr/sbin/omv-btrfs-dfree') -%}
 {%- set dfree_cache_time = salt['pillar.get']('default:OMV_SAMBA_SHARE_DFREECACHETIME', '30') -%}
@@ -60,6 +62,7 @@ full_audit:facility = {{ full_audit_facility }}
 full_audit:priority = {{ full_audit_priority }}
 {%- endif %}
 {%- if enable_timemachine_vfs | to_bool %}
+{%- set _ = vfs_objects.append('catia') %}
 {%- set _ = vfs_objects.append('fruit') %}
 {%- set _ = vfs_objects.append('streams_xattr') %}
 {%- endif %}
@@ -71,6 +74,8 @@ fruit:resource = {{ fruit_resource }}
 fruit:veto_appledouble = {{ fruit_veto_appledouble }}
 fruit:wipe_intentionally_left_blank_rfork = {{ fruit_wipe_intentionally_left_blank_rfork }}
 fruit:delete_empty_adfiles = {{ fruit_delete_empty_adfiles }}
+fruit:model = {{ fruit_model }}
+fruit:posix_rename = {{ fruit_posix_rename }}
 fruit:time machine = yes
 {%- if share.timemachinemaxsize | length > 0 %}
 fruit:time machine max size = {{ share.timemachinemaxsize }}


### PR DESCRIPTION
`catia` used to sit alongside `fruit`/`streams_xattr` in `vfs objects` for Time-Machine-enabled shares, but was removed in 559c65e6f5 while `fruit`/`streams_xattr` were kept. Without it, macOS clients writing filenames with characters that are valid on APFS but reserved in SMB (`:`, `|`, etc.) fail to copy - e.g. copying a `.photoslibrary` package fails on files like `CreateDatabase_20251112-053758-08:00` and `FeaturedPhoto|<UUID>`.

This PR re-adds `catia` before `fruit`/`streams_xattr` in `shares.j2` and `homes.j2` (Samba's recommended module order), riding the same existing "Time Machine support" toggle - no new UI/config option needed. It also fills in two Mac-compatibility tunables recommended in openmediavault#1393's comment thread that were still missing: `fruit:model = MacSamba` and `fruit:posix_rename = yes`.

Separately, note that reserved Windows device names (`AUX`, `CON`, `NUL`, etc.) can never be supported over SMB regardless of `catia`/`fruit` - that's a protocol-level limitation, out of scope here.

Fixes: https://github.com/openmediavault/openmediavault/issues/2263

Signed-off-by: Johannes Kern <mail@johanneskern.net>

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug

No automated test/reproducer is included: this is a Jinja2 salt template change with no OMV/Samba test harness in the repo, and full rendering outside a live Salt+OMV stack isn't feasible (see commit message / plan notes). Verified by manual diff review against the removal commit; end-to-end SMB behavior should be confirmed against a real NAS.
