### PR TITLE
Issue #2265: `-d cciss,N` is no longer required for non-RAID hpsa devices

### DIFF
--- a/deb/openmediavault/debian/changelog
+++ b/deb/openmediavault/debian/changelog
@@ -1,6 +1,7 @@
 openmediavault (8.5.8-1) stable; urgency=medium
 
-  *
+  * Issue #2265: smartmontools no longer requires `-d cciss,N` for
+    non-RAID hpsa devices.
 
  -- Volker Theile <volker.theile@openmediavault.org>  Wed, 02 Sep 2026 21:25:22 +0200
 

--- a/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/device/plugins/sd.py
+++ b/deb/openmediavault/usr/lib/python3/dist-packages/openmediavault/device/plugins/sd.py
@@ -245,30 +245,6 @@ class StorageDeviceHPSA(StorageDevice):
         return self.raid_level.startswith('RAID')
 
     @property
-    def smart_device_type(self):
-        # Note, we need to distinguish between RAID and HBA mode here.
-        if self.is_raid:
-            return super().smart_device_type
-        # $ hpssacli ctrl slot=0 pd all show detail
-        # ...
-        # physicaldrive 1I:1:5
-        # Port: 1I
-        # Box: 1
-        # Bay: 5
-        # Status: OK
-        # Disk Name: /dev/sde
-        # ...
-
-        # The drive bay is encoded in the devpath of the device via the
-        # SCSI address (HCTL), e.g.
-        # /devices/pci0000:00/0000:00:02.2/0000:02:00.0/host1/scsi_host/host1/port-1:6/end_device-1:6/target1:0:5/1:0:5:0/block/sde
-
-        # Return 'cciss,N'. The non-negative integer N (in the
-        # range from 0 to 15 inclusive) denotes which disk on the
-        # controller is monitored.
-        return 'cciss,{}'.format(self.hctl.target - 1)
-
-    @property
     def raid_level(self) -> str:
         """
         Get the RAID level of the device. If it is a logical device,

--- a/deb/openmediavault/usr/share/openmediavault/unittests/python/test_openmediavault_device_storagedevice.py
+++ b/deb/openmediavault/usr/share/openmediavault/unittests/python/test_openmediavault_device_storagedevice.py
@@ -434,7 +434,7 @@ class StorageDeviceTestCase(unittest.TestCase):
             sd, openmediavault.device.plugins.sd.StorageDeviceHPSA
         )
         self.assertFalse(sd.is_raid)
-        self.assertEqual(sd.smart_device_type, 'cciss,4')
+        self.assertEqual(sd.smart_device_type, '')
 
 
 if __name__ == "__main__":

--- a/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevicehpsa.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/storage/storagedevicehpsa.inc
@@ -36,37 +36,6 @@ class StorageDeviceHPSA extends StorageDeviceSD
     }
 
     /**
-     * See \OMV\System\Storage\SmartInterface interface definition.
-     */
-    public function getSmartDeviceType()
-    {
-        // Note, we need to distinguish between RAID and HBA mode here.
-        if (true === $this->isRaid()) {
-            return parent::getSmartDeviceType();
-        }
-        //
-        // $ hpssacli ctrl slot=0 pd all show detail
-        // ...
-        // physicaldrive 1I:1:5
-        // Port: 1I
-        // Box: 1
-        // Bay: 5
-        // Status: OK
-        // Disk Name: /dev/sde
-        // ...
-
-        // The drive bay is encoded in the devpath of the device via the
-        // SCSI address (HCTL), e.g.
-        // /devices/pci0000:00/0000:00:02.2/0000:02:00.0/host1/scsi_host/host1/port-1:6/end_device-1:6/target1:0:5/1:0:5:0/block/sde
-
-        // Return 'cciss,N'. The non-negative integer N (in the
-        // range from 0 to 15 inclusive) denotes which disk on the
-        // controller is monitored.
-        $hctl = $this->getHCTL();
-        return sprintf("cciss,%d", $hctl['target'] - 1);
-    }
-
-    /**
      * Get the RAID level of the device. If it is a logical device,
      * then 'N/A' will be returned, otherwise 'RAID 0', 'RAID 1(+0)'
      * or 'RAID <N>'.


### PR DESCRIPTION
References:
- https://github.com/smartmontools/smartmontools/releases#release-RELEASE_7_3

Fixes: https://github.com/openmediavault/openmediavault/issues/2265


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [x] References issue
- [ ] Includes tests for new functionality or reproducer for bug
