### PR TITLE
fix(workbench): fix typo in detectSystemTheme() media query

### DIFF
--- a/deb/openmediavault/workbench/src/app/shared/services/prefers-color-scheme.service.ts
+++ b/deb/openmediavault/workbench/src/app/shared/services/prefers-color-scheme.service.ts
@@ -74,6 +74,6 @@ export class PrefersColorSchemeService {
   }
 
   private detectSystemTheme(): PrefersColorScheme {
-    return window.matchMedia?.('(prefers-color-schema: dark)').matches ? 'dark' : 'light';
+    return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
 }


### PR DESCRIPTION
'prefers-color-schema' was used instead of 'prefers-color-scheme'
in the detectSystemTheme() method of PrefersColorSchemeService.

This typo prevented the automatic system theme detection from ever
working, causing OMV to always fall back to the default light theme
instead of respecting the user's OS-level dark/light preference.

Signed-off-by: Dr4w <dev.armando.local@gmail.com>